### PR TITLE
fix(nisra): update cancer_waiting_times parser for Q3 2025-26 schema change

### DIFF
--- a/src/bolster/data_sources/nisra/cancer_waiting_times.py
+++ b/src/bolster/data_sources/nisra/cancer_waiting_times.py
@@ -63,7 +63,7 @@ from bs4 import BeautifulSoup
 
 from bolster.utils.web import session
 
-from ._base import NISRADataNotFoundError, add_date_columns, download_file, make_absolute_url
+from ._base import NISRADataNotFoundError, NISRAValidationError, add_date_columns, download_file, make_absolute_url
 
 logger = logging.getLogger(__name__)
 
@@ -78,7 +78,15 @@ SHEET_62_DAY_TRUST = "62 Day Wait by HSC Trust"
 SHEET_62_DAY_TUMOUR = "62 Day Wait by Tumour Site"
 SHEET_14_DAY_REGIONAL = "14 d Wait - Breast Regional"
 SHEET_14_DAY_HISTORIC = "14 d Wait - Breast Historic"
+# Pre-Q3-2025-26 files used a single combined sheet instead of the historic/regional split
+SHEET_14_DAY_LEGACY = "14 Day Wait - Breast Cancer"
 SHEET_BREAST_REFERRALS = "Breast Cancer Referrals"
+
+# Column schemas vary by publication era:
+# - Pre-Q3 2025-26: 5 cols (no median/percentile); breast referrals 4 cols (total before urgent, no routine)
+# - Q3 2025-26+:    7 cols (+ median_days, percentile_95_days); breast referrals 5 cols (routine, urgent, total)
+_WAIT_COLS_5 = ["period_month", "group", "within_target", "over_target", "total"]
+_WAIT_COLS_7 = ["period_month", "group", "within_target", "over_target", "total", "median_days", "percentile_95_days"]
 
 
 def get_latest_publication_url() -> tuple[str, str]:
@@ -158,8 +166,34 @@ def get_latest_publication_url() -> tuple[str, str]:
     return excel_url, quarter_str
 
 
+def _parse_wait_sheet(file_path: str | Path, sheet_name: str, group_col: str) -> pd.DataFrame:
+    """Parse a wait-time sheet, handling 5-column (pre-Q3 2025-26) and 7-column (Q3 2025-26+) formats.
+
+    Args:
+        file_path: Path to the Excel file
+        sheet_name: Name of the sheet to parse
+        group_col: Output column name for the grouping dimension (e.g. 'trust' or 'tumour_site')
+
+    Returns:
+        DataFrame with columns: period_month, group_col, within_target, over_target, total
+        (median_days and percentile_95_days are dropped — not yet used downstream)
+    """
+    df = pd.read_excel(file_path, sheet_name=sheet_name)
+    n_cols = len(df.columns)
+    if n_cols == 7:
+        df.columns = _WAIT_COLS_7
+    elif n_cols == 5:
+        df.columns = _WAIT_COLS_5
+    else:
+        raise NISRAValidationError(f"Unexpected column count ({n_cols}) in sheet '{sheet_name}' of {file_path}")
+    return df.rename(columns={"group": group_col})
+
+
 def parse_31_day_by_trust(file_path: str | Path) -> pd.DataFrame:
     """Parse 31-day waiting times by HSC Trust.
+
+    Handles both the 5-column format (pre-Q3 2025-26) and the 7-column format
+    (Q3 2025-26+, which added Median and 95th Percentile columns).
 
     Args:
         file_path: Path to the Excel file
@@ -168,17 +202,17 @@ def parse_31_day_by_trust(file_path: str | Path) -> pd.DataFrame:
         DataFrame with columns: date, year, month, trust, within_target,
         over_target, total, performance_rate
     """
-    df = pd.read_excel(file_path, sheet_name=SHEET_31_DAY_TRUST)
-
-    df.columns = ["treatment_month", "trust", "within_target", "over_target", "total"]
-    df = add_date_columns(df, "treatment_month")
+    df = _parse_wait_sheet(file_path, SHEET_31_DAY_TRUST, "trust")
+    df = add_date_columns(df, "period_month")
     df["performance_rate"] = df["within_target"] / df["total"]
-
     return df[["date", "year", "month", "trust", "within_target", "over_target", "total", "performance_rate"]]
 
 
 def parse_31_day_by_tumour(file_path: str | Path) -> pd.DataFrame:
     """Parse 31-day waiting times by Tumour Site.
+
+    Handles both the 5-column format (pre-Q3 2025-26) and the 7-column format
+    (Q3 2025-26+, which added Median and 95th Percentile columns).
 
     Args:
         file_path: Path to the Excel file
@@ -187,17 +221,17 @@ def parse_31_day_by_tumour(file_path: str | Path) -> pd.DataFrame:
         DataFrame with columns: date, year, month, tumour_site, within_target,
         over_target, total, performance_rate
     """
-    df = pd.read_excel(file_path, sheet_name=SHEET_31_DAY_TUMOUR)
-
-    df.columns = ["treatment_month", "tumour_site", "within_target", "over_target", "total"]
-    df = add_date_columns(df, "treatment_month")
+    df = _parse_wait_sheet(file_path, SHEET_31_DAY_TUMOUR, "tumour_site")
+    df = add_date_columns(df, "period_month")
     df["performance_rate"] = df["within_target"] / df["total"]
-
     return df[["date", "year", "month", "tumour_site", "within_target", "over_target", "total", "performance_rate"]]
 
 
 def parse_62_day_by_trust(file_path: str | Path) -> pd.DataFrame:
     """Parse 62-day waiting times by HSC Trust.
+
+    Handles both the 5-column format (pre-Q3 2025-26) and the 7-column format
+    (Q3 2025-26+, which added Median and 95th Percentile columns).
 
     Args:
         file_path: Path to the Excel file
@@ -210,17 +244,17 @@ def parse_62_day_by_trust(file_path: str | Path) -> pd.DataFrame:
         62-day data may contain fractional patient counts due to shared care
         arrangements between trusts.
     """
-    df = pd.read_excel(file_path, sheet_name=SHEET_62_DAY_TRUST)
-
-    df.columns = ["treatment_month", "trust", "within_target", "over_target", "total"]
-    df = add_date_columns(df, "treatment_month")
+    df = _parse_wait_sheet(file_path, SHEET_62_DAY_TRUST, "trust")
+    df = add_date_columns(df, "period_month")
     df["performance_rate"] = df["within_target"] / df["total"]
-
     return df[["date", "year", "month", "trust", "within_target", "over_target", "total", "performance_rate"]]
 
 
 def parse_62_day_by_tumour(file_path: str | Path) -> pd.DataFrame:
     """Parse 62-day waiting times by Tumour Site.
+
+    Handles both the 5-column format (pre-Q3 2025-26) and the 7-column format
+    (Q3 2025-26+, which added Median and 95th Percentile columns).
 
     Args:
         file_path: Path to the Excel file
@@ -229,17 +263,19 @@ def parse_62_day_by_tumour(file_path: str | Path) -> pd.DataFrame:
         DataFrame with columns: date, year, month, tumour_site, within_target,
         over_target, total, performance_rate
     """
-    df = pd.read_excel(file_path, sheet_name=SHEET_62_DAY_TUMOUR)
-
-    df.columns = ["treatment_month", "tumour_site", "within_target", "over_target", "total"]
-    df = add_date_columns(df, "treatment_month")
+    df = _parse_wait_sheet(file_path, SHEET_62_DAY_TUMOUR, "tumour_site")
+    df = add_date_columns(df, "period_month")
     df["performance_rate"] = df["within_target"] / df["total"]
-
     return df[["date", "year", "month", "tumour_site", "within_target", "over_target", "total", "performance_rate"]]
 
 
 def parse_14_day_breast(file_path: str | Path) -> pd.DataFrame:
-    """Parse 14-day breast cancer waiting times (combined historic and regional).
+    """Parse 14-day breast cancer waiting times.
+
+    Handles three publication formats:
+    - Pre-Q4 2024-25: single sheet 'SHEET_14_DAY_LEGACY' (5 cols)
+    - Q4 2024-25 to Q2 2025-26: split into historic (5 cols) + regional (5 cols)
+    - Q3 2025-26+: split into historic (5 cols) + regional (7 cols, + median/95th pct)
 
     Args:
         file_path: Path to the Excel file
@@ -252,25 +288,36 @@ def parse_14_day_breast(file_path: str | Path) -> pd.DataFrame:
         From May 2025, breast cancer services became regional. Historic data
         (pre-May 2025) is by individual Trust. Regional data shows NI-wide figures.
     """
-    # Parse historic data (by Trust, up to April 2025)
-    df_historic = pd.read_excel(file_path, sheet_name=SHEET_14_DAY_HISTORIC)
-    df_historic.columns = ["month_seen", "trust", "within_target", "over_target", "total"]
-    df_historic = add_date_columns(df_historic, "month_seen")
+    xl = pd.ExcelFile(file_path)
+    sheet_names = xl.sheet_names
 
-    # Parse regional data (May 2025 onwards)
-    df_regional = pd.read_excel(file_path, sheet_name=SHEET_14_DAY_REGIONAL)
-    df_regional.columns = ["month_seen", "trust", "within_target", "over_target", "total"]
-    df_regional = add_date_columns(df_regional, "month_seen")
+    if SHEET_14_DAY_HISTORIC in sheet_names:
+        # New split format (Q4 2024-25 onwards)
+        df_historic = _parse_wait_sheet(file_path, SHEET_14_DAY_HISTORIC, "trust")
+        df_historic = add_date_columns(df_historic, "period_month")
+        parts = [df_historic]
 
-    # Combine
-    df = pd.concat([df_historic, df_regional], ignore_index=True)
+        if SHEET_14_DAY_REGIONAL in sheet_names:
+            df_regional = _parse_wait_sheet(file_path, SHEET_14_DAY_REGIONAL, "trust")
+            df_regional = add_date_columns(df_regional, "period_month")
+            parts.append(df_regional)
+
+        df = pd.concat(parts, ignore_index=True)
+    else:
+        # Legacy single-sheet format (pre-Q4 2024-25)
+        df = _parse_wait_sheet(file_path, SHEET_14_DAY_LEGACY, "trust")
+        df = add_date_columns(df, "period_month")
+
     df["performance_rate"] = df["within_target"] / df["total"]
-
     return df[["date", "year", "month", "trust", "within_target", "over_target", "total", "performance_rate"]]
 
 
 def parse_breast_referrals(file_path: str | Path) -> pd.DataFrame:
     """Parse breast cancer referrals data.
+
+    Handles two formats:
+    - Pre-Q3 2025-26: 4 columns (referral_month, trust, total_referrals, urgent_referrals)
+    - Q3 2025-26+: 5 columns (referral_month, trust, routine_referrals, urgent_referrals, total_referrals)
 
     Args:
         file_path: Path to the Excel file
@@ -280,11 +327,19 @@ def parse_breast_referrals(file_path: str | Path) -> pd.DataFrame:
         urgent_referrals, urgent_rate
     """
     df = pd.read_excel(file_path, sheet_name=SHEET_BREAST_REFERRALS)
+    n_cols = len(df.columns)
 
-    df.columns = ["referral_month", "trust", "total_referrals", "urgent_referrals"]
+    if n_cols == 5:
+        # Q3 2025-26+: routine, urgent, total
+        df.columns = ["referral_month", "trust", "routine_referrals", "urgent_referrals", "total_referrals"]
+    elif n_cols == 4:
+        # Pre-Q3 2025-26: total before urgent, no routine column
+        df.columns = ["referral_month", "trust", "total_referrals", "urgent_referrals"]
+    else:
+        raise NISRAValidationError(f"Unexpected column count ({n_cols}) in breast referrals sheet of {file_path}")
+
     df = add_date_columns(df, "referral_month")
     df["urgent_rate"] = df["urgent_referrals"] / df["total_referrals"]
-
     return df[["date", "year", "month", "trust", "total_referrals", "urgent_referrals", "urgent_rate"]]
 
 

--- a/tests/test_nisra_cancer_waiting_times_integrity.py
+++ b/tests/test_nisra_cancer_waiting_times_integrity.py
@@ -19,10 +19,7 @@ import pytest
 
 from bolster.data_sources.nisra import cancer_waiting_times as cwt
 
-_SKIP_REASON = "Cancer waiting times parser broken by upstream column structure change — see issue #1724"
 
-
-@pytest.mark.skip(reason=_SKIP_REASON)
 class Test31DayByTrustIntegrity:
     """Test suite for 31-day waiting times by HSC Trust."""
 
@@ -77,7 +74,6 @@ class Test31DayByTrustIntegrity:
         assert cwt.validate_performance_data(latest_data) is True
 
 
-@pytest.mark.skip(reason=_SKIP_REASON)
 class Test62DayByTumourIntegrity:
     """Test suite for 62-day waiting times by Tumour Site."""
 
@@ -109,7 +105,6 @@ class Test62DayByTumourIntegrity:
         assert cwt.validate_performance_data(latest_data) is True
 
 
-@pytest.mark.skip(reason=_SKIP_REASON)
 class Test14DayBreastIntegrity:
     """Test suite for 14-day breast cancer waiting times."""
 
@@ -124,7 +119,6 @@ class Test14DayBreastIntegrity:
         assert set(latest_data.columns) == required
 
 
-@pytest.mark.skip(reason=_SKIP_REASON)
 class TestBreastReferralsIntegrity:
     """Test suite for breast cancer referrals data."""
 
@@ -150,7 +144,6 @@ class TestBreastReferralsIntegrity:
         assert (valid_rates <= 1).all()
 
 
-@pytest.mark.skip(reason=_SKIP_REASON)
 class TestHelperFunctions:
     """Test suite for helper and analysis functions."""
 
@@ -213,7 +206,6 @@ class TestHelperFunctions:
         assert trend["rolling_performance"].std() < trend["performance_rate"].std()
 
 
-@pytest.mark.skip(reason=_SKIP_REASON)
 class TestDataQuality:
     """Test suite for overall data quality checks."""
 


### PR DESCRIPTION
Closes #1724

## Summary

NISRA's Q3 2025-26 cancer waiting times publication changed the Excel structure in three ways:

1. **Wait-time sheets** (31-day Trust/Tumour, 62-day Trust/Tumour): 5 columns → 7, adding `Median (days)` and `95th Percentile (days)`
2. **Breast Referrals**: 4 columns → 5, adding `Routine Referrals` and reordering `Total` after `Urgent`
3. **14-day Breast** sheet split into `Historic` (pre-May 2025, by Trust) and `Regional` (May 2025+, NI-wide) happened in Q4 2024-25 — the parser already handled this but the legacy single-sheet format wasn't covered

## Approach

Rather than hardcoding the new schema and breaking old files, the fix detects column count at parse time and applies the correct schema for each format. All parsers remain backwards-compatible with pre-Q3 publications.

- Added `_parse_wait_sheet()` helper that handles 5-col and 7-col formats (raises `NISRAValidationError` on unexpected count)
- `parse_breast_referrals()` handles 4-col (old) and 5-col (new) formats
- `parse_14_day_breast()` handles legacy single-sheet, split 5-col, and split 7-col formats
- Output schemas are unchanged — downstream code unaffected

## Test plan

- [ ] All 25 `test_nisra_cancer_waiting_times_integrity.py` tests pass against live data (verified locally)
- [ ] Parsers confirmed working against Q1 2024-25 (5-col old format) and Q3 2025-26 (7-col new format)
- [ ] Full test suite passes

🤖 Generated with [Claude Code](https://claude.ai/claude-code)