### PR TITLE
ci: disable uv cache in auto-release analyze-changes job

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -37,6 +37,7 @@ jobs:
       uses: astral-sh/setup-uv@v7
       with:
         python-version: "3.11"
+        enable-cache: false
 
     - name: Analyze changes and determine version bump
       id: analyze


### PR DESCRIPTION
## Summary

The `analyze-changes` job in `auto-release.yml` uses `astral-sh/setup-uv@v7` with caching enabled (the default), but it only runs a `github-script` step and never installs any Python dependencies. The post-job cache prune step then fails because the cache directory was never created:

```
Cache path /home/runner/work/_temp/setup-uv-cache does not exist on disk.
```

Fix: set `enable-cache: false` for this job since it has nothing to cache.

## Test plan

- [ ] `Automated Release` workflow no longer errors on post-job cleanup

🤖 Generated with [Claude Code](https://claude.ai/claude-code)