### PR TITLE
ci: replace deprecated codecov/test-results-action with codecov-action@v6

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -42,6 +42,7 @@ jobs:
 
             - name: Upload test results to Codecov
               if: ${{ !cancelled() }}
-              uses: codecov/test-results-action@v1
+              uses: codecov/codecov-action@v6
               with:
+                  report_type: test_results
                   token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Replaces `codecov/test-results-action@v1` with `codecov/codecov-action@v6` using `report_type: test_results`.

The `test-results-action` repo carries an official deprecation warning and is being folded into the main `codecov-action`. Node 20 support (which it runs on) is removed from GitHub-hosted runners on June 2, 2026.

No functional change — same token, same trigger (`if: !cancelled()`), same behaviour.