### PR TITLE
Ignore numpy CVE-2021-41495 until safety db is updated

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -112,7 +112,7 @@ def safety(session: Session) -> None:
     """Scan dependencies for insecure packages."""
     requirements = session.poetry.export_requirements()
     session.install("safety")
-    session.run("safety", "check", "--full-report", f"--file={requirements}")
+    session.run("safety", "check", "--full-report", f"--file={requirements}", "--ignore 44715")
 
 
 @session(python=python_versions)

--- a/noxfile.py
+++ b/noxfile.py
@@ -113,7 +113,7 @@ def safety(session: Session) -> None:
     requirements = session.poetry.export_requirements()
     session.install("safety")
     session.run(
-        "safety", "check", "--full-report", f"--file={requirements}", "--ignore 44715"
+        "safety", "check", "--full-report", f"--file={requirements}", "--ignore", "44715"
     )
 
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -118,7 +118,7 @@ def safety(session: Session) -> None:
         "--full-report",
         f"--file={requirements}",
         "--ignore",
-        "44715"
+        "44715",
     )
 
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -113,7 +113,12 @@ def safety(session: Session) -> None:
     requirements = session.poetry.export_requirements()
     session.install("safety")
     session.run(
-        "safety", "check", "--full-report", f"--file={requirements}", "--ignore", "44715"
+        "safety",
+        "check",
+        "--full-report",
+        f"--file={requirements}",
+        "--ignore",
+        "44715"
     )
 
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -112,7 +112,9 @@ def safety(session: Session) -> None:
     """Scan dependencies for insecure packages."""
     requirements = session.poetry.export_requirements()
     session.install("safety")
-    session.run("safety", "check", "--full-report", f"--file={requirements}", "--ignore 44715")
+    session.run(
+        "safety", "check", "--full-report", f"--file={requirements}", "--ignore 44715"
+    )
 
 
 @session(python=python_versions)


### PR DESCRIPTION
Ignore [CVE-2021-41495](https://github.com/advisories/GHSA-5545-2q6w-2gh6) affecting numpy until safety database is monthly updated.

See [safety](https://github.com/pyupio/safety/issues/364) and [numpy](https://github.com/numpy/numpy/issues/19038) issues