### PR TITLE
fix(cli): support --limit > 20 in nisra feed via GOV.UK pagination

### DIFF
--- a/src/bolster/cli.py
+++ b/src/bolster/cli.py
@@ -1218,7 +1218,7 @@ def nisra_feed(limit: int, title_filter: str, days: int, check_coverage: bool):
     }
 
     with console.status("Fetching NISRA RSS feed..."):
-        feed = get_nisra_statistics_feed()
+        feed = get_nisra_statistics_feed(limit=limit)
 
     entries = feed.entries
 

--- a/src/bolster/utils/rss.py
+++ b/src/bolster/utils/rss.py
@@ -276,12 +276,16 @@ def filter_entries(
     return filtered
 
 
-def get_nisra_statistics_feed(order: str = "recent", timeout: int = 30) -> Feed:
+def get_nisra_statistics_feed(order: str = "recent", timeout: int = 30, limit: int | None = None) -> Feed:
     """Get the NISRA statistics feed from GOV.UK.
+
+    The GOV.UK Atom feed returns 20 entries per page. When limit exceeds 20,
+    multiple pages are fetched automatically.
 
     Args:
         order: Sort order - 'recent' for newest first, 'oldest' for oldest first
         timeout: Request timeout in seconds
+        limit: Maximum number of entries to return (None = first page only, i.e. 20)
 
     Returns:
         Feed object with NISRA statistics
@@ -289,20 +293,40 @@ def get_nisra_statistics_feed(order: str = "recent", timeout: int = 30) -> Feed:
     Example:
         >>> feed = get_nisra_statistics_feed()
         >>> print(f"Found {len(feed.entries)} NISRA publications")
+        >>> feed100 = get_nisra_statistics_feed(limit=100)
+        >>> print(f"Found {len(feed100.entries)} NISRA publications")
     """
-    # Build the URL based on sort order
-    if order == "oldest":
-        url = (
-            "https://www.gov.uk/search/research-and-statistics.atom?"
-            "content_store_document_type=all_research_and_statistics&"
-            "organisations%5B%5D=northern-ireland-statistics-and-research-agency&"
-            "order=release-date-oldest"
-        )
-    else:
-        url = (
-            "https://www.gov.uk/search/research-and-statistics.atom?"
-            "content_store_document_type=all_research_and_statistics&"
-            "organisations%5B%5D=northern-ireland-statistics-and-research-agency"
-        )
+    order_param = "&order=release-date-oldest" if order == "oldest" else ""
+    base_url = (
+        "https://www.gov.uk/search/research-and-statistics.atom?"
+        "content_store_document_type=all_research_and_statistics&"
+        f"organisations%5B%5D=northern-ireland-statistics-and-research-agency{order_param}"
+    )
 
-    return parse_rss_feed(url, timeout=timeout)
+    first_page = parse_rss_feed(base_url, timeout=timeout)
+
+    if limit is None or limit <= len(first_page.entries):
+        return first_page
+
+    # Paginate until we have enough entries or run out of pages
+    all_entries = list(first_page.entries)
+    page = 2
+    while len(all_entries) < limit:
+        paged_url = f"{base_url}&page={page}"
+        try:
+            next_page = parse_rss_feed(paged_url, timeout=timeout)
+        except Exception:
+            break
+        if not next_page.entries:
+            break
+        all_entries.extend(next_page.entries)
+        page += 1
+
+    return Feed(
+        title=first_page.title,
+        link=first_page.link,
+        description=first_page.description,
+        language=first_page.language,
+        updated=first_page.updated,
+        entries=all_entries[:limit],
+    )

--- a/src/bolster/utils/rss.py
+++ b/src/bolster/utils/rss.py
@@ -306,6 +306,7 @@ def get_nisra_statistics_feed(order: str = "recent", timeout: int = 30, limit: i
     first_page = parse_rss_feed(base_url, timeout=timeout)
 
     if limit is None or limit <= len(first_page.entries):
+        first_page.entries = first_page.entries[:limit]
         return first_page
 
     # Paginate until we have enough entries or run out of pages

--- a/tests/test_rss.py
+++ b/tests/test_rss.py
@@ -265,3 +265,70 @@ def test_feed_empty_entries():
 
     assert feed.entries == []
     assert isinstance(feed.entries, list)
+
+
+def _make_feed(n: int) -> Feed:
+    """Helper: Feed with n entries."""
+    return Feed(
+        title="NISRA Stats",
+        link="https://www.gov.uk",
+        entries=[FeedEntry(title=f"Entry {i}", link=f"https://www.gov.uk/{i}") for i in range(n)],
+    )
+
+
+@patch("bolster.utils.rss.parse_rss_feed")
+def test_get_nisra_statistics_feed_limit_within_first_page(mock_parse):
+    """limit <= page size returns first page without extra fetches."""
+    mock_parse.return_value = _make_feed(20)
+
+    feed = get_nisra_statistics_feed(limit=10)
+
+    assert len(feed.entries) == 10
+    mock_parse.assert_called_once()
+
+
+@patch("bolster.utils.rss.parse_rss_feed")
+def test_get_nisra_statistics_feed_pagination(mock_parse):
+    """limit > 20 triggers additional page fetches."""
+    mock_parse.side_effect = [_make_feed(20), _make_feed(20), _make_feed(20)]
+
+    feed = get_nisra_statistics_feed(limit=50)
+
+    assert len(feed.entries) == 50
+    assert mock_parse.call_count == 3
+    # Second call should include &page=2
+    second_url = mock_parse.call_args_list[1][0][0]
+    assert "page=2" in second_url
+
+
+@patch("bolster.utils.rss.parse_rss_feed")
+def test_get_nisra_statistics_feed_pagination_stops_on_empty(mock_parse):
+    """Pagination stops when a page returns no entries."""
+    mock_parse.side_effect = [_make_feed(20), _make_feed(0)]
+
+    feed = get_nisra_statistics_feed(limit=50)
+
+    assert len(feed.entries) == 20
+    assert mock_parse.call_count == 2
+
+
+@patch("bolster.utils.rss.parse_rss_feed")
+def test_get_nisra_statistics_feed_pagination_stops_on_error(mock_parse):
+    """Pagination stops gracefully if a page fetch raises."""
+    mock_parse.side_effect = [_make_feed(20), Exception("network error")]
+
+    feed = get_nisra_statistics_feed(limit=50)
+
+    assert len(feed.entries) == 20
+    assert mock_parse.call_count == 2
+
+
+@patch("bolster.utils.rss.parse_rss_feed")
+def test_get_nisra_statistics_feed_no_limit(mock_parse):
+    """No limit returns only the first page."""
+    mock_parse.return_value = _make_feed(20)
+
+    feed = get_nisra_statistics_feed()
+
+    assert len(feed.entries) == 20
+    mock_parse.assert_called_once()


### PR DESCRIPTION
## Summary

`bolster nisra feed --limit 100` was silently capped at 20 entries because the GOV.UK Atom feed returns a fixed 20 entries per page and only page 1 was ever fetched.

- `get_nisra_statistics_feed()` now accepts a `limit` parameter and fetches additional pages (`&page=N`) until the limit is satisfied or pages run out
- The CLI passes `limit` through to the feed function directly
- Default behaviour (no `--limit` flag, default 20) is unchanged — only one page is fetched

The pagination pattern is GOV.UK-specific (`&page=N` query param, stop on empty response) and is self-contained in `rss.py` — no shared abstraction needed.

## Test plan

- [ ] `bolster nisra feed -n 50` returns 50 entries (verified locally: 3 pages fetched)
- [ ] `bolster nisra feed` (default) still returns 20 entries from a single page fetch
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.ai/claude-code)