### PR TITLE
feat: weekly NISRA feed drift detection via TF-IDF

### DIFF
--- a/.github/workflows/nisra-feed-drift.yml
+++ b/.github/workflows/nisra-feed-drift.yml
@@ -1,0 +1,157 @@
+name: NISRA Feed Drift Detection
+
+on:
+  schedule:
+    # Friday 01:00 UTC (covers both GMT and BST)
+    - cron: '0 1 * * 5'
+  workflow_dispatch:
+    inputs:
+      limit:
+        description: 'Number of feed entries to check'
+        default: '20'
+        required: false
+      covered_threshold:
+        description: 'Min similarity score to classify as covered (0-1)'
+        default: '0.60'
+        required: false
+      adjacent_threshold:
+        description: 'Min similarity score to classify as adjacent (0-1)'
+        default: '0.40'
+        required: false
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  drift-detection:
+    runs-on: ubuntu-latest
+    outputs:
+      new_count: ${{ steps.classify.outputs.new_count }}
+      adjacent_count: ${{ steps.classify.outputs.adjacent_count }}
+
+    steps:
+    - uses: actions/checkout@v6
+
+    - name: Setup Python and uv
+      uses: astral-sh/setup-uv@v7
+      with:
+        python-version: "3.11"
+        enable-cache: false
+
+    - name: Run TF-IDF drift detection
+      id: classify
+      run: |
+        uv run scripts/nisra_feed_tfidf.py \
+          --limit ${{ inputs.limit || '20' }} \
+          --covered-threshold ${{ inputs.covered_threshold || '0.60' }} \
+          --adjacent-threshold ${{ inputs.adjacent_threshold || '0.40' }} \
+          --verbose \
+          --json-out results.json \
+          --github-summary \
+          || EXIT_CODE=$?
+
+        NEW_COUNT=$(python3 -c "import json; r=json.load(open('results.json')); print(sum(1 for x in r if x['status']=='new'))")
+        ADJACENT_COUNT=$(python3 -c "import json; r=json.load(open('results.json')); print(sum(1 for x in r if x['status']=='adjacent'))")
+        echo "new_count=$NEW_COUNT" >> $GITHUB_OUTPUT
+        echo "adjacent_count=$ADJACENT_COUNT" >> $GITHUB_OUTPUT
+        echo "New datasets found: $NEW_COUNT, Adjacent: $ADJACENT_COUNT"
+
+        # Exit 0 even if new entries found — we handle that in the next job
+        exit 0
+
+    - name: Upload results
+      uses: actions/upload-artifact@v4
+      with:
+        name: drift-results
+        path: results.json
+        retention-days: 30
+
+  create-issues:
+    needs: drift-detection
+    runs-on: ubuntu-latest
+    if: needs.drift-detection.outputs.new_count > 0
+
+    steps:
+    - uses: actions/checkout@v6
+
+    - name: Download results
+      uses: actions/download-artifact@v4
+      with:
+        name: drift-results
+
+    - name: Create or update issues for new datasets
+      uses: actions/github-script@v9
+      with:
+        script: |
+          const fs = require('fs');
+          const results = JSON.parse(fs.readFileSync('results.json', 'utf8'));
+          const newEntries = results.filter(r => r.status === 'new');
+
+          for (const entry of newEntries) {
+            // Search for existing open issue with this title
+            const searchResult = await github.rest.search.issuesAndPullRequests({
+              q: `repo:${context.repo.owner}/${context.repo.repo} is:issue is:open label:data-source-candidate "${entry.title}" in:title`,
+            });
+
+            if (searchResult.data.total_count > 0) {
+              // Comment on existing issue with latest detection
+              const issue = searchResult.data.items[0];
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                body: `🔄 **Re-detected by NISRA feed drift scan** (${new Date().toISOString().split('T')[0]})\n\n- Score: ${entry.score.toFixed(3)} (closest match: \`${entry.best_match}\`)\n- Published: ${entry.published || 'unknown'}\n- [Source](${entry.link})`,
+              });
+              console.log(`Updated existing issue #${issue.number}: ${entry.title}`);
+            } else {
+              // Create new issue
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title: `data-source-candidate: ${entry.title}`,
+                labels: ['data-source-candidate', 'enhancement'],
+                body: [
+                  '## New NISRA Dataset Detected',
+                  '',
+                  `Identified by the weekly NISRA feed drift scan on ${new Date().toISOString().split('T')[0]}.`,
+                  '',
+                  '### Dataset details',
+                  '',
+                  `- **Title**: ${entry.title}`,
+                  `- **Published**: ${entry.published || 'unknown'}`,
+                  `- **Source**: ${entry.link}`,
+                  `- **TF-IDF score**: ${entry.score.toFixed(3)} (closest existing module: \`${entry.best_match}\`)`,
+                  '',
+                  '### Next steps',
+                  '',
+                  '- [ ] Run `data-explore` agent to evaluate accessibility and format',
+                  '- [ ] Assess integration complexity',
+                  '- [ ] If RECOMMENDED, run `data-build` agent',
+                  '',
+                  '_Auto-created by [NISRA Feed Drift Detection](.github/workflows/nisra-feed-drift.yml)_',
+                ].join('\n'),
+              });
+              console.log(`Created new issue: ${entry.title}`);
+            }
+          }
+
+  run-tests:
+    needs: drift-detection
+    runs-on: ubuntu-latest
+    # Always run tests on schedule to catch silent schema drift
+    if: always()
+
+    steps:
+    - uses: actions/checkout@v6
+
+    - name: Setup Python and uv
+      uses: astral-sh/setup-uv@v7
+      with:
+        python-version: "3.11"
+
+    - name: Install dependencies
+      run: uv sync --dev
+
+    - name: Run full test suite
+      run: uv run pytest tests/ -v --tb=short

--- a/.github/workflows/nisra-feed-drift.yml
+++ b/.github/workflows/nisra-feed-drift.yml
@@ -88,28 +88,74 @@ jobs:
           const results = JSON.parse(fs.readFileSync('results.json', 'utf8'));
           const newEntries = results.filter(r => r.status === 'new');
 
+          // Strip temporal tokens to get a stable dataset "species" name for dedup.
+          // e.g. "Baby Names (Northern Ireland) 2025" -> "Baby Names (Northern Ireland)"
+          //      "LAC municipal waste statistics - Oct-Dec 2025" -> "LAC municipal waste statistics"
+          function speciesName(title) {
+            return title
+              .replace(/\b(19|20)\d{2}(\/\d{2,4})?\b/g, '')   // years like 2025, 2025/26
+              .replace(/\b(Q[1-4]|quarter\s*[1-4])\b/gi, '')   // Q1-Q4
+              .replace(/\b(jan(uary)?|feb(ruary)?|mar(ch)?|apr(il)?|may|jun(e)?|jul(y)?|aug(ust)?|sep(tember)?|oct(ober)?|nov(ember)?|dec(ember)?)\b/gi, '')
+              .replace(/[-–]\s*[-–]/g, '')                       // dangling separators
+              .replace(/\s{2,}/g, ' ')
+              .trim();
+          }
+
+          // Fetch ALL existing data-source-candidate issues (open and closed)
+          // to avoid recreating things that were deliberately closed/resolved.
+          const existingIssues = await github.paginate(github.rest.issues.listForRepo, {
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            labels: 'data-source-candidate',
+            state: 'all',
+            per_page: 100,
+          });
+
+          console.log(`Found ${existingIssues.length} existing data-source-candidate issues`);
+
           for (const entry of newEntries) {
-            // Search for existing open issue with this title
-            const searchResult = await github.rest.search.issuesAndPullRequests({
-              q: `repo:${context.repo.owner}/${context.repo.repo} is:issue is:open label:data-source-candidate "${entry.title}" in:title`,
+            const species = speciesName(entry.title);
+            console.log(`Processing: "${entry.title}" (species: "${species}")`);
+
+            // Match against existing issues by comparing species names
+            const match = existingIssues.find(issue => {
+              const issueSpecies = speciesName(
+                issue.title.replace(/^data-source-candidate:\s*/i, '')
+              );
+              // Both must share enough words to be the same dataset type
+              const entryWords = new Set(species.toLowerCase().split(/\s+/).filter(w => w.length > 2));
+              const issueWords = new Set(issueSpecies.toLowerCase().split(/\s+/).filter(w => w.length > 2));
+              const intersection = [...entryWords].filter(w => issueWords.has(w));
+              const overlap = intersection.length / Math.max(entryWords.size, issueWords.size, 1);
+              return overlap >= 0.5;  // 50% word overlap = same species
             });
 
-            if (searchResult.data.total_count > 0) {
-              // Comment on existing issue with latest detection
-              const issue = searchResult.data.items[0];
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: issue.number,
-                body: `🔄 **Re-detected by NISRA feed drift scan** (${new Date().toISOString().split('T')[0]})\n\n- Score: ${entry.score.toFixed(3)} (closest match: \`${entry.best_match}\`)\n- Published: ${entry.published || 'unknown'}\n- [Source](${entry.link})`,
-              });
-              console.log(`Updated existing issue #${issue.number}: ${entry.title}`);
+            if (match) {
+              if (match.state === 'closed') {
+                console.log(`Skipping "${entry.title}" — already resolved in #${match.number} (closed)`);
+              } else {
+                // Comment on existing open issue
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: match.number,
+                  body: [
+                    `🔄 **Re-detected by NISRA feed drift scan** (${new Date().toISOString().split('T')[0]})`,
+                    '',
+                    `- **New publication**: ${entry.title}`,
+                    `- **Score**: ${entry.score.toFixed(3)} (closest match: \`${entry.best_match}\`)`,
+                    `- **Published**: ${entry.published || 'unknown'}`,
+                    `- [Source](${entry.link})`,
+                  ].join('\n'),
+                });
+                console.log(`Commented on existing issue #${match.number}: ${entry.title}`);
+              }
             } else {
               // Create new issue
               await github.rest.issues.create({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                title: `data-source-candidate: ${entry.title}`,
+                title: `data-source-candidate: ${species}`,
                 labels: ['data-source-candidate', 'enhancement'],
                 body: [
                   '## New NISRA Dataset Detected',
@@ -132,7 +178,7 @@ jobs:
                   '_Auto-created by [NISRA Feed Drift Detection](.github/workflows/nisra-feed-drift.yml)_',
                 ].join('\n'),
               });
-              console.log(`Created new issue: ${entry.title}`);
+              console.log(`Created new issue for species: ${species}`);
             }
           }
 

--- a/scripts/nisra_feed_tfidf.py
+++ b/scripts/nisra_feed_tfidf.py
@@ -1,0 +1,306 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["scipy", "numpy", "feedparser", "rich"]
+# ///
+"""NISRA feed drift detection via TF-IDF.
+
+Fetches the NISRA discovery RSS feed, builds a TF-IDF corpus from existing
+data source module docstrings, and classifies each feed entry as:
+
+  covered   — similarity >= COVERED_THRESHOLD  (known dataset, new release)
+  adjacent  — similarity >= ADJACENT_THRESHOLD (related, possibly covered)
+  new       — similarity <  ADJACENT_THRESHOLD (potential new species)
+
+Exits with code 2 if any 'new' entries are found so CI can act on them.
+"""
+
+import argparse
+import ast
+import json
+import pathlib
+import re
+import sys
+from collections import Counter
+from dataclasses import dataclass, field
+
+import feedparser
+import numpy as np
+
+COVERED_THRESHOLD = 0.60
+ADJACENT_THRESHOLD = 0.40
+
+NISRA_FEED_URL = (
+    "https://www.gov.uk/search/research-and-statistics.atom?"
+    "content_store_document_type=all_research_and_statistics&"
+    "organisations%5B%5D=northern-ireland-statistics-and-research-agency"
+)
+
+# Terms so common in NI government publications they add no discriminatory signal
+_STOPWORDS = {
+    "northern", "ireland", "ni", "statistics", "statistical", "quarterly",
+    "monthly", "annual", "weekly", "report", "bulletin", "publication",
+    "data", "register", "registered", "registrar", "quarter", "ending",
+    "january", "february", "march", "april", "may", "june", "july",
+    "august", "september", "october", "november", "december",
+    "2020", "2021", "2022", "2023", "2024", "2025", "2026",
+    "in", "of", "the", "and", "for", "to", "by", "at", "or",
+    "with", "from", "on", "an", "is", "as",
+}
+
+REPO_ROOT = pathlib.Path(__file__).parent.parent
+
+
+# ---------------------------------------------------------------------------
+# TF-IDF (scipy + numpy, no sklearn)
+# ---------------------------------------------------------------------------
+
+def _tokenise(text: str) -> list[str]:
+    text = text.lower()
+    text = re.sub(r"[^a-z0-9\s]", " ", text)
+    return [t for t in text.split() if len(t) > 1 and t not in _STOPWORDS]
+
+
+def _build_tfidf(documents: list[str]) -> tuple[np.ndarray, list[str]]:
+    tokenised = [_tokenise(d) for d in documents]
+    vocab = sorted({tok for tokens in tokenised for tok in tokens})
+    vocab_index = {t: i for i, t in enumerate(vocab)}
+    n_docs, n_terms = len(documents), len(vocab)
+
+    tf = np.zeros((n_docs, n_terms), dtype=float)
+    for di, tokens in enumerate(tokenised):
+        counts = Counter(tokens)
+        total = sum(counts.values()) or 1
+        for tok, cnt in counts.items():
+            if tok in vocab_index:
+                tf[di, vocab_index[tok]] = cnt / total
+
+    df = np.zeros(n_terms, dtype=float)
+    for tokens in tokenised:
+        for tok in set(tokens):
+            if tok in vocab_index:
+                df[vocab_index[tok]] += 1
+
+    idf = np.log((1 + n_docs) / (1 + df)) + 1
+    tfidf = tf * idf
+    norms = np.linalg.norm(tfidf, axis=1, keepdims=True)
+    norms[norms == 0] = 1
+    return tfidf / norms, vocab
+
+
+def _query(text: str, corpus_tfidf: np.ndarray, vocab: list[str]) -> np.ndarray:
+    vocab_index = {t: i for i, t in enumerate(vocab)}
+    tokens = _tokenise(text)
+    counts = Counter(tokens)
+    total = sum(counts.values()) or 1
+    q = np.zeros(len(vocab), dtype=float)
+    for tok, cnt in counts.items():
+        if tok in vocab_index:
+            q[vocab_index[tok]] = cnt / total
+    norm = np.linalg.norm(q)
+    if norm == 0:
+        return np.zeros(len(corpus_tfidf))
+    return corpus_tfidf @ (q / norm)
+
+
+# ---------------------------------------------------------------------------
+# Corpus
+# ---------------------------------------------------------------------------
+
+@dataclass
+class ModuleDoc:
+    name: str
+    path: str
+    docstring: str
+    text: str = field(init=False)
+
+    def __post_init__(self):
+        self.text = f"{self.name.replace('_', ' ')} {self.docstring}"
+
+
+def extract_corpus(root: pathlib.Path) -> list[ModuleDoc]:
+    docs = []
+    for path in sorted(root.rglob("*.py")):
+        if path.name.startswith("_"):
+            continue
+        try:
+            tree = ast.parse(path.read_text())
+            docstring = ast.get_docstring(tree) or ""
+            first_line = next((l.strip() for l in docstring.splitlines() if l.strip()), "")
+            docs.append(ModuleDoc(
+                name=path.stem,
+                path=str(path.relative_to(REPO_ROOT)),
+                docstring=first_line,
+            ))
+        except Exception:
+            pass
+    return docs
+
+
+# ---------------------------------------------------------------------------
+# Feed
+# ---------------------------------------------------------------------------
+
+def fetch_feed(limit: int = 20) -> list[dict]:
+    parsed = feedparser.parse(NISRA_FEED_URL)
+    entries = []
+    for e in parsed.entries[:limit]:
+        entries.append({
+            "title": e.get("title", ""),
+            "summary": e.get("summary", ""),
+            "link": e.get("link", ""),
+            "published": e.get("published", None),
+        })
+    return entries
+
+
+# ---------------------------------------------------------------------------
+# Classification
+# ---------------------------------------------------------------------------
+
+@dataclass
+class Classification:
+    title: str
+    link: str
+    published: str | None
+    status: str
+    best_match: str
+    best_match_path: str
+    score: float
+
+
+def classify_feed(
+    entries: list[dict],
+    corpus: list[ModuleDoc],
+    covered_threshold: float = COVERED_THRESHOLD,
+    adjacent_threshold: float = ADJACENT_THRESHOLD,
+) -> list[Classification]:
+    tfidf, vocab = _build_tfidf([m.text for m in corpus])
+    results = []
+    for entry in entries:
+        sims = _query(f"{entry['title']} {entry['summary']}", tfidf, vocab)
+        best_idx = int(np.argmax(sims))
+        best_score = float(sims[best_idx])
+        best = corpus[best_idx]
+        if best_score >= covered_threshold:
+            status = "covered"
+        elif best_score >= adjacent_threshold:
+            status = "adjacent"
+        else:
+            status = "new"
+        results.append(Classification(
+            title=entry["title"],
+            link=entry["link"],
+            published=entry["published"],
+            status=status,
+            best_match=best.name,
+            best_match_path=best.path,
+            score=best_score,
+        ))
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Output
+# ---------------------------------------------------------------------------
+
+def print_results(results: list[Classification], verbose: bool = False) -> None:
+    from rich.console import Console
+    from rich.table import Table
+
+    console = Console()
+    table = Table(title="NISRA Feed Drift Detection", show_lines=True)
+    table.add_column("Status", width=10)
+    table.add_column("Score", width=6)
+    table.add_column("Title", width=55)
+    table.add_column("Best match", width=30)
+
+    colours = {"covered": "green", "adjacent": "yellow", "new": "red"}
+    for r in results:
+        if not verbose and r.status == "covered":
+            continue
+        c = colours[r.status]
+        table.add_row(f"[{c}]{r.status}[/{c}]", f"{r.score:.3f}", r.title, r.best_match)
+
+    console.print(table)
+
+
+def write_github_summary(results: list[Classification]) -> None:
+    import os
+    path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if not path:
+        return
+    covered = [r for r in results if r.status == "covered"]
+    adjacent = [r for r in results if r.status == "adjacent"]
+    new = [r for r in results if r.status == "new"]
+    lines = [
+        "## NISRA Feed Drift Detection",
+        "",
+        "| Status | Count |",
+        "|--------|-------|",
+        f"| ✅ Covered | {len(covered)} |",
+        f"| ⚠️ Adjacent | {len(adjacent)} |",
+        f"| 🆕 New | {len(new)} |",
+        "",
+    ]
+    if adjacent:
+        lines += ["### ⚠️ Adjacent (possibly covered)", ""]
+        for r in adjacent:
+            lines.append(f"- **{r.title}** (score {r.score:.3f} → `{r.best_match}`)")
+        lines.append("")
+    if new:
+        lines += ["### 🆕 Potentially new datasets", ""]
+        for r in new:
+            lines.append(f"- **[{r.title}]({r.link})** (score {r.score:.3f}, closest: `{r.best_match}`)")
+        lines.append("")
+    with open(path, "a") as f:
+        f.write("\n".join(lines))
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--limit", type=int, default=20)
+    parser.add_argument("--covered-threshold", type=float, default=COVERED_THRESHOLD,
+                        help=f"Min similarity to classify as covered (default: {COVERED_THRESHOLD})")
+    parser.add_argument("--adjacent-threshold", type=float, default=ADJACENT_THRESHOLD,
+                        help=f"Min similarity to classify as adjacent (default: {ADJACENT_THRESHOLD})")
+    parser.add_argument("--verbose", action="store_true", help="Show covered entries too")
+    parser.add_argument("--json-out", type=pathlib.Path, help="Write full results JSON")
+    parser.add_argument("--github-summary", action="store_true")
+    args = parser.parse_args()
+
+    corpus = extract_corpus(REPO_ROOT / "src" / "bolster" / "data_sources")
+    print(f"Corpus: {len(corpus)} modules", file=sys.stderr)
+
+    entries = fetch_feed(limit=args.limit)
+    print(f"Feed: {len(entries)} entries", file=sys.stderr)
+
+    results = classify_feed(
+        entries, corpus,
+        covered_threshold=args.covered_threshold,
+        adjacent_threshold=args.adjacent_threshold,
+    )
+
+    print_results(results, verbose=args.verbose)
+
+    if args.json_out:
+        args.json_out.write_text(json.dumps(
+            [{"title": r.title, "link": r.link, "published": r.published,
+              "status": r.status, "best_match": r.best_match,
+              "best_match_path": r.best_match_path, "score": r.score}
+             for r in results],
+            indent=2,
+        ))
+
+    if args.github_summary:
+        write_github_summary(results)
+
+    return 2 if any(r.status == "new" for r in results) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Implements #1730 — a weekly automated workflow that monitors the NISRA discovery feed for new datasets and schema drift.

### How it works

1. **TF-IDF classification** (`scripts/nisra_feed_tfidf.py`): fetches the NISRA RSS feed, builds a corpus from all existing data source module docstrings + names, and scores each feed entry against the corpus using cosine similarity with NI-specific stopwords (`northern`, `ireland`, `statistics`, `monthly`, etc.) to prevent false matches on common terms.

2. **Three-way classification**:
   - ✅ **Covered** (≥0.60): high-confidence match to existing module — new release of known dataset
   - ⚠️ **Adjacent** (0.40–0.60): moderate match — possibly a sub-type or renamed edition worth reviewing
   - 🆕 **New** (<0.40): no good match — potential new species, creates/updates a GitHub issue with label `data-source-candidate`

3. **Issue management**: deduplicates against existing open issues before creating new ones; re-detections add a comment with the latest publication date and score

4. **Test re-run**: always runs the full test suite to catch silent upstream schema drift

### Threshold calibration against current feed

| Score | Title | Status | Module |
|-------|-------|--------|--------|
| 0.95 | NI cancer waiting times Oct–Dec 2025 | ✅ covered | `cancer_waiting_times` |
| 0.93 | DVA Monthly Tests March 2026 | ✅ covered | `dva` |
| 0.92 | NI Labour Market April 2026 | ✅ covered | `labour_market` |
| 0.89 | Monthly Occupancy Feb 2026 | ✅ covered | `occupancy` |
| 0.87 | Emergency Care Waiting Times Jan–Mar 2026 | ✅ covered | `emergency_care_waiting_times` |
| 0.56 | Monthly Deaths March 2026 | ⚠️ adjacent | `deaths` |
| 0.56 | Monthly Births March 2026 | ⚠️ adjacent | `births` |
| 0.44 | Monthly Marriages March 2026 | ⚠️ adjacent | `marriages` |
| 0.38 | Police Ombudsman Complaints Q4 2025/26 | 🆕 new | — |
| 0.00 | LAC municipal waste Oct–Dec 2025 | 🆕 new | — |
| 0.00 | Baby Names (NI) 2025 | 🆕 new | — |
| 0.00 | NI planning statistics Oct–Dec 2025 | 🆕 new | — |

### Schedule

Fridays at 01:00 UTC. Also triggerable manually via `workflow_dispatch` with configurable `limit`, `covered_threshold`, and `adjacent_threshold` inputs.

## Test plan

- [x] Script runs locally and produces correct classification against current feed
- [x] `uv run pre-commit run --files scripts/nisra_feed_tfidf.py` — clean
- [x] Workflow YAML validates (`check yaml` pre-commit hook passes)
- [ ] CI build passes
- [ ] Manual `workflow_dispatch` trigger validates issue creation logic

## Related

- Closes #1730
- Precursor to #1731 (embedding-based deep exploration of new species)