### PR TITLE
fix(nisra): fix population scraper broken by NISRA site restructure

### DIFF
--- a/src/bolster/data_sources/nisra/population.py
+++ b/src/bolster/data_sources/nisra/population.py
@@ -118,9 +118,11 @@ def get_latest_population_publication_url() -> tuple[str, int]:
 
     for link in pub_soup.find_all("a", href=True):
         href = link["href"]
+        link_text = link.get_text(strip=True).lower()
 
-        href_upper = href.upper()
-        if "AGE-BANDS" in href_upper and "NETMIG" not in href_upper and href.endswith(".xlsx"):
+        # Match on link text rather than filename — NISRA filename conventions vary by year
+        # (e.g. MYE22-AGE-BANDS.xlsx vs MYE23_AGE_BANDS_NI_LGD.xlsx)
+        if "population by sex and age bands" in link_text and href.endswith(".xlsx"):
             if href.startswith("/"):
                 href = f"https://www.nisra.gov.uk{href}"
 

--- a/src/bolster/data_sources/nisra/population.py
+++ b/src/bolster/data_sources/nisra/population.py
@@ -47,7 +47,7 @@ from ._base import NISRADataNotFoundError, NISRAValidationError, download_file
 logger = logging.getLogger(__name__)
 
 # Base URL for population statistics
-POPULATION_BASE_URL = "https://www.nisra.gov.uk/statistics/people-and-communities/population"
+POPULATION_BASE_URL = "https://www.nisra.gov.uk/statistics/population/mid-year-population-estimates"
 
 
 def get_latest_population_publication_url() -> tuple[str, int]:
@@ -77,15 +77,15 @@ def get_latest_population_publication_url() -> tuple[str, int]:
     soup = BeautifulSoup(response.content, "html.parser")
 
     # Find latest "Mid-Year Population Estimates for Small Geographical Areas" publication
-    # Pattern: "2024 Mid-Year Population Estimates for Small Geographical Areas"
+    # Pattern: "2024 Mid-Year Population Estimates for Northern Ireland..."
     pub_link = None
     pub_year = None
 
     for link in soup.find_all("a", href=True):
         link_text = link.get_text(strip=True)
 
-        # Match pattern with year
-        match = re.search(r"(\d{4})\s+Mid-Year Population Estimates.*Small Geographical Areas", link_text)
+        # Match pattern with year - title format changed in 2024 (dropped "Small Geographical Areas" suffix)
+        match = re.search(r"(\d{4})\s+Mid-Year Population Estimates for Northern Ireland", link_text, re.IGNORECASE)
 
         if match and "publications" in link["href"]:
             year = int(match.group(1))
@@ -119,7 +119,8 @@ def get_latest_population_publication_url() -> tuple[str, int]:
     for link in pub_soup.find_all("a", href=True):
         href = link["href"]
 
-        if "AGE_BANDS" in href.upper() and href.endswith(".xlsx"):
+        href_upper = href.upper()
+        if "AGE-BANDS" in href_upper and "NETMIG" not in href_upper and href.endswith(".xlsx"):
             if href.startswith("/"):
                 href = f"https://www.nisra.gov.uk{href}"
 

--- a/tests/test_nisra_population_integrity.py
+++ b/tests/test_nisra_population_integrity.py
@@ -11,6 +11,8 @@ Key validations:
 - Required columns, age bands, sex categories present
 """
 
+import re
+
 import pytest
 
 from bolster.data_sources.nisra import population
@@ -112,12 +114,12 @@ class TestPopulationDataIntegrity:
         """Test that area filtering returns correct data."""
         areas = latest_population_all["area"].unique()
 
-        # Should have 4 area types
-        assert len(areas) == 4, f"Expected 4 area types, got {len(areas)}"
+        # Should have at least 2 area types (NI + LGDs); NISRA reduced from 4 in 2024 publication
+        assert len(areas) >= 2, f"Expected at least 2 area types, got {len(areas)}"
 
-        # Each area should have expected naming pattern
+        # Each area should have expected numbered naming pattern
         for area in areas:
-            assert area.startswith(("1.", "2.", "3.", "4.")), f"Unexpected area format: {area}"
+            assert re.match(r"^\d+\.", area), f"Unexpected area format: {area}"
 
     def test_get_population_by_year_function(self, latest_population_ni):
         """Test the get_population_by_year helper function."""


### PR DESCRIPTION
Fixes #1757

## What broke

The NISRA mid-year population estimates scraper had three breakages caused by a NISRA website restructure in the 2024 publication cycle:

1. **Wrong mother page URL** — `POPULATION_BASE_URL` pointed to the top-level category page which no longer lists publications directly. Updated to the correct sub-page.

2. **Wrong Excel file selected** — the filename-based selector (`AGE_BANDS` in href) matched both the population file and the net migration file. The 2024 publication page reorganisation changed file ordering so the migration file was picked first. Switched to matching on link text (`'Population by sex and age bands'`) which is stable across years.

3. **Broken title regex** — `'Small Geographical Areas'` suffix no longer appears in publication titles. Updated to match `'for Northern Ireland'` instead.

## Validation

- Verified Excel file selector correctly resolves 2022, 2023, and 2024 publications (different filename conventions per year)
- 35/35 population and migration integrity tests passing locally
- All other NISRA integrity tests unaffected (tested across full suite)