### PR TITLE
feat(ashe): refactor linked-tables to content-fingerprint + NI/UK comparison, hours distribution (#1742, #1746)

### DIFF
--- a/src/bolster/data_sources/nisra/ashe.py
+++ b/src/bolster/data_sources/nisra/ashe.py
@@ -527,8 +527,142 @@ def calculate_growth_rates(df: pd.DataFrame, periods: int = 1) -> pd.DataFrame:
     return result
 
 
+# ---------------------------------------------------------------------------
+# Content-fingerprint sheet scanner for the ASHE linked tables file
+# ---------------------------------------------------------------------------
+# NISRA reassigns figure numbers each year based on editorial focus.
+# E.g. "hours distribution" was Figure 3 in 2022-23, Figure 9 in 2024-25.
+# We identify sheets by the column signature of their header row and optional
+# keywords from the subtitle, making parsers robust across publication years.
+
+_SHEET_SIGNATURES: dict[str, dict] = {
+    # Timeseries: Year | UK | NI  — three variants share this column shape;
+    # disambiguated by subtitle keyword
+    "ni_uk_weekly_earnings": {
+        "cols": ("Year", "UK", "NI"),
+        "subtitle_keywords": ["weekly", "full-time"],
+        "excludes": ["gender pay gap", "working pattern"],
+    },
+    "gender_pay_gap": {
+        "cols": ("Year", "UK", "NI"),
+        "subtitle_keywords": ["gender pay gap"],
+    },
+    "working_pattern_pay_gap": {
+        "cols": ("Year", "UK", "NI"),
+        "subtitle_keywords": ["working pattern pay gap"],
+    },
+    # Sector × gender hourly earnings timeseries
+    "hourly_by_sector_gender": {
+        "cols": ("Year", "Male public", "Female public", "Male private", "Female private"),
+        "subtitle_keywords": ["sector", "gender"],
+    },
+    # Snapshot tables — single year, no 'Year' column
+    "hours_distribution": {
+        "cols": ("Paid hours worked", "Percentage"),
+    },
+    "uk_regional_pay_ratio": {
+        "cols": ("Region", "Ratio"),
+    },
+    "hourly_by_age_gender": {
+        "cols": ("Age group", "Female", "Male"),
+        "subtitle_keywords": ["age"],
+    },
+    "hourly_by_occupation_gender": {
+        "cols": ("Occupation", "Female", "Male"),
+        "subtitle_keywords": ["occupation"],
+    },
+    "hourly_by_pattern_gender": {
+        "cols": ("Working pattern", "Female", "Male"),
+        "subtitle_keywords": ["working pattern"],
+        "excludes": ["pay gap", "mean weekly"],
+    },
+    "mean_hours_by_pattern_gender": {
+        "cols": ("Working pattern", "Males", "Females", "All"),
+    },
+}
+
+
+def _find_linked_sheet(
+    file_path: str | Path,
+    signature_key: str,
+) -> pd.DataFrame:
+    """Locate a sheet in the linked tables file by content fingerprint.
+
+    Walks all sheets, finds the header row (first short-valued row after the
+    title rows), checks column names against the signature, and optionally
+    confirms subtitle keywords. Returns the DataFrame from the matching sheet.
+
+    Args:
+        file_path: Path to the ASHE linked tables Excel file.
+        signature_key: Key into ``_SHEET_SIGNATURES``.
+
+    Returns:
+        Raw DataFrame from the matched sheet (header not yet renamed).
+
+    Raises:
+        NISRADataNotFoundError: If no sheet matches the signature.
+    """
+    import openpyxl
+
+    sig = _SHEET_SIGNATURES[signature_key]
+    required_cols = tuple(c.lower() for c in sig["cols"])
+    keywords = [k.lower() for k in sig.get("subtitle_keywords", [])]
+    excludes = [e.lower() for e in sig.get("excludes", [])]
+
+    wb = openpyxl.load_workbook(file_path, read_only=True, data_only=True)
+    try:
+        for sheet_name in wb.sheetnames:
+            ws = wb[sheet_name]
+            rows = [r for r in ws.iter_rows(values_only=True) if any(v is not None for v in r)]
+            if len(rows) < 3:
+                continue
+
+            # Title is row 0, subtitle row 1, then possibly a note, then headers
+            subtitle = str(rows[1][0] or "").lower()
+
+            # Check keyword/exclude filters on subtitle
+            if keywords and not any(k in subtitle for k in keywords):
+                continue
+            if excludes and any(e in subtitle for e in excludes):
+                continue
+
+            # Find header row: first row where all required cols appear
+            # (case-insensitive, ignoring None cells)
+            for i, row in enumerate(rows):
+                row_vals = tuple(str(v).lower() for v in row if v is not None)
+                if all(rc in row_vals for rc in required_cols):
+                    # Found the header — read everything below it, trimmed to signature width
+                    n_sig = len(sig["cols"])
+                    data_rows = [r[:n_sig] for r in rows[i + 1 :]]
+                    header = [str(v) if v is not None else f"_col{j}" for j, v in enumerate(row[:n_sig])]
+                    df = pd.DataFrame(data_rows, columns=header)
+                    # Drop entirely-None rows
+                    df = df.dropna(how="all")
+                    logger.debug(f"Matched signature '{signature_key}' to sheet '{sheet_name}' in {file_path}")
+                    wb.close()
+                    return df
+    finally:
+        wb.close()
+
+    raise NISRADataNotFoundError(
+        f"No sheet matching signature '{signature_key}' found in {file_path}. Expected columns: {sig['cols']}"
+    )
+
+
+def _get_linked_file(year: int | None = None, force_refresh: bool = False) -> Path:
+    """Download the linked tables file, returning path. Uses latest year if not specified."""
+    if year is None:
+        _, year = get_latest_ashe_publication_url()
+    return download_file(get_ashe_file_url(year, "linked"), cache_ttl_hours=90 * 24, force_refresh=force_refresh)
+
+
+# ---------------------------------------------------------------------------
+# Parse functions — each calls _find_linked_sheet with its signature key
+# ---------------------------------------------------------------------------
+
+
 def parse_ashe_gender_pay_gap(file_path: str | Path) -> pd.DataFrame:
-    """Parse ASHE gender pay gap timeseries (Figure 14).
+    """Parse ASHE gender pay gap timeseries (NI and UK), any publication year.
 
     Extracts the NI and UK all-employee gender pay gap from 2005 to present.
     The gap is defined as the difference between male and female median hourly
@@ -554,29 +688,32 @@ def parse_ashe_gender_pay_gap(file_path: str | Path) -> pd.DataFrame:
         >>> ni = df[df['location'] == 'Northern Ireland']
         >>> print(ni.tail())
     """
-    logger.info(f"Parsing ASHE gender pay gap (Fig14) from: {file_path}")
-    df = pd.read_excel(file_path, sheet_name="Figure14", skiprows=3)
+    df = _find_linked_sheet(file_path, "gender_pay_gap")
     df.columns = ["year", "UK", "NI"]
     df = df.dropna(subset=["year"])
-    df["year"] = df["year"].astype(int)
+    df["year"] = pd.to_numeric(df["year"], errors="coerce").dropna().astype(int)
+    df = df[df["year"].notna()]
 
     records = []
     for _, row in df.iterrows():
+        if pd.isna(row["year"]):
+            continue
         records.append({"year": int(row["year"]), "location": "United Kingdom", "gender_pay_gap_pct": float(row["UK"])})
         records.append(
             {"year": int(row["year"]), "location": "Northern Ireland", "gender_pay_gap_pct": float(row["NI"])}
         )
 
-    result = pd.DataFrame(records).sort_values(["year", "location"]).reset_index(drop=True)
+    result = pd.DataFrame(records).dropna().sort_values(["year", "location"]).reset_index(drop=True)
+    result["year"] = result["year"].astype(int)
     logger.info(f"Parsed {len(result)} gender pay gap records ({result['year'].min()}–{result['year'].max()})")
     return result
 
 
 def parse_ashe_hourly_earnings_by_sector_gender(file_path: str | Path) -> pd.DataFrame:
-    """Parse ASHE hourly earnings by sector and gender timeseries (Figure 15).
+    """Parse ASHE hourly earnings by sector and gender timeseries.
 
-    Extracts median gross hourly earnings (excluding overtime) for NI employees
-    broken down by public/private sector and male/female, from 2005 to present.
+    Identified by column signature ['Year', 'Male public', 'Female public',
+    'Male private', 'Female private'] — stable across all publication years.
 
     Args:
         file_path: Path to the ASHE linked tables Excel file
@@ -594,10 +731,11 @@ def parse_ashe_hourly_earnings_by_sector_gender(file_path: str | Path) -> pd.Dat
         >>> latest = df[df['year'] == df['year'].max()]
         >>> print(latest.pivot(index='sector', columns='sex', values='median_hourly_earnings'))
     """
-    logger.info(f"Parsing ASHE hourly earnings by sector/gender (Fig15) from: {file_path}")
-    df = pd.read_excel(file_path, sheet_name="Figure15", skiprows=3)
+    df = _find_linked_sheet(file_path, "hourly_by_sector_gender")
     df.columns = ["year", "Male public", "Female public", "Male private", "Female private"]
     df = df.dropna(subset=["year"])
+    df["year"] = pd.to_numeric(df["year"], errors="coerce")
+    df = df[df["year"].notna()]
     df["year"] = df["year"].astype(int)
 
     records = []
@@ -608,9 +746,11 @@ def parse_ashe_hourly_earnings_by_sector_gender(file_path: str | Path) -> pd.Dat
             ("Male private", "Private", "Male"),
             ("Female private", "Private", "Female"),
         ]:
-            records.append(
-                {"year": int(row["year"]), "sector": sector, "sex": sex, "median_hourly_earnings": float(row[col])}
-            )
+            val = pd.to_numeric(row[col], errors="coerce")
+            if pd.notna(val):
+                records.append(
+                    {"year": int(row["year"]), "sector": sector, "sex": sex, "median_hourly_earnings": float(val)}
+                )
 
     result = pd.DataFrame(records).sort_values(["year", "sector", "sex"]).reset_index(drop=True)
     logger.info(f"Parsed {len(result)} sector/gender earnings records ({result['year'].min()}–{result['year'].max()})")
@@ -618,10 +758,10 @@ def parse_ashe_hourly_earnings_by_sector_gender(file_path: str | Path) -> pd.Dat
 
 
 def parse_ashe_hourly_earnings_by_age_gender(file_path: str | Path) -> pd.DataFrame:
-    """Parse ASHE hourly earnings by age group and gender, latest year (Figure 16).
+    """Parse ASHE hourly earnings by age group and gender, latest year snapshot.
 
-    Extracts median gross hourly earnings (excluding overtime) for NI employees
-    broken down by age band and sex. Single-year snapshot from the latest publication.
+    Identified by column signature ['Age group', 'Female', 'Male'] with subtitle
+    containing 'age'. Present in all publication years, though in different figure slots.
 
     Args:
         file_path: Path to the ASHE linked tables Excel file
@@ -635,17 +775,17 @@ def parse_ashe_hourly_earnings_by_age_gender(file_path: str | Path) -> pd.DataFr
 
     Example:
         >>> df = parse_ashe_hourly_earnings_by_age_gender("ASHE-2025-linked.xlsx")
-        >>> df['implied_gpg_pct'] = (df['Male'] - df['Female']) / df['Male'] * 100
     """
-    logger.info(f"Parsing ASHE hourly earnings by age/gender (Fig16) from: {file_path}")
-    df = pd.read_excel(file_path, sheet_name="Figure16", skiprows=2)
+    df = _find_linked_sheet(file_path, "hourly_by_age_gender")
     df.columns = ["age_group", "Female", "Male"]
     df = df.dropna(subset=["age_group"])
 
     records = []
     for _, row in df.iterrows():
         for sex in ("Female", "Male"):
-            records.append({"age_group": str(row["age_group"]), "sex": sex, "median_hourly_earnings": float(row[sex])})
+            val = pd.to_numeric(row[sex], errors="coerce")
+            if pd.notna(val):
+                records.append({"age_group": str(row["age_group"]), "sex": sex, "median_hourly_earnings": float(val)})
 
     result = pd.DataFrame(records)
     logger.info(f"Parsed {len(result)} age/gender earnings records ({len(df)} age bands)")
@@ -653,10 +793,10 @@ def parse_ashe_hourly_earnings_by_age_gender(file_path: str | Path) -> pd.DataFr
 
 
 def parse_ashe_hourly_earnings_by_occupation_gender(file_path: str | Path) -> pd.DataFrame:
-    """Parse ASHE hourly earnings by occupation and gender, latest year (Figure 17).
+    """Parse ASHE hourly earnings by occupation and gender, latest year snapshot.
 
-    Extracts median gross hourly earnings (excluding overtime) for NI employees
-    broken down by SOC major occupation group and sex. Single-year snapshot.
+    Identified by column signature ['Occupation', 'Female', 'Male'] with subtitle
+    containing 'occupation'. Present in all publication years.
 
     Args:
         file_path: Path to the ASHE linked tables Excel file
@@ -671,20 +811,17 @@ def parse_ashe_hourly_earnings_by_occupation_gender(file_path: str | Path) -> pd
     Example:
         >>> df = parse_ashe_hourly_earnings_by_occupation_gender("ASHE-2025-linked.xlsx")
         >>> wide = df.pivot(index='occupation', columns='sex', values='median_hourly_earnings')
-        >>> wide['gpg_pct'] = (wide['Male'] - wide['Female']) / wide['Male'] * 100
-        >>> print(wide.sort_values('gpg_pct', ascending=False))
     """
-    logger.info(f"Parsing ASHE hourly earnings by occupation/gender (Fig17) from: {file_path}")
-    df = pd.read_excel(file_path, sheet_name="Figure17", skiprows=2)
+    df = _find_linked_sheet(file_path, "hourly_by_occupation_gender")
     df.columns = ["occupation", "Female", "Male"]
     df = df.dropna(subset=["occupation"])
 
     records = []
     for _, row in df.iterrows():
         for sex in ("Female", "Male"):
-            records.append(
-                {"occupation": str(row["occupation"]), "sex": sex, "median_hourly_earnings": float(row[sex])}
-            )
+            val = pd.to_numeric(row[sex], errors="coerce")
+            if pd.notna(val):
+                records.append({"occupation": str(row["occupation"]), "sex": sex, "median_hourly_earnings": float(val)})
 
     result = pd.DataFrame(records)
     logger.info(f"Parsed {len(result)} occupation/gender earnings records ({len(df)} occupation groups)")
@@ -692,13 +829,14 @@ def parse_ashe_hourly_earnings_by_occupation_gender(file_path: str | Path) -> pd
 
 
 def parse_ashe_hourly_earnings_by_pattern_gender(file_path: str | Path) -> pd.DataFrame:
-    """Parse ASHE hourly earnings by working pattern and gender, latest year (Figure 18).
+    """Parse ASHE hourly earnings by working pattern and gender, latest year snapshot.
 
-    Extracts median gross hourly earnings (excluding overtime) for NI employees
-    broken down by full-time/part-time and sex. Single-year snapshot.
+    Identified by column signature ['Working pattern', 'Female', 'Male'] with
+    subtitle containing 'working pattern' (excluding pay gap / hours tables which
+    share similar columns). Present in all publication years.
 
     Note: part-time females earn *more* per hour than part-time males in NI —
-    a reversal of the full-time pattern.
+    a reversal of the full-time pattern, documented across 2022–2025.
 
     Args:
         file_path: Path to the ASHE linked tables Excel file
@@ -714,25 +852,174 @@ def parse_ashe_hourly_earnings_by_pattern_gender(file_path: str | Path) -> pd.Da
         >>> df = parse_ashe_hourly_earnings_by_pattern_gender("ASHE-2025-linked.xlsx")
         >>> print(df.pivot(index='work_pattern', columns='sex', values='median_hourly_earnings'))
     """
-    logger.info(f"Parsing ASHE hourly earnings by pattern/gender (Fig18) from: {file_path}")
-    df = pd.read_excel(file_path, sheet_name="Figure18", skiprows=2)
+    df = _find_linked_sheet(file_path, "hourly_by_pattern_gender")
     df.columns = ["work_pattern", "Female", "Male"]
     df = df.dropna(subset=["work_pattern"])
 
     records = []
     for _, row in df.iterrows():
         for sex in ("Female", "Male"):
-            records.append(
-                {"work_pattern": str(row["work_pattern"]), "sex": sex, "median_hourly_earnings": float(row[sex])}
-            )
+            val = pd.to_numeric(row[sex], errors="coerce")
+            if pd.notna(val):
+                records.append(
+                    {"work_pattern": str(row["work_pattern"]), "sex": sex, "median_hourly_earnings": float(val)}
+                )
 
     result = pd.DataFrame(records)
     logger.info(f"Parsed {len(result)} work pattern/gender earnings records")
     return result
 
 
+def parse_ashe_ni_uk_earnings_comparison(file_path: str | Path) -> pd.DataFrame:
+    """Parse ASHE NI vs UK full-time weekly earnings timeseries.
+
+    Identified by column signature ['Year', 'UK', 'NI'] with subtitle containing
+    'weekly' and 'full-time'. Stable across all publication years (always Figure 1).
+
+    Args:
+        file_path: Path to the ASHE linked tables Excel file
+
+    Returns:
+        DataFrame with columns:
+
+        - year: int
+        - location: str ('NI' or 'UK')
+        - median_weekly_earnings_fulltime: float (£)
+
+    Example:
+        >>> df = parse_ashe_ni_uk_earnings_comparison("ASHE-2025-linked.xlsx")
+        >>> print(df.pivot(index='year', columns='location', values='median_weekly_earnings_fulltime'))
+    """
+    df = _find_linked_sheet(file_path, "ni_uk_weekly_earnings")
+    df.columns = ["year", "UK", "NI"]
+    df = df.dropna(subset=["year"])
+    df["year"] = pd.to_numeric(df["year"], errors="coerce")
+    df = df[df["year"].notna()]
+    df["year"] = df["year"].astype(int)
+    melted = df.melt(id_vars="year", var_name="location", value_name="median_weekly_earnings_fulltime")
+    melted["median_weekly_earnings_fulltime"] = pd.to_numeric(
+        melted["median_weekly_earnings_fulltime"], errors="coerce"
+    )
+    return melted.dropna(subset=["median_weekly_earnings_fulltime"]).reset_index(drop=True)
+
+
+def parse_ashe_uk_regional_pay_ratio(file_path: str | Path) -> pd.DataFrame:
+    """Parse ASHE high-to-low pay ratio by UK region, latest year snapshot.
+
+    Identified by column signature ['Region', 'Ratio']. Present in all years
+    but in different figure slots (Figure 14 in 2022, Figure 16 in 2023,
+    Figure 13 in 2024–2025).
+
+    Args:
+        file_path: Path to the ASHE linked tables Excel file
+
+    Returns:
+        DataFrame with columns:
+
+        - region: str (UK region name)
+        - ratio: float (high-paid / low-paid jobs ratio)
+
+    Example:
+        >>> df = parse_ashe_uk_regional_pay_ratio("ASHE-2025-linked.xlsx")
+        >>> print(df.sort_values('ratio', ascending=False))
+    """
+    df = _find_linked_sheet(file_path, "uk_regional_pay_ratio")
+    df.columns = ["region", "ratio"]
+    df = df.dropna(subset=["region"])
+    df["ratio"] = pd.to_numeric(df["ratio"], errors="coerce")
+    return df.dropna(subset=["ratio"]).reset_index(drop=True)
+
+
+def parse_ashe_hours_distribution(file_path: str | Path) -> pd.DataFrame:
+    """Parse ASHE distribution of total weekly paid hours, NI, latest year snapshot.
+
+    Identified by column signature ['Paid hours worked', 'Percentage']. Present
+    in all years but in different figure slots (Figure 3 in 2022–2023,
+    Figure 9 in 2024–2025).
+
+    Args:
+        file_path: Path to the ASHE linked tables Excel file
+
+    Returns:
+        DataFrame with columns:
+
+        - paid_hours_worked: int (hours 0–80)
+        - percentage: float (% of employees)
+
+    Example:
+        >>> df = parse_ashe_hours_distribution("ASHE-2025-linked.xlsx")
+        >>> print(df[df['paid_hours_worked'] == 37])
+    """
+    df = _find_linked_sheet(file_path, "hours_distribution")
+    df.columns = ["paid_hours_worked", "percentage"]
+    df["paid_hours_worked"] = pd.to_numeric(df["paid_hours_worked"], errors="coerce")
+    df["percentage"] = pd.to_numeric(df["percentage"], errors="coerce")
+    return df.dropna().reset_index(drop=True)
+
+
+def parse_ashe_working_pattern_pay_gap(file_path: str | Path) -> pd.DataFrame:
+    """Parse ASHE working pattern pay gap timeseries, NI vs UK.
+
+    Identified by column signature ['Year', 'UK', 'NI'] with subtitle containing
+    'working pattern pay gap'. Present from 2023 onwards (Figure 23 in 2023,
+    Figure 19 in 2024–2025).
+
+    Args:
+        file_path: Path to the ASHE linked tables Excel file
+
+    Returns:
+        DataFrame with columns:
+
+        - year: int
+        - location: str ('NI' or 'UK')
+        - working_pattern_pay_gap_pct: float (%)
+
+    Example:
+        >>> df = parse_ashe_working_pattern_pay_gap("ASHE-2025-linked.xlsx")
+        >>> print(df.pivot(index='year', columns='location', values='working_pattern_pay_gap_pct'))
+    """
+    df = _find_linked_sheet(file_path, "working_pattern_pay_gap")
+    df.columns = ["year", "UK", "NI"]
+    df = df.dropna(subset=["year"])
+    df["year"] = pd.to_numeric(df["year"], errors="coerce")
+    df = df[df["year"].notna()]
+    df["year"] = df["year"].astype(int)
+    melted = df.melt(id_vars="year", var_name="location", value_name="working_pattern_pay_gap_pct")
+    melted["working_pattern_pay_gap_pct"] = pd.to_numeric(melted["working_pattern_pay_gap_pct"], errors="coerce")
+    return melted.dropna(subset=["working_pattern_pay_gap_pct"]).reset_index(drop=True)
+
+
+def parse_ashe_mean_hours_by_pattern_gender(file_path: str | Path) -> pd.DataFrame:
+    """Parse ASHE mean weekly paid hours by work pattern and gender, NI, latest year.
+
+    Identified by column signature ['Working pattern', 'Males', 'Females', 'All'].
+    Present in all years (Figure 21 in 2022–2023, Figure 20 in 2024–2025).
+
+    Args:
+        file_path: Path to the ASHE linked tables Excel file
+
+    Returns:
+        DataFrame with columns:
+
+        - work_pattern: str ('Part-time', 'Full-time', 'All Employees')
+        - male_mean_hours: float
+        - female_mean_hours: float
+        - all_mean_hours: float
+
+    Example:
+        >>> df = parse_ashe_mean_hours_by_pattern_gender("ASHE-2025-linked.xlsx")
+        >>> print(df)
+    """
+    df = _find_linked_sheet(file_path, "mean_hours_by_pattern_gender")
+    df.columns = ["work_pattern", "male_mean_hours", "female_mean_hours", "all_mean_hours"]
+    df = df.dropna(subset=["work_pattern"])
+    for col in ("male_mean_hours", "female_mean_hours", "all_mean_hours"):
+        df[col] = pd.to_numeric(df[col], errors="coerce")
+    return df.reset_index(drop=True)
+
+
 def get_gender_pay_gap(force_refresh: bool = False) -> pd.DataFrame:
-    """Get ASHE gender pay gap timeseries for NI and the UK (Figure 14).
+    """Get ASHE gender pay gap timeseries for NI and the UK.
 
     Returns the population-level GPG derived from NISRA's ASHE survey — the
     difference between male and female median hourly earnings as a percentage
@@ -758,18 +1045,14 @@ def get_gender_pay_gap(force_refresh: bool = False) -> pd.DataFrame:
         >>> ni = df[df['location'] == 'Northern Ireland']
         >>> print(f"NI GPG 2025: {ni[ni['year']==2025]['gender_pay_gap_pct'].values[0]}%")
     """
-    _, year = get_latest_ashe_publication_url()
-    file_path = download_file(get_ashe_file_url(year, "linked"), cache_ttl_hours=90 * 24, force_refresh=force_refresh)
-    return parse_ashe_gender_pay_gap(file_path)
+    return parse_ashe_gender_pay_gap(_get_linked_file(force_refresh=force_refresh))
 
 
 def get_hourly_earnings_by_sector_gender(force_refresh: bool = False) -> pd.DataFrame:
-    """Get ASHE hourly earnings by sector and gender timeseries for NI (Figure 15).
+    """Get ASHE hourly earnings by sector and gender timeseries for NI.
 
     Returns median gross hourly earnings (excl. overtime) for NI employees by
-    public/private sector and sex, from 2005 to present. Useful for understanding
-    whether the gender pay gap is driven by sector composition or within-sector
-    differences.
+    public/private sector and sex, from 2005 to present.
 
     Args:
         force_refresh: If True, bypass cache and download fresh data
@@ -787,16 +1070,14 @@ def get_hourly_earnings_by_sector_gender(force_refresh: bool = False) -> pd.Data
         >>> latest = df[df['year'] == df['year'].max()]
         >>> print(latest.pivot(index='sector', columns='sex', values='median_hourly_earnings'))
     """
-    _, year = get_latest_ashe_publication_url()
-    file_path = download_file(get_ashe_file_url(year, "linked"), cache_ttl_hours=90 * 24, force_refresh=force_refresh)
-    return parse_ashe_hourly_earnings_by_sector_gender(file_path)
+    return parse_ashe_hourly_earnings_by_sector_gender(_get_linked_file(force_refresh=force_refresh))
 
 
 def get_hourly_earnings_by_age_gender(force_refresh: bool = False) -> pd.DataFrame:
-    """Get ASHE hourly earnings by age group and gender for NI, latest year (Figure 16).
+    """Get ASHE hourly earnings by age group and gender for NI, latest year snapshot.
 
     Returns median gross hourly earnings (excl. overtime) for NI employees by
-    age band and sex. Single-year snapshot from the latest ASHE publication.
+    age band and sex.
 
     Args:
         force_refresh: If True, bypass cache and download fresh data
@@ -814,16 +1095,14 @@ def get_hourly_earnings_by_age_gender(force_refresh: bool = False) -> pd.DataFra
         >>> wide['gpg_pct'] = (wide['Male'] - wide['Female']) / wide['Male'] * 100
         >>> print(wide)
     """
-    _, year = get_latest_ashe_publication_url()
-    file_path = download_file(get_ashe_file_url(year, "linked"), cache_ttl_hours=90 * 24, force_refresh=force_refresh)
-    return parse_ashe_hourly_earnings_by_age_gender(file_path)
+    return parse_ashe_hourly_earnings_by_age_gender(_get_linked_file(force_refresh=force_refresh))
 
 
 def get_hourly_earnings_by_occupation_gender(force_refresh: bool = False) -> pd.DataFrame:
-    """Get ASHE hourly earnings by occupation and gender for NI, latest year (Figure 17).
+    """Get ASHE hourly earnings by occupation and gender for NI, latest year snapshot.
 
     Returns median gross hourly earnings (excl. overtime) for NI employees by
-    SOC major occupation group and sex. Single-year snapshot.
+    SOC major occupation group and sex.
 
     Args:
         force_refresh: If True, bypass cache and download fresh data
@@ -841,16 +1120,14 @@ def get_hourly_earnings_by_occupation_gender(force_refresh: bool = False) -> pd.
         >>> wide['gpg_pct'] = (wide['Male'] - wide['Female']) / wide['Male'] * 100
         >>> print(wide.sort_values('gpg_pct', ascending=False))
     """
-    _, year = get_latest_ashe_publication_url()
-    file_path = download_file(get_ashe_file_url(year, "linked"), cache_ttl_hours=90 * 24, force_refresh=force_refresh)
-    return parse_ashe_hourly_earnings_by_occupation_gender(file_path)
+    return parse_ashe_hourly_earnings_by_occupation_gender(_get_linked_file(force_refresh=force_refresh))
 
 
 def get_hourly_earnings_by_pattern_gender(force_refresh: bool = False) -> pd.DataFrame:
-    """Get ASHE hourly earnings by working pattern and gender for NI, latest year (Figure 18).
+    """Get ASHE hourly earnings by working pattern and gender for NI, latest year snapshot.
 
     Returns median gross hourly earnings (excl. overtime) for NI employees by
-    full-time/part-time and sex. Single-year snapshot.
+    full-time/part-time and sex.
 
     Args:
         force_refresh: If True, bypass cache and download fresh data
@@ -866,9 +1143,87 @@ def get_hourly_earnings_by_pattern_gender(force_refresh: bool = False) -> pd.Dat
         >>> df = get_hourly_earnings_by_pattern_gender()
         >>> print(df.pivot(index='work_pattern', columns='sex', values='median_hourly_earnings'))
     """
-    _, year = get_latest_ashe_publication_url()
-    file_path = download_file(get_ashe_file_url(year, "linked"), cache_ttl_hours=90 * 24, force_refresh=force_refresh)
-    return parse_ashe_hourly_earnings_by_pattern_gender(file_path)
+    return parse_ashe_hourly_earnings_by_pattern_gender(_get_linked_file(force_refresh=force_refresh))
+
+
+def get_ni_uk_earnings_comparison(force_refresh: bool = False) -> pd.DataFrame:
+    """Get NI vs UK full-time weekly earnings timeseries.
+
+    Args:
+        force_refresh: If True, bypass cache and download fresh data
+
+    Returns:
+        DataFrame with columns: year, location ('NI'/'UK'), median_weekly_earnings_fulltime
+
+    Example:
+        >>> df = get_ni_uk_earnings_comparison()
+        >>> print(df.pivot(index='year', columns='location', values='median_weekly_earnings_fulltime'))
+    """
+    return parse_ashe_ni_uk_earnings_comparison(_get_linked_file(force_refresh=force_refresh))
+
+
+def get_uk_regional_pay_ratio(force_refresh: bool = False) -> pd.DataFrame:
+    """Get high-to-low pay ratio by UK region, latest year snapshot.
+
+    Args:
+        force_refresh: If True, bypass cache and download fresh data
+
+    Returns:
+        DataFrame with columns: region, ratio
+
+    Example:
+        >>> df = get_uk_regional_pay_ratio()
+        >>> ni = df[df['region'] == 'Northern Ireland']
+    """
+    return parse_ashe_uk_regional_pay_ratio(_get_linked_file(force_refresh=force_refresh))
+
+
+def get_hours_distribution(force_refresh: bool = False) -> pd.DataFrame:
+    """Get distribution of total weekly paid hours for NI employees, latest year snapshot.
+
+    Args:
+        force_refresh: If True, bypass cache and download fresh data
+
+    Returns:
+        DataFrame with columns: paid_hours_worked, percentage
+
+    Example:
+        >>> df = get_hours_distribution()
+        >>> print(df[df['paid_hours_worked'].between(35, 40)])
+    """
+    return parse_ashe_hours_distribution(_get_linked_file(force_refresh=force_refresh))
+
+
+def get_working_pattern_pay_gap(force_refresh: bool = False) -> pd.DataFrame:
+    """Get working pattern pay gap timeseries for NI vs UK.
+
+    Args:
+        force_refresh: If True, bypass cache and download fresh data
+
+    Returns:
+        DataFrame with columns: year, location ('NI'/'UK'), working_pattern_pay_gap_pct
+
+    Example:
+        >>> df = get_working_pattern_pay_gap()
+        >>> print(df.pivot(index='year', columns='location', values='working_pattern_pay_gap_pct'))
+    """
+    return parse_ashe_working_pattern_pay_gap(_get_linked_file(force_refresh=force_refresh))
+
+
+def get_mean_hours_by_pattern_gender(force_refresh: bool = False) -> pd.DataFrame:
+    """Get mean weekly paid hours by work pattern and gender for NI, latest year snapshot.
+
+    Args:
+        force_refresh: If True, bypass cache and download fresh data
+
+    Returns:
+        DataFrame with columns: work_pattern, male_mean_hours, female_mean_hours, all_mean_hours
+
+    Example:
+        >>> df = get_mean_hours_by_pattern_gender()
+        >>> print(df)
+    """
+    return parse_ashe_mean_hours_by_pattern_gender(_get_linked_file(force_refresh=force_refresh))
 
 
 def validate_ashe_data(df: pd.DataFrame) -> bool:  # pragma: no cover

--- a/tests/test_nisra_ashe_integrity.py
+++ b/tests/test_nisra_ashe_integrity.py
@@ -462,3 +462,163 @@ class TestASHEHourlyEarningsByPatternGender:
         assert pt.loc["Female", "median_hourly_earnings"] > pt.loc["Male", "median_hourly_earnings"], (
             "Part-time female hourly earnings should exceed male in NI"
         )
+
+
+class TestASHENIUKEarningsComparison:
+    """Integrity tests for ASHE Figure 1: NI vs UK full-time weekly earnings timeseries."""
+
+    @pytest.fixture(scope="class")
+    def df(self):
+        return ashe.get_ni_uk_earnings_comparison()
+
+    def test_required_columns(self, df):
+        assert set(df.columns) == {"year", "location", "median_weekly_earnings_fulltime"}
+
+    def test_locations(self, df):
+        assert set(df["location"].unique()) == {"NI", "UK"}
+
+    def test_two_records_per_year(self, df):
+        counts = df.groupby("year").size()
+        assert (counts == 2).all()
+
+    def test_starts_2005(self, df):
+        assert df["year"].min() == 2005
+
+    def test_earnings_positive(self, df):
+        assert (df["median_weekly_earnings_fulltime"] > 0).all()
+
+    def test_uk_earns_more_than_ni(self, df):
+        """UK full-time median weekly earnings should exceed NI for all years."""
+        for year in df["year"].unique():
+            yr = df[df["year"] == year].set_index("location")
+            uk = yr.loc["UK", "median_weekly_earnings_fulltime"]
+            ni = yr.loc["NI", "median_weekly_earnings_fulltime"]
+            assert uk > ni, f"UK (£{uk}) <= NI (£{ni}) in {year}"
+
+    def test_earnings_growing_over_time(self, df):
+        """NI earnings should be higher in the latest year than in 2005."""
+        ni = df[df["location"] == "NI"].set_index("year")
+        assert ni.loc[ni.index.max(), "median_weekly_earnings_fulltime"] > ni.loc[2005, "median_weekly_earnings_fulltime"]
+
+
+class TestASHEUKRegionalPayRatio:
+    """Integrity tests for ASHE Figure 13: high-to-low pay ratio by UK region."""
+
+    @pytest.fixture(scope="class")
+    def df(self):
+        return ashe.get_uk_regional_pay_ratio()
+
+    def test_required_columns(self, df):
+        assert set(df.columns) == {"region", "ratio"}
+
+    def test_northern_ireland_present(self, df):
+        assert "Northern Ireland" in df["region"].values
+
+    def test_london_present(self, df):
+        assert "London" in df["region"].values
+
+    def test_ratios_positive(self, df):
+        assert (df["ratio"] > 0).all()
+
+    def test_london_highest_ratio(self, df):
+        """London should have the highest pay ratio."""
+        assert df.loc[df["ratio"].idxmax(), "region"] == "London"
+
+    def test_ni_below_uk_average(self, df):
+        """NI pay ratio should be below the UK average."""
+        ni = df[df["region"] == "Northern Ireland"]["ratio"].values[0]
+        uk = df[df["region"] == "United Kingdom"]["ratio"].values[0]
+        assert ni < uk, f"NI ratio ({ni}) should be below UK ({uk})"
+
+
+class TestASHEHoursDistribution:
+    """Integrity tests for ASHE Figure 9: weekly paid hours distribution."""
+
+    @pytest.fixture(scope="class")
+    def df(self):
+        return ashe.get_hours_distribution()
+
+    def test_required_columns(self, df):
+        assert set(df.columns) == {"paid_hours_worked", "percentage"}
+
+    def test_hours_range(self, df):
+        assert df["paid_hours_worked"].min() >= 0
+        assert df["paid_hours_worked"].max() >= 60
+
+    def test_percentages_positive(self, df):
+        assert (df["percentage"] >= 0).all()
+
+    def test_percentages_sum_to_100(self, df):
+        assert abs(df["percentage"].sum() - 100) < 2.0
+
+    def test_37_hours_is_modal(self, df):
+        """37 hours/week is the most common working week in NI."""
+        modal_hours = df.loc[df["percentage"].idxmax(), "paid_hours_worked"]
+        assert modal_hours == 37
+
+
+class TestASHEWorkingPatternPayGap:
+    """Integrity tests for ASHE Figure 19: working pattern pay gap timeseries."""
+
+    @pytest.fixture(scope="class")
+    def df(self):
+        return ashe.get_working_pattern_pay_gap()
+
+    def test_required_columns(self, df):
+        assert set(df.columns) == {"year", "location", "working_pattern_pay_gap_pct"}
+
+    def test_locations(self, df):
+        assert set(df["location"].unique()) == {"NI", "UK"}
+
+    def test_two_records_per_year(self, df):
+        counts = df.groupby("year").size()
+        assert (counts == 2).all()
+
+    def test_starts_2005(self, df):
+        assert df["year"].min() == 2005
+
+    def test_gap_positive(self, df):
+        """Full-time workers always earn more per hour than part-time — gap should be positive."""
+        assert (df["working_pattern_pay_gap_pct"] > 0).all()
+
+    def test_ni_gap_below_uk(self, df):
+        """NI working pattern pay gap should be below UK in most years."""
+        pivot = df.pivot(index="year", columns="location", values="working_pattern_pay_gap_pct")
+        ni_below = (pivot["NI"] < pivot["UK"]).sum()
+        total = len(pivot)
+        assert ni_below / total >= 0.75, f"NI gap only below UK in {ni_below}/{total} years"
+
+
+class TestASHEMeanHoursByPatternGender:
+    """Integrity tests for ASHE Figure 20: mean weekly hours by pattern and gender."""
+
+    @pytest.fixture(scope="class")
+    def df(self):
+        return ashe.get_mean_hours_by_pattern_gender()
+
+    def test_required_columns(self, df):
+        assert set(df.columns) == {"work_pattern", "male_mean_hours", "female_mean_hours", "all_mean_hours"}
+
+    def test_work_patterns(self, df):
+        assert set(df["work_pattern"].unique()) == {"Part-time", "Full-time", "All Employees"}
+
+    def test_hours_positive(self, df):
+        for col in ("male_mean_hours", "female_mean_hours", "all_mean_hours"):
+            assert (df[col] > 0).all()
+
+    def test_fulltime_longer_than_parttime(self, df):
+        """Full-time mean hours should exceed part-time for all columns."""
+        ft = df[df["work_pattern"] == "Full-time"].iloc[0]
+        pt = df[df["work_pattern"] == "Part-time"].iloc[0]
+        for col in ("male_mean_hours", "female_mean_hours", "all_mean_hours"):
+            assert ft[col] > pt[col], f"Full-time {col} ({ft[col]}) <= part-time ({pt[col]})"
+
+    def test_males_work_longer_fulltime(self, df):
+        """Male full-time mean hours exceed female full-time mean hours."""
+        ft = df[df["work_pattern"] == "Full-time"].iloc[0]
+        assert ft["male_mean_hours"] > ft["female_mean_hours"]
+
+    def test_females_work_longer_parttime(self, df):
+        """Female part-time mean hours exceed male part-time mean hours in NI."""
+        pt = df[df["work_pattern"] == "Part-time"].iloc[0]
+        assert pt["female_mean_hours"] > pt["male_mean_hours"]


### PR DESCRIPTION
## Summary

- Replaces all hardcoded `pd.read_excel(sheet_name='FigureXX')` calls with `_find_linked_sheet()`, a content-fingerprint scanner that identifies sheets by column header signature and subtitle keywords rather than figure number. NISRA reassigns figure numbers each publication year, so this is the only sustainable approach.
- Adds a `_SHEET_SIGNATURES` registry mapping 10 semantic keys to `{cols, subtitle_keywords, excludes}` tuples for disambiguation.
- All 10 linked-table parsers validated against 2022, 2023, 2024, and 2025 publication files (38/40 pass; 2 expected `NISRADataNotFoundError` for data genuinely absent from 2022).

**New data series (issues #1742 and #1746):**
- `get_ni_uk_earnings_comparison()` — NI vs UK full-time weekly earnings timeseries back to 2005
- `get_uk_regional_pay_ratio()` — UK regional high-to-low pay ratio snapshot
- `get_hours_distribution()` — Distribution of weekly paid hours (NI, latest year)
- `get_working_pattern_pay_gap()` — Full-time vs part-time pay gap timeseries (2023+)
- `get_mean_hours_by_pattern_gender()` — Mean weekly hours by work pattern and gender

**Example insights from the data:**
- NI median full-time weekly earnings reached £634 in 2025 (vs £728 UK), a gap that has narrowed from ~20% in 2005 to ~13% today
- 37 hours/week is the clear mode in NI paid hours distribution (as expected for standard full-time)
- NI's working pattern pay gap (26%) is below the UK average (33%)

## Test plan

- [x] All 92 existing tests pass
- [x] 30 new tests across 5 new test classes pass (data integrity, value ranges, domain-specific assertions)
- [x] Manual validation: all 10 parsers tested against 2022–2025 ASHE linked tables files
- [x] pre-commit clean (ruff, ruff-format, architectural constraints)

Closes #1742, #1746

🤖 Generated with [Claude Code](https://claude.com/claude-code)