### PR TITLE
feat(ashe): implement Figures 14-18 gender earnings analysis

### DIFF
--- a/src/bolster/data_sources/nisra/ashe.py
+++ b/src/bolster/data_sources/nisra/ashe.py
@@ -527,25 +527,348 @@ def calculate_growth_rates(df: pd.DataFrame, periods: int = 1) -> pd.DataFrame:
     return result
 
 
-def get_gender_pay_gap(df_weekly: pd.DataFrame) -> pd.DataFrame:
-    """Calculate gender pay gap from weekly earnings data.
+def parse_ashe_gender_pay_gap(file_path: str | Path) -> pd.DataFrame:
+    """Parse ASHE gender pay gap timeseries (Figure 14).
 
-    Note: This requires weekly earnings data broken down by gender, which may not
-    be available in the timeseries file. Use the linked tables file instead.
+    Extracts the NI and UK all-employee gender pay gap from 2005 to present.
+    The gap is defined as the difference between male and female median hourly
+    earnings as a percentage of male median hourly earnings (all employees,
+    excluding overtime).
+
+    Note: methodological changes occurred in 2006, 2011 and 2021 — these are
+    annotated in NISRA publications and should be considered when interpreting
+    trend breaks.
 
     Args:
-        df_weekly: Weekly earnings DataFrame with 'sex' or 'gender' column
+        file_path: Path to the ASHE linked tables Excel file
 
     Returns:
-        DataFrame with gender pay gap by year
+        DataFrame with columns:
+
+        - year: int
+        - location: str ('Northern Ireland' or 'United Kingdom')
+        - gender_pay_gap_pct: float — GPG as % of male earnings (positive = men paid more)
 
     Example:
-        >>> # This requires data from the linked tables file with gender breakdown
-        >>> # Not available in the simple timeseries
-        >>> pass
+        >>> df = parse_ashe_gender_pay_gap("ASHE-2025-linked.xlsx")
+        >>> ni = df[df['location'] == 'Northern Ireland']
+        >>> print(ni.tail())
     """
-    # Placeholder - would need gender-specific data from linked tables
-    raise NotImplementedError("Gender pay gap calculation requires gender-specific data from linked tables file")
+    logger.info(f"Parsing ASHE gender pay gap (Fig14) from: {file_path}")
+    df = pd.read_excel(file_path, sheet_name="Figure14", skiprows=3)
+    df.columns = ["year", "UK", "NI"]
+    df = df.dropna(subset=["year"])
+    df["year"] = df["year"].astype(int)
+
+    records = []
+    for _, row in df.iterrows():
+        records.append({"year": int(row["year"]), "location": "United Kingdom", "gender_pay_gap_pct": float(row["UK"])})
+        records.append(
+            {"year": int(row["year"]), "location": "Northern Ireland", "gender_pay_gap_pct": float(row["NI"])}
+        )
+
+    result = pd.DataFrame(records).sort_values(["year", "location"]).reset_index(drop=True)
+    logger.info(f"Parsed {len(result)} gender pay gap records ({result['year'].min()}–{result['year'].max()})")
+    return result
+
+
+def parse_ashe_hourly_earnings_by_sector_gender(file_path: str | Path) -> pd.DataFrame:
+    """Parse ASHE hourly earnings by sector and gender timeseries (Figure 15).
+
+    Extracts median gross hourly earnings (excluding overtime) for NI employees
+    broken down by public/private sector and male/female, from 2005 to present.
+
+    Args:
+        file_path: Path to the ASHE linked tables Excel file
+
+    Returns:
+        DataFrame with columns:
+
+        - year: int
+        - sector: str ('Public' or 'Private')
+        - sex: str ('Male' or 'Female')
+        - median_hourly_earnings: float (£, excluding overtime)
+
+    Example:
+        >>> df = parse_ashe_hourly_earnings_by_sector_gender("ASHE-2025-linked.xlsx")
+        >>> latest = df[df['year'] == df['year'].max()]
+        >>> print(latest.pivot(index='sector', columns='sex', values='median_hourly_earnings'))
+    """
+    logger.info(f"Parsing ASHE hourly earnings by sector/gender (Fig15) from: {file_path}")
+    df = pd.read_excel(file_path, sheet_name="Figure15", skiprows=3)
+    df.columns = ["year", "Male public", "Female public", "Male private", "Female private"]
+    df = df.dropna(subset=["year"])
+    df["year"] = df["year"].astype(int)
+
+    records = []
+    for _, row in df.iterrows():
+        for col, sector, sex in [
+            ("Male public", "Public", "Male"),
+            ("Female public", "Public", "Female"),
+            ("Male private", "Private", "Male"),
+            ("Female private", "Private", "Female"),
+        ]:
+            records.append(
+                {"year": int(row["year"]), "sector": sector, "sex": sex, "median_hourly_earnings": float(row[col])}
+            )
+
+    result = pd.DataFrame(records).sort_values(["year", "sector", "sex"]).reset_index(drop=True)
+    logger.info(f"Parsed {len(result)} sector/gender earnings records ({result['year'].min()}–{result['year'].max()})")
+    return result
+
+
+def parse_ashe_hourly_earnings_by_age_gender(file_path: str | Path) -> pd.DataFrame:
+    """Parse ASHE hourly earnings by age group and gender, latest year (Figure 16).
+
+    Extracts median gross hourly earnings (excluding overtime) for NI employees
+    broken down by age band and sex. Single-year snapshot from the latest publication.
+
+    Args:
+        file_path: Path to the ASHE linked tables Excel file
+
+    Returns:
+        DataFrame with columns:
+
+        - age_group: str (e.g. '18-21', '22-29', '30-39', '40-49', '50-59', '60+')
+        - sex: str ('Male' or 'Female')
+        - median_hourly_earnings: float (£, excluding overtime)
+
+    Example:
+        >>> df = parse_ashe_hourly_earnings_by_age_gender("ASHE-2025-linked.xlsx")
+        >>> df['implied_gpg_pct'] = (df['Male'] - df['Female']) / df['Male'] * 100
+    """
+    logger.info(f"Parsing ASHE hourly earnings by age/gender (Fig16) from: {file_path}")
+    df = pd.read_excel(file_path, sheet_name="Figure16", skiprows=2)
+    df.columns = ["age_group", "Female", "Male"]
+    df = df.dropna(subset=["age_group"])
+
+    records = []
+    for _, row in df.iterrows():
+        for sex in ("Female", "Male"):
+            records.append({"age_group": str(row["age_group"]), "sex": sex, "median_hourly_earnings": float(row[sex])})
+
+    result = pd.DataFrame(records)
+    logger.info(f"Parsed {len(result)} age/gender earnings records ({len(df)} age bands)")
+    return result
+
+
+def parse_ashe_hourly_earnings_by_occupation_gender(file_path: str | Path) -> pd.DataFrame:
+    """Parse ASHE hourly earnings by occupation and gender, latest year (Figure 17).
+
+    Extracts median gross hourly earnings (excluding overtime) for NI employees
+    broken down by SOC major occupation group and sex. Single-year snapshot.
+
+    Args:
+        file_path: Path to the ASHE linked tables Excel file
+
+    Returns:
+        DataFrame with columns:
+
+        - occupation: str (SOC major group label)
+        - sex: str ('Male' or 'Female')
+        - median_hourly_earnings: float (£, excluding overtime)
+
+    Example:
+        >>> df = parse_ashe_hourly_earnings_by_occupation_gender("ASHE-2025-linked.xlsx")
+        >>> wide = df.pivot(index='occupation', columns='sex', values='median_hourly_earnings')
+        >>> wide['gpg_pct'] = (wide['Male'] - wide['Female']) / wide['Male'] * 100
+        >>> print(wide.sort_values('gpg_pct', ascending=False))
+    """
+    logger.info(f"Parsing ASHE hourly earnings by occupation/gender (Fig17) from: {file_path}")
+    df = pd.read_excel(file_path, sheet_name="Figure17", skiprows=2)
+    df.columns = ["occupation", "Female", "Male"]
+    df = df.dropna(subset=["occupation"])
+
+    records = []
+    for _, row in df.iterrows():
+        for sex in ("Female", "Male"):
+            records.append(
+                {"occupation": str(row["occupation"]), "sex": sex, "median_hourly_earnings": float(row[sex])}
+            )
+
+    result = pd.DataFrame(records)
+    logger.info(f"Parsed {len(result)} occupation/gender earnings records ({len(df)} occupation groups)")
+    return result
+
+
+def parse_ashe_hourly_earnings_by_pattern_gender(file_path: str | Path) -> pd.DataFrame:
+    """Parse ASHE hourly earnings by working pattern and gender, latest year (Figure 18).
+
+    Extracts median gross hourly earnings (excluding overtime) for NI employees
+    broken down by full-time/part-time and sex. Single-year snapshot.
+
+    Note: part-time females earn *more* per hour than part-time males in NI —
+    a reversal of the full-time pattern.
+
+    Args:
+        file_path: Path to the ASHE linked tables Excel file
+
+    Returns:
+        DataFrame with columns:
+
+        - work_pattern: str ('Full-time', 'Part-time', 'All Employees')
+        - sex: str ('Male' or 'Female')
+        - median_hourly_earnings: float (£, excluding overtime)
+
+    Example:
+        >>> df = parse_ashe_hourly_earnings_by_pattern_gender("ASHE-2025-linked.xlsx")
+        >>> print(df.pivot(index='work_pattern', columns='sex', values='median_hourly_earnings'))
+    """
+    logger.info(f"Parsing ASHE hourly earnings by pattern/gender (Fig18) from: {file_path}")
+    df = pd.read_excel(file_path, sheet_name="Figure18", skiprows=2)
+    df.columns = ["work_pattern", "Female", "Male"]
+    df = df.dropna(subset=["work_pattern"])
+
+    records = []
+    for _, row in df.iterrows():
+        for sex in ("Female", "Male"):
+            records.append(
+                {"work_pattern": str(row["work_pattern"]), "sex": sex, "median_hourly_earnings": float(row[sex])}
+            )
+
+    result = pd.DataFrame(records)
+    logger.info(f"Parsed {len(result)} work pattern/gender earnings records")
+    return result
+
+
+def get_gender_pay_gap(force_refresh: bool = False) -> pd.DataFrame:
+    """Get ASHE gender pay gap timeseries for NI and the UK (Figure 14).
+
+    Returns the population-level GPG derived from NISRA's ASHE survey — the
+    difference between male and female median hourly earnings as a percentage
+    of male earnings, for all employees.
+
+    This is survey-based (HMRC PAYE sample) and covers the whole NI economy,
+    complementing the mandatory employer-reported GPG data available via
+    ``bolster.data_sources.gender_pay_gap`` (which covers named employers with
+    250+ staff only).
+
+    Args:
+        force_refresh: If True, bypass cache and download fresh data
+
+    Returns:
+        DataFrame with columns:
+
+        - year: int (2005–present)
+        - location: str ('Northern Ireland' or 'United Kingdom')
+        - gender_pay_gap_pct: float
+
+    Example:
+        >>> df = get_gender_pay_gap()
+        >>> ni = df[df['location'] == 'Northern Ireland']
+        >>> print(f"NI GPG 2025: {ni[ni['year']==2025]['gender_pay_gap_pct'].values[0]}%")
+    """
+    _, year = get_latest_ashe_publication_url()
+    file_path = download_file(get_ashe_file_url(year, "linked"), cache_ttl_hours=90 * 24, force_refresh=force_refresh)
+    return parse_ashe_gender_pay_gap(file_path)
+
+
+def get_hourly_earnings_by_sector_gender(force_refresh: bool = False) -> pd.DataFrame:
+    """Get ASHE hourly earnings by sector and gender timeseries for NI (Figure 15).
+
+    Returns median gross hourly earnings (excl. overtime) for NI employees by
+    public/private sector and sex, from 2005 to present. Useful for understanding
+    whether the gender pay gap is driven by sector composition or within-sector
+    differences.
+
+    Args:
+        force_refresh: If True, bypass cache and download fresh data
+
+    Returns:
+        DataFrame with columns:
+
+        - year: int (2005–present)
+        - sector: str ('Public' or 'Private')
+        - sex: str ('Male' or 'Female')
+        - median_hourly_earnings: float (£)
+
+    Example:
+        >>> df = get_hourly_earnings_by_sector_gender()
+        >>> latest = df[df['year'] == df['year'].max()]
+        >>> print(latest.pivot(index='sector', columns='sex', values='median_hourly_earnings'))
+    """
+    _, year = get_latest_ashe_publication_url()
+    file_path = download_file(get_ashe_file_url(year, "linked"), cache_ttl_hours=90 * 24, force_refresh=force_refresh)
+    return parse_ashe_hourly_earnings_by_sector_gender(file_path)
+
+
+def get_hourly_earnings_by_age_gender(force_refresh: bool = False) -> pd.DataFrame:
+    """Get ASHE hourly earnings by age group and gender for NI, latest year (Figure 16).
+
+    Returns median gross hourly earnings (excl. overtime) for NI employees by
+    age band and sex. Single-year snapshot from the latest ASHE publication.
+
+    Args:
+        force_refresh: If True, bypass cache and download fresh data
+
+    Returns:
+        DataFrame with columns:
+
+        - age_group: str
+        - sex: str ('Male' or 'Female')
+        - median_hourly_earnings: float (£)
+
+    Example:
+        >>> df = get_hourly_earnings_by_age_gender()
+        >>> wide = df.pivot(index='age_group', columns='sex', values='median_hourly_earnings')
+        >>> wide['gpg_pct'] = (wide['Male'] - wide['Female']) / wide['Male'] * 100
+        >>> print(wide)
+    """
+    _, year = get_latest_ashe_publication_url()
+    file_path = download_file(get_ashe_file_url(year, "linked"), cache_ttl_hours=90 * 24, force_refresh=force_refresh)
+    return parse_ashe_hourly_earnings_by_age_gender(file_path)
+
+
+def get_hourly_earnings_by_occupation_gender(force_refresh: bool = False) -> pd.DataFrame:
+    """Get ASHE hourly earnings by occupation and gender for NI, latest year (Figure 17).
+
+    Returns median gross hourly earnings (excl. overtime) for NI employees by
+    SOC major occupation group and sex. Single-year snapshot.
+
+    Args:
+        force_refresh: If True, bypass cache and download fresh data
+
+    Returns:
+        DataFrame with columns:
+
+        - occupation: str
+        - sex: str ('Male' or 'Female')
+        - median_hourly_earnings: float (£)
+
+    Example:
+        >>> df = get_hourly_earnings_by_occupation_gender()
+        >>> wide = df.pivot(index='occupation', columns='sex', values='median_hourly_earnings')
+        >>> wide['gpg_pct'] = (wide['Male'] - wide['Female']) / wide['Male'] * 100
+        >>> print(wide.sort_values('gpg_pct', ascending=False))
+    """
+    _, year = get_latest_ashe_publication_url()
+    file_path = download_file(get_ashe_file_url(year, "linked"), cache_ttl_hours=90 * 24, force_refresh=force_refresh)
+    return parse_ashe_hourly_earnings_by_occupation_gender(file_path)
+
+
+def get_hourly_earnings_by_pattern_gender(force_refresh: bool = False) -> pd.DataFrame:
+    """Get ASHE hourly earnings by working pattern and gender for NI, latest year (Figure 18).
+
+    Returns median gross hourly earnings (excl. overtime) for NI employees by
+    full-time/part-time and sex. Single-year snapshot.
+
+    Args:
+        force_refresh: If True, bypass cache and download fresh data
+
+    Returns:
+        DataFrame with columns:
+
+        - work_pattern: str ('Full-time', 'Part-time', 'All Employees')
+        - sex: str ('Male' or 'Female')
+        - median_hourly_earnings: float (£)
+
+    Example:
+        >>> df = get_hourly_earnings_by_pattern_gender()
+        >>> print(df.pivot(index='work_pattern', columns='sex', values='median_hourly_earnings'))
+    """
+    _, year = get_latest_ashe_publication_url()
+    file_path = download_file(get_ashe_file_url(year, "linked"), cache_ttl_hours=90 * 24, force_refresh=force_refresh)
+    return parse_ashe_hourly_earnings_by_pattern_gender(file_path)
 
 
 def validate_ashe_data(df: pd.DataFrame) -> bool:  # pragma: no cover

--- a/tests/test_nisra_ashe_integrity.py
+++ b/tests/test_nisra_ashe_integrity.py
@@ -253,3 +253,212 @@ class TestASHEDataQuality:
         """Test that most recent year is recent."""
         latest_year = latest_weekly["year"].max()
         assert latest_year >= 2025
+
+
+class TestASHEGenderPayGap:
+    """Integrity tests for ASHE gender pay gap timeseries (Figure 14)."""
+
+    @pytest.fixture(scope="class")
+    def gpg(self):
+        return ashe.get_gender_pay_gap()
+
+    def test_required_columns(self, gpg):
+        assert set(gpg.columns) == {"year", "location", "gender_pay_gap_pct"}
+
+    def test_locations(self, gpg):
+        assert set(gpg["location"].unique()) == {"Northern Ireland", "United Kingdom"}
+
+    def test_two_records_per_year(self, gpg):
+        counts = gpg.groupby("year").size()
+        assert (counts == 2).all()
+
+    def test_starts_2005(self, gpg):
+        assert gpg["year"].min() == 2005
+
+    def test_recent_year_present(self, gpg):
+        assert gpg["year"].max() >= 2025
+
+    def test_gap_plausible_range(self, gpg):
+        """GPG should be between 0% and 40% — no negative values expected at population level."""
+        assert (gpg["gender_pay_gap_pct"] >= 0).all()
+        assert (gpg["gender_pay_gap_pct"] < 40).all()
+
+    def test_ni_gap_below_uk(self, gpg):
+        """NI GPG has historically been below the UK average across all years."""
+        for year in gpg["year"].unique():
+            yr = gpg[gpg["year"] == year]
+            ni = yr[yr["location"] == "Northern Ireland"]["gender_pay_gap_pct"].values[0]
+            uk = yr[yr["location"] == "United Kingdom"]["gender_pay_gap_pct"].values[0]
+            assert ni < uk, f"NI GPG ({ni}%) >= UK GPG ({uk}%) in {year}"
+
+    def test_gap_narrowing_trend(self, gpg):
+        """Both NI and UK GPG should be lower in 2025 than in 2005."""
+        for loc in ("Northern Ireland", "United Kingdom"):
+            loc_df = gpg[gpg["location"] == loc].sort_values("year")
+            gap_2005 = loc_df[loc_df["year"] == 2005]["gender_pay_gap_pct"].values[0]
+            gap_latest = loc_df.iloc[-1]["gender_pay_gap_pct"]
+            assert gap_latest < gap_2005, f"{loc}: gap has not narrowed since 2005"
+
+
+class TestASHEHourlyEarningsBySectorGender:
+    """Integrity tests for ASHE hourly earnings by sector and gender (Figure 15)."""
+
+    @pytest.fixture(scope="class")
+    def df(self):
+        return ashe.get_hourly_earnings_by_sector_gender()
+
+    def test_required_columns(self, df):
+        assert set(df.columns) == {"year", "sector", "sex", "median_hourly_earnings"}
+
+    def test_sectors(self, df):
+        assert set(df["sector"].unique()) == {"Public", "Private"}
+
+    def test_sexes(self, df):
+        assert set(df["sex"].unique()) == {"Male", "Female"}
+
+    def test_four_records_per_year(self, df):
+        counts = df.groupby("year").size()
+        assert (counts == 4).all()
+
+    def test_starts_2005(self, df):
+        assert df["year"].min() == 2005
+
+    def test_earnings_positive(self, df):
+        assert (df["median_hourly_earnings"] > 0).all()
+
+    def test_public_sector_pays_more_than_private(self, df):
+        """Public sector median hourly earnings should exceed private in NI for all years."""
+        for year in df["year"].unique():
+            yr = df[df["year"] == year]
+            for sex in ("Male", "Female"):
+                pub = yr[(yr["sector"] == "Public") & (yr["sex"] == sex)]["median_hourly_earnings"].values[0]
+                priv = yr[(yr["sector"] == "Private") & (yr["sex"] == sex)]["median_hourly_earnings"].values[0]
+                assert pub > priv, f"{sex} public (£{pub}) <= private (£{priv}) in {year}"
+
+    def test_males_earn_more_than_females_in_each_sector(self, df):
+        """Male median hourly earnings should exceed female in each sector for most years.
+
+        In 2020, NI public sector females earned slightly more than males (£15.65 vs £15.31),
+        likely reflecting COVID-era public sector composition effects. We check that the
+        male premium holds in >=80% of year-sector combinations rather than requiring it
+        for every single year.
+        """
+        exceptions = []
+        for year in df["year"].unique():
+            yr = df[df["year"] == year]
+            for sector in ("Public", "Private"):
+                male = yr[(yr["sector"] == sector) & (yr["sex"] == "Male")]["median_hourly_earnings"].values[0]
+                female = yr[(yr["sector"] == sector) & (yr["sex"] == "Female")]["median_hourly_earnings"].values[0]
+                if male <= female:
+                    exceptions.append((year, sector, male, female))
+
+        total = len(df["year"].unique()) * 2  # 2 sectors per year
+        exception_rate = len(exceptions) / total
+        assert exception_rate < 0.20, (
+            f"Male earnings exceeded female in too few cases. Exceptions: {exceptions}"
+        )
+
+
+class TestASHEHourlyEarningsByAgeGender:
+    """Integrity tests for ASHE hourly earnings by age and gender (Figure 16)."""
+
+    @pytest.fixture(scope="class")
+    def df(self):
+        return ashe.get_hourly_earnings_by_age_gender()
+
+    def test_required_columns(self, df):
+        assert set(df.columns) == {"age_group", "sex", "median_hourly_earnings"}
+
+    def test_age_groups(self, df):
+        expected = {"18-21", "22-29", "30-39", "40-49", "50-59", "60+"}
+        assert set(df["age_group"].unique()) == expected
+
+    def test_sexes(self, df):
+        assert set(df["sex"].unique()) == {"Male", "Female"}
+
+    def test_two_records_per_age_group(self, df):
+        counts = df.groupby("age_group").size()
+        assert (counts == 2).all()
+
+    def test_earnings_positive(self, df):
+        assert (df["median_hourly_earnings"] > 0).all()
+
+    def test_peak_earnings_in_middle_age(self, df):
+        """Earnings should peak in 40-49 or 50-59 band (career seniority effect)."""
+        for sex in ("Male", "Female"):
+            sex_df = df[df["sex"] == sex]
+            peak_age = sex_df.loc[sex_df["median_hourly_earnings"].idxmax(), "age_group"]
+            assert peak_age in {"40-49", "50-59"}, f"{sex} peak earnings in unexpected band: {peak_age}"
+
+    def test_youngest_earns_least(self, df):
+        """18-21 band should have the lowest earnings for both sexes."""
+        for sex in ("Male", "Female"):
+            sex_df = df[df["sex"] == sex]
+            min_age = sex_df.loc[sex_df["median_hourly_earnings"].idxmin(), "age_group"]
+            assert min_age == "18-21", f"{sex} minimum earnings not in 18-21 band: {min_age}"
+
+
+class TestASHEHourlyEarningsByOccupationGender:
+    """Integrity tests for ASHE hourly earnings by occupation and gender (Figure 17)."""
+
+    @pytest.fixture(scope="class")
+    def df(self):
+        return ashe.get_hourly_earnings_by_occupation_gender()
+
+    def test_required_columns(self, df):
+        assert set(df.columns) == {"occupation", "sex", "median_hourly_earnings"}
+
+    def test_nine_occupation_groups(self, df):
+        assert df["occupation"].nunique() == 9
+
+    def test_sexes(self, df):
+        assert set(df["sex"].unique()) == {"Male", "Female"}
+
+    def test_earnings_positive(self, df):
+        assert (df["median_hourly_earnings"] > 0).all()
+
+    def test_managers_highest_paid(self, df):
+        """Managers/directors should be the highest-paid occupation for both sexes."""
+        for sex in ("Male", "Female"):
+            sex_df = df[df["sex"] == sex]
+            top_occ = sex_df.loc[sex_df["median_hourly_earnings"].idxmax(), "occupation"]
+            assert "Managers" in top_occ, f"{sex} highest-paid occupation unexpected: {top_occ}"
+
+    def test_gap_positive_in_all_occupations(self, df):
+        """Male earnings should exceed female in all NI occupation groups (per NISRA)."""
+        wide = df.pivot(index="occupation", columns="sex", values="median_hourly_earnings")
+        gap = wide["Male"] - wide["Female"]
+        assert (gap > 0).all(), f"Female earns more than male in: {gap[gap <= 0].index.tolist()}"
+
+
+class TestASHEHourlyEarningsByPatternGender:
+    """Integrity tests for ASHE hourly earnings by working pattern and gender (Figure 18)."""
+
+    @pytest.fixture(scope="class")
+    def df(self):
+        return ashe.get_hourly_earnings_by_pattern_gender()
+
+    def test_required_columns(self, df):
+        assert set(df.columns) == {"work_pattern", "sex", "median_hourly_earnings"}
+
+    def test_work_patterns(self, df):
+        assert set(df["work_pattern"].unique()) == {"Full-time", "Part-time", "All Employees"}
+
+    def test_sexes(self, df):
+        assert set(df["sex"].unique()) == {"Male", "Female"}
+
+    def test_earnings_positive(self, df):
+        assert (df["median_hourly_earnings"] > 0).all()
+
+    def test_fulltime_earns_more_than_parttime(self, df):
+        """Full-time hourly earnings should exceed part-time for both sexes."""
+        for sex in ("Male", "Female"):
+            sex_df = df[df["sex"] == sex].set_index("work_pattern")
+            assert sex_df.loc["Full-time", "median_hourly_earnings"] > sex_df.loc["Part-time", "median_hourly_earnings"]
+
+    def test_parttime_females_earn_more_than_parttime_males(self, df):
+        """NI data shows part-time females earn more per hour than part-time males."""
+        pt = df[df["work_pattern"] == "Part-time"].set_index("sex")
+        assert pt.loc["Female", "median_hourly_earnings"] > pt.loc["Male", "median_hourly_earnings"], (
+            "Part-time female hourly earnings should exceed male in NI"
+        )


### PR DESCRIPTION
## Summary

Implements five new gender earnings analysis functions for the ASHE linked-tables module (issue #1139), replacing the existing `NotImplementedError` stub with real data:

- **Figure 14** (`get_gender_pay_gap`): NI vs UK gender pay gap timeseries 2005–present
- **Figure 15** (`get_hourly_earnings_by_sector_gender`): Median hourly earnings by public/private sector and sex, 2005–present
- **Figure 16** (`get_hourly_earnings_by_age_gender`): Median hourly earnings by age band and sex, latest year
- **Figure 17** (`get_hourly_earnings_by_occupation_gender`): Median hourly earnings by SOC occupation group and sex, latest year
- **Figure 18** (`get_hourly_earnings_by_pattern_gender`): Median hourly earnings by full-time/part-time and sex, latest year

## Key insights from the data

- NI gender pay gap (7.2% in 2025) is consistently **below the UK average** (12.8%) across the entire 2005–2025 period
- In 2020, NI public sector females briefly earned **more** than males (£15.65 vs £15.31), likely a COVID-era composition effect — test suite accounts for this real-world exception
- **Part-time females earn more per hour than part-time males** in NI (£13.56 vs £12.92) — a striking counter-intuitive finding documented in the module and tested

## Test plan

- [x] 62 integrity tests passing (all ASHE tests, no regressions)
- [x] Real data only — no mocks, `scope="class"` fixtures
- [x] Pre-commit clean (ruff, ruff-format, mdformat, architecture checks)
- [x] Test for `test_males_earn_more_than_females_in_each_sector` relaxed to tolerate documented exceptions (≥80% threshold) rather than enforcing an absolute rule that contradicts real data

## Usage

```python
from bolster.data_sources.nisra import ashe

# NI vs UK gender pay gap timeseries
gap_df = ashe.get_gender_pay_gap()

# Hourly earnings by sector and sex
sector_df = ashe.get_hourly_earnings_by_sector_gender()

# Hourly earnings by age band
age_df = ashe.get_hourly_earnings_by_age_gender()

# Hourly earnings by occupation group
occ_df = ashe.get_hourly_earnings_by_occupation_gender()

# Hourly earnings by work pattern
pattern_df = ashe.get_hourly_earnings_by_pattern_gender()
```

Closes part of #1139. Related future work tracked in #1742–#1746.

🤖 Generated with [Claude Code](https://claude.com/claude-code)