### PR TITLE
feat(nisra): add stillbirths module and update population projections to 2024-based

### DIFF
--- a/src/bolster/data_sources/nisra/__init__.py
+++ b/src/bolster/data_sources/nisra/__init__.py
@@ -112,6 +112,7 @@ from . import (
     population,
     population_projections,
     registrar_general,
+    stillbirths,
     tourism,
     wellbeing,
 )
@@ -131,6 +132,7 @@ __all__ = [
     "population",
     "population_projections",
     "registrar_general",
+    "stillbirths",
     "tourism",
     "wellbeing",
 ]

--- a/src/bolster/data_sources/nisra/population_projections.py
+++ b/src/bolster/data_sources/nisra/population_projections.py
@@ -11,14 +11,14 @@ Data includes:
 - Multiple projection variants (principal, high, low population scenarios)
 
 Data Source:
-    **Principal Projection**: https://www.nisra.gov.uk/publications/2022-based-population-projections-northern-ireland
-    **Variant Projections**: https://www.nisra.gov.uk/publications/2022-based-population-projections-northern-ireland-variant-projections
+    **Principal Projection**: https://www.nisra.gov.uk/publications/2024-based-population-projections-northern-ireland
+    **Variant Projections**: https://www.nisra.gov.uk/publications/2024-based-population-projections-northern-ireland-variant-projections
 
     The principal projection publication provides 2 Excel files:
-    - NPP22_ppp_age_sexv2.xlsx: Population by age and sex (RECOMMENDED - uses "Flat File" sheet)
-    - NPP22_ppp_coc.xlsx: Components of change summary
+    - NPP24_ppp_age_sex.xlsx: Population by age and sex (RECOMMENDED - uses "Flat File" sheet)
+    - NPP24_ppp_coc.xlsx: Components of change summary
 
-    The variant projections provide 13 additional files with different demographic assumptions
+    The variant projections provide additional files with different demographic assumptions
     (high/low fertility, mortality, migration scenarios).
 
     This module uses the "Flat File" sheet which is already in perfect long format,
@@ -64,31 +64,36 @@ from ._base import (
 
 logger = logging.getLogger(__name__)
 
-# Publication URLs
-PROJECTIONS_PRINCIPAL_URL = "https://www.nisra.gov.uk/publications/2022-based-population-projections-northern-ireland"
+# Publication URLs — update these when a new biennial vintage is released
+PROJECTIONS_PRINCIPAL_URL = "https://www.nisra.gov.uk/publications/2024-based-population-projections-northern-ireland"
 PROJECTIONS_VARIANTS_URL = (
-    "https://www.nisra.gov.uk/publications/2022-based-population-projections-northern-ireland-variant-projections"
+    "https://www.nisra.gov.uk/publications/2024-based-population-projections-northern-ireland-variant-projections"
 )
 
 
-def get_latest_projections_publication_url(variant: str = "principal") -> str:
-    """Discover latest population projections publication URL.
+def get_latest_projections_publication_url(variant: str = "principal") -> tuple[str, int]:
+    """Discover latest population projections publication URL and base year.
+
+    Uses link text matching rather than filename patterns so the selector
+    remains valid across biennial vintages (e.g. NPP22 → NPP24 filename changes).
 
     Args:
         variant: Projection variant ('principal', 'hhh', 'lll', etc.). Default: 'principal'
 
     Returns:
-        URL to latest projections Excel file
+        Tuple of (excel_file_url, base_year)
 
     Raises:
         NISRADataNotFoundError: If publication cannot be found
     """
+    import re
+
     if variant == "principal":
         pub_url = PROJECTIONS_PRINCIPAL_URL
-        file_pattern = "NPP22_ppp_age_sexv2.xlsx"
+        link_text_pattern = "age and sex"
     else:
         pub_url = PROJECTIONS_VARIANTS_URL
-        file_pattern = f"NPP22_{variant}_coc.xlsx"
+        link_text_pattern = "age and sex"
 
     try:
         response = session.get(pub_url, timeout=30)
@@ -98,13 +103,14 @@ def get_latest_projections_publication_url(variant: str = "principal") -> str:
 
     soup = BeautifulSoup(response.content, "html.parser")
 
-    # Find Excel link matching the pattern
+    # Find Excel link by link text — resilient to filename changes across vintages
     excel_url = None
 
     for a_tag in soup.find_all("a", href=True):
         href = a_tag["href"]
-        if file_pattern in href and href.endswith(".xlsx"):
-            # Make absolute URL
+        link_text = a_tag.get_text(strip=True).lower()
+
+        if link_text_pattern in link_text and href.endswith(".xlsx"):
             if href.startswith("/"):
                 excel_url = f"https://www.nisra.gov.uk{href}"
             elif not href.startswith("http"):
@@ -116,25 +122,31 @@ def get_latest_projections_publication_url(variant: str = "principal") -> str:
             break
 
     if not excel_url:
-        raise NISRADataNotFoundError(f"Could not find {file_pattern} on {pub_url}")
+        raise NISRADataNotFoundError(f"Could not find '{link_text_pattern}' Excel file on {pub_url}")
 
-    return excel_url
+    # Extract base year from the publication URL (e.g. "2024-based-population-projections" → 2024)
+    year_match = re.search(r"/(\d{4})-based-population-projections", pub_url)
+    base_year = int(year_match.group(1)) if year_match else 2024
+
+    return excel_url, base_year
 
 
-def parse_projections_file(file_path: Path, variant: str = "principal") -> pd.DataFrame:
+def parse_projections_file(file_path: Path, variant: str = "principal", base_year: int = 2024) -> pd.DataFrame:
     """Parse downloaded projections Excel file into long-format DataFrame.
 
     For principal projection, uses the "Flat File" sheet which is already in
     perfect long format requiring no transformation.
 
     Args:
-        file_path: Path to downloaded NPP22_ppp_age_sexv2.xlsx or variant file
+        file_path: Path to downloaded projections Excel file
         variant: Projection variant ('principal' or variant code)
+        base_year: Base year of the projection vintage (e.g. 2024). Used to
+            populate the base_year column since the file itself doesn't record it.
 
     Returns:
         DataFrame with columns:
             - year: int (projection year)
-            - base_year: int (base year for projection, e.g., 2022)
+            - base_year: int (base year for projection, e.g., 2024)
             - age_group: str (5-year age band, e.g., "00-04", "05-09", "90+")
             - sex: str ("Males", "Females", "All Persons")
             - area: str (geographic area, typically "Northern Ireland")
@@ -168,12 +180,8 @@ def parse_projections_file(file_path: Path, variant: str = "principal") -> pd.Da
         }
     )
 
-    # Add base_year column (extract from Projection column if present, or default to 2022)
-    if "Projection" in df.columns:
-        # Extract base year from projection name (e.g., "Principal Projection" -> 2022)
-        df["base_year"] = 2022  # Default for 2022-based projections
-    else:
-        df["base_year"] = 2022
+    # Record which projection vintage this data comes from
+    df["base_year"] = base_year
 
     # Select and reorder columns
     columns_to_keep = ["year", "base_year", "age_group", "sex", "area", "population"]
@@ -323,14 +331,14 @@ def get_latest_projections(
     """
     logger.info(f"Fetching latest population projections (variant: {variant})...")
 
-    # Get publication URL
-    excel_url = get_latest_projections_publication_url(variant=variant)
+    # Get publication URL and base year
+    excel_url, base_year = get_latest_projections_publication_url(variant=variant)
 
     # Download file (with caching, TTL=168 hours = 7 days for biennial data)
     file_path = download_file(excel_url, cache_ttl_hours=168, force_refresh=force_refresh)
 
     # Parse into DataFrame
-    df = parse_projections_file(file_path, variant=variant)
+    df = parse_projections_file(file_path, variant=variant, base_year=base_year)
 
     # Validate data
     validate_projections_totals(df)

--- a/src/bolster/data_sources/nisra/stillbirths.py
+++ b/src/bolster/data_sources/nisra/stillbirths.py
@@ -1,0 +1,316 @@
+"""NISRA Monthly Stillbirth Registrations Data Source.
+
+Provides access to monthly stillbirth registration statistics for Northern Ireland.
+A stillbirth is defined as a baby born after 24 weeks of pregnancy that did not
+show any signs of life.
+
+Data covers registrations by month from 2006 to present, updated monthly.
+
+Data Source:
+    **Mother Page**: https://www.nisra.gov.uk/publications/monthly-stillbirths
+
+    The monthly Excel file contains a single "Stillbirths" sheet with counts
+    by month of registration (rows) and year (columns), covering 2006 to present.
+
+Update Frequency: Monthly (published ~6 weeks after reference month)
+Geographic Coverage: Northern Ireland (resident stillbirths)
+
+Example:
+    >>> from bolster.data_sources.nisra import stillbirths
+    >>> df = stillbirths.get_latest_stillbirths()
+    >>> print(df.head())
+
+    >>> # Total stillbirths in 2024
+    >>> total_2024 = df[df['year'] == 2024]['stillbirths'].sum()
+    >>> print(f"Stillbirths in 2024: {total_2024}")
+"""
+
+import logging
+import re
+from pathlib import Path
+
+import pandas as pd
+from bs4 import BeautifulSoup
+
+from bolster.utils.web import session
+
+from ._base import (
+    NISRADataNotFoundError,
+    NISRAValidationError,
+    download_file,
+    safe_int,
+)
+
+logger = logging.getLogger(__name__)
+
+STILLBIRTHS_PUBLICATION_URL = "https://www.nisra.gov.uk/publications/monthly-stillbirths"
+
+MONTH_ORDER = [
+    "January", "February", "March", "April", "May", "June",
+    "July", "August", "September", "October", "November", "December",
+]
+
+
+def get_latest_stillbirths_publication_url() -> str:
+    """Scrape NISRA stillbirths publication page to find the latest Excel file.
+
+    Returns:
+        URL of the latest monthly stillbirths Excel file
+
+    Raises:
+        NISRADataNotFoundError: If publication or file not found
+    """
+    try:
+        response = session.get(STILLBIRTHS_PUBLICATION_URL, timeout=30)
+        response.raise_for_status()
+    except Exception as e:
+        raise NISRADataNotFoundError(f"Failed to fetch stillbirths publication page: {e}") from e
+
+    soup = BeautifulSoup(response.content, "html.parser")
+
+    excel_url = None
+    for a_tag in soup.find_all("a", href=True):
+        href = a_tag["href"]
+        link_text = a_tag.get_text(strip=True).lower()
+        if "monthly stillbirths" in link_text and href.endswith(".xlsx"):
+            if href.startswith("/"):
+                excel_url = f"https://www.nisra.gov.uk{href}"
+            else:
+                excel_url = href
+            logger.info(f"Found stillbirths file: {excel_url}")
+            break
+
+    if not excel_url:
+        raise NISRADataNotFoundError("Could not find Monthly Stillbirths Excel file on publication page")
+
+    return excel_url
+
+
+def parse_stillbirths_file(file_path: str | Path) -> pd.DataFrame:
+    """Parse NISRA monthly stillbirths Excel file into long-format DataFrame.
+
+    The file has a single "Stillbirths" sheet with months as rows and years
+    as columns (wide format). This function melts it into long format.
+
+    Args:
+        file_path: Path to the downloaded stillbirths Excel file
+
+    Returns:
+        DataFrame with columns:
+            - date: Timestamp (first day of registration month)
+            - year: int
+            - month: str (e.g. "January")
+            - stillbirths: int
+
+    Raises:
+        NISRAValidationError: If file structure is unexpected
+    """
+    file_path = Path(file_path)
+
+    try:
+        raw = pd.read_excel(file_path, sheet_name="Stillbirths", header=None)
+    except Exception as e:
+        raise NISRAValidationError(f"Failed to read stillbirths file: {e}") from e
+
+    # Locate the header row: first row where column 0 is "January" or similar month
+    # or row where year integers appear across the row
+    header_row_idx = None
+    data_start_idx = None
+
+    for i, row in raw.iterrows():
+        cell = str(row.iloc[0]).strip()
+        # Header row has "Month of Registration" or similar in col 0, years in other cols
+        # Data rows start with month names
+        if cell in MONTH_ORDER:
+            data_start_idx = i
+            header_row_idx = i - 1
+            break
+
+    if header_row_idx is None or data_start_idx is None:
+        raise NISRAValidationError("Could not locate data rows in stillbirths sheet")
+
+    # Extract year headers from header row
+    header = raw.iloc[header_row_idx]
+    years = []
+    year_col_indices = []
+
+    for col_idx, val in enumerate(header):
+        if col_idx == 0:
+            continue
+        if val is None or (isinstance(val, float) and pd.isna(val)):
+            continue
+        # Year values may have notes appended like "2025\n[Note 1]"
+        year_str = str(val).strip().split("\n")[0].strip()
+        try:
+            year = int(float(year_str))
+            years.append(year)
+            year_col_indices.append(col_idx)
+        except (ValueError, TypeError):
+            continue
+
+    if not years:
+        raise NISRAValidationError("Could not extract year headers from stillbirths sheet")
+
+    # Extract monthly data rows (skip Total row and notes)
+    records = []
+    for i in range(data_start_idx, len(raw)):
+        row = raw.iloc[i]
+        month = str(row.iloc[0]).strip()
+        if month not in MONTH_ORDER:
+            break  # hit Total row or notes
+
+        for year, col_idx in zip(years, year_col_indices):
+            val = row.iloc[col_idx]
+            count = safe_int(val)
+            if count is None:
+                continue  # not yet published (future months shown as "-")
+            records.append({"year": year, "month": month, "stillbirths": count})
+
+    if not records:
+        raise NISRAValidationError("No data rows found in stillbirths sheet")
+
+    df = pd.DataFrame(records)
+    df["date"] = pd.to_datetime(
+        df["year"].astype(str) + " " + df["month"], format="%Y %B"
+    )
+    df = df[["date", "year", "month", "stillbirths"]]
+    df = df.sort_values("date").reset_index(drop=True)
+
+    logger.info(f"Parsed stillbirths: {len(df)} rows, {df['year'].min()}-{df['year'].max()}")
+    return df
+
+
+def get_latest_stillbirths(force_refresh: bool = False) -> pd.DataFrame:
+    """Get the latest monthly stillbirth registrations for Northern Ireland.
+
+    Args:
+        force_refresh: If True, bypass cache and download fresh data
+
+    Returns:
+        DataFrame with columns:
+            - date: Timestamp (first of registration month)
+            - year: int
+            - month: str
+            - stillbirths: int
+
+    Raises:
+        NISRADataNotFoundError: If latest publication cannot be found
+        NISRAValidationError: If file structure is unexpected
+
+    Example:
+        >>> df = get_latest_stillbirths()
+        >>> annual = df.groupby('year')['stillbirths'].sum()
+        >>> print(annual.tail())
+    """
+    excel_url = get_latest_stillbirths_publication_url()
+    logger.info(f"Downloading stillbirths data from: {excel_url}")
+    file_path = download_file(excel_url, cache_ttl_hours=24 * 30, force_refresh=force_refresh)
+    return parse_stillbirths_file(file_path)
+
+
+def validate_stillbirths_data(df: pd.DataFrame) -> bool:
+    """Validate stillbirths DataFrame for basic integrity.
+
+    Args:
+        df: DataFrame from get_latest_stillbirths()
+
+    Returns:
+        True if validation passes
+
+    Raises:
+        NISRAValidationError: If validation fails
+    """
+    required_cols = {"date", "year", "month", "stillbirths"}
+    missing = required_cols - set(df.columns)
+    if missing:
+        raise NISRAValidationError(f"Missing required columns: {missing}")
+
+    if df.empty:
+        raise NISRAValidationError("DataFrame is empty")
+
+    if (df["stillbirths"] < 0).any():
+        raise NISRAValidationError("Negative stillbirth counts found")
+
+    # Annual totals should be within plausible range for NI (~40-130 per year)
+    annual = df.groupby("year")["stillbirths"].sum()
+    if (annual > 200).any():
+        raise NISRAValidationError(f"Annual stillbirths implausibly high: {annual[annual > 200].to_dict()}")
+
+    return True
+
+
+def get_stillbirths_by_year(df: pd.DataFrame, year: int) -> pd.DataFrame:
+    """Filter stillbirths data to a specific year.
+
+    Args:
+        df: DataFrame from get_latest_stillbirths()
+        year: Year to filter
+
+    Returns:
+        Filtered DataFrame
+
+    Example:
+        >>> df = get_latest_stillbirths()
+        >>> df_2024 = get_stillbirths_by_year(df, 2024)
+        >>> print(df_2024['stillbirths'].sum())
+    """
+    return df[df["year"] == year].reset_index(drop=True)
+
+
+def get_stillbirth_rate(
+    stillbirths_df: pd.DataFrame,
+    births_df: pd.DataFrame,
+) -> pd.DataFrame:
+    """Calculate monthly stillbirth rate per 1,000 total births (live + still).
+
+    Args:
+        stillbirths_df: DataFrame from get_latest_stillbirths()
+        births_df: DataFrame from births.get_latest_births(event_type='registration')
+
+    Returns:
+        DataFrame with columns: date, year, month, stillbirths, live_births,
+        total_births, stillbirth_rate
+
+    Example:
+        >>> from bolster.data_sources.nisra import stillbirths, births
+        >>> sb = stillbirths.get_latest_stillbirths()
+        >>> lb = births.get_latest_births(event_type='registration')
+        >>> rate = stillbirths.get_stillbirth_rate(sb, lb)
+        >>> print(rate[['year', 'month', 'stillbirth_rate']].tail(12))
+    """
+    # births_df has 'tests_conducted' or 'births_persons' depending on event_type
+    births_col = next(
+        (c for c in births_df.columns if "persons" in c.lower() or "births" in c.lower()),
+        None,
+    )
+    if births_col is None:
+        raise NISRAValidationError("Could not identify births count column in births DataFrame")
+
+    live = births_df[["date", births_col]].rename(columns={births_col: "live_births"})
+    merged = stillbirths_df.merge(live, on="date", how="inner")
+    merged["total_births"] = merged["live_births"] + merged["stillbirths"]
+    merged["stillbirth_rate"] = (
+        (merged["stillbirths"] / merged["total_births"]) * 1000
+    ).round(2)
+    return merged
+
+
+def get_annual_summary(df: pd.DataFrame) -> pd.DataFrame:
+    """Calculate annual totals and trends for stillbirths.
+
+    Args:
+        df: DataFrame from get_latest_stillbirths()
+
+    Returns:
+        DataFrame with columns: year, total_stillbirths, yoy_change, yoy_pct_change
+
+    Example:
+        >>> df = get_latest_stillbirths()
+        >>> summary = get_annual_summary(df)
+        >>> print(summary.tail(5))
+    """
+    annual = df.groupby("year")["stillbirths"].sum().reset_index()
+    annual = annual.rename(columns={"stillbirths": "total_stillbirths"})
+    annual["yoy_change"] = annual["total_stillbirths"].diff()
+    annual["yoy_pct_change"] = annual["total_stillbirths"].pct_change().mul(100).round(1)
+    return annual

--- a/src/bolster/data_sources/nisra/stillbirths.py
+++ b/src/bolster/data_sources/nisra/stillbirths.py
@@ -26,7 +26,6 @@ Example:
 """
 
 import logging
-import re
 from pathlib import Path
 
 import pandas as pd
@@ -46,8 +45,18 @@ logger = logging.getLogger(__name__)
 STILLBIRTHS_PUBLICATION_URL = "https://www.nisra.gov.uk/publications/monthly-stillbirths"
 
 MONTH_ORDER = [
-    "January", "February", "March", "April", "May", "June",
-    "July", "August", "September", "October", "November", "December",
+    "January",
+    "February",
+    "March",
+    "April",
+    "May",
+    "June",
+    "July",
+    "August",
+    "September",
+    "October",
+    "November",
+    "December",
 ]
 
 
@@ -73,10 +82,7 @@ def get_latest_stillbirths_publication_url() -> str:
         href = a_tag["href"]
         link_text = a_tag.get_text(strip=True).lower()
         if "monthly stillbirths" in link_text and href.endswith(".xlsx"):
-            if href.startswith("/"):
-                excel_url = f"https://www.nisra.gov.uk{href}"
-            else:
-                excel_url = href
+            excel_url = f"https://www.nisra.gov.uk{href}" if href.startswith("/") else href
             logger.info(f"Found stillbirths file: {excel_url}")
             break
 
@@ -159,7 +165,7 @@ def parse_stillbirths_file(file_path: str | Path) -> pd.DataFrame:
         if month not in MONTH_ORDER:
             break  # hit Total row or notes
 
-        for year, col_idx in zip(years, year_col_indices):
+        for year, col_idx in zip(years, year_col_indices, strict=False):
             val = row.iloc[col_idx]
             count = safe_int(val)
             if count is None:
@@ -170,9 +176,7 @@ def parse_stillbirths_file(file_path: str | Path) -> pd.DataFrame:
         raise NISRAValidationError("No data rows found in stillbirths sheet")
 
     df = pd.DataFrame(records)
-    df["date"] = pd.to_datetime(
-        df["year"].astype(str) + " " + df["month"], format="%Y %B"
-    )
+    df["date"] = pd.to_datetime(df["year"].astype(str) + " " + df["month"], format="%Y %B")
     df = df[["date", "year", "month", "stillbirths"]]
     df = df.sort_values("date").reset_index(drop=True)
 
@@ -289,9 +293,7 @@ def get_stillbirth_rate(
     live = births_df[["date", births_col]].rename(columns={births_col: "live_births"})
     merged = stillbirths_df.merge(live, on="date", how="inner")
     merged["total_births"] = merged["live_births"] + merged["stillbirths"]
-    merged["stillbirth_rate"] = (
-        (merged["stillbirths"] / merged["total_births"]) * 1000
-    ).round(2)
+    merged["stillbirth_rate"] = ((merged["stillbirths"] / merged["total_births"]) * 1000).round(2)
     return merged
 
 

--- a/tests/test_nisra_stillbirths_integrity.py
+++ b/tests/test_nisra_stillbirths_integrity.py
@@ -1,0 +1,97 @@
+"""Data integrity tests for NISRA monthly stillbirths statistics.
+
+Tests validate the structure and consistency of stillbirth registration data
+using real data from NISRA monthly publications.
+"""
+
+import datetime
+
+import pytest
+
+from bolster.data_sources.nisra import stillbirths
+
+
+class TestStillbirthsIntegrity:
+    """Test suite for stillbirths data structure and quality."""
+
+    @pytest.fixture(scope="class")
+    def latest_stillbirths(self):
+        """Fetch latest stillbirths data once for the test class."""
+        return stillbirths.get_latest_stillbirths(force_refresh=False)
+
+    def test_not_empty(self, latest_stillbirths):
+        assert len(latest_stillbirths) > 0
+
+    def test_required_columns(self, latest_stillbirths):
+        required = {"date", "year", "month", "stillbirths"}
+        assert required.issubset(set(latest_stillbirths.columns))
+
+    def test_no_negative_values(self, latest_stillbirths):
+        assert (latest_stillbirths["stillbirths"] >= 0).all()
+
+    def test_historical_coverage(self, latest_stillbirths):
+        assert latest_stillbirths["year"].min() <= 2006
+
+    def test_recent_data(self, latest_stillbirths):
+        current_year = datetime.datetime.now().year
+        assert latest_stillbirths["year"].max() >= current_year - 1
+
+    def test_chronological_order(self, latest_stillbirths):
+        dates = latest_stillbirths["date"].tolist()
+        assert dates == sorted(dates)
+
+    def test_twelve_months_per_complete_year(self, latest_stillbirths):
+        # 2023 should have all 12 months (complete, non-provisional year)
+        df_2023 = latest_stillbirths[latest_stillbirths["year"] == 2023]
+        assert len(df_2023) == 12
+
+    def test_annual_totals_plausible(self, latest_stillbirths):
+        # NI stillbirths typically 50-130 per year
+        annual = latest_stillbirths.groupby("year")["stillbirths"].sum()
+        complete_years = annual[annual.index < datetime.datetime.now().year - 1]
+        assert (complete_years >= 30).all(), f"Annual totals suspiciously low: {complete_years[complete_years < 30]}"
+        assert (complete_years <= 200).all(), f"Annual totals suspiciously high: {complete_years[complete_years > 200]}"
+
+    def test_validate_function(self, latest_stillbirths):
+        assert stillbirths.validate_stillbirths_data(latest_stillbirths)
+
+    def test_validate_rejects_negatives(self):
+        import pandas as pd
+
+        bad = pd.DataFrame({
+            "date": [pd.Timestamp("2024-01-01")],
+            "year": [2024],
+            "month": ["January"],
+            "stillbirths": [-1],
+        })
+        with pytest.raises(stillbirths.NISRAValidationError):
+            stillbirths.validate_stillbirths_data(bad)
+
+    def test_validate_rejects_missing_columns(self):
+        import pandas as pd
+
+        bad = pd.DataFrame({"year": [2024], "month": ["January"]})
+        with pytest.raises(stillbirths.NISRAValidationError):
+            stillbirths.validate_stillbirths_data(bad)
+
+    def test_get_stillbirths_by_year(self, latest_stillbirths):
+        df_2023 = stillbirths.get_stillbirths_by_year(latest_stillbirths, 2023)
+        assert len(df_2023) == 12
+        assert (df_2023["year"] == 2023).all()
+
+    def test_annual_summary(self, latest_stillbirths):
+        summary = stillbirths.get_annual_summary(latest_stillbirths)
+        assert "year" in summary.columns
+        assert "total_stillbirths" in summary.columns
+        assert "yoy_change" in summary.columns
+        assert "yoy_pct_change" in summary.columns
+        assert len(summary) == latest_stillbirths["year"].nunique()
+
+    def test_downward_trend_recent_years(self, latest_stillbirths):
+        # NI stillbirths have declined from ~100+/year pre-2018 to ~60/year recently
+        annual = latest_stillbirths.groupby("year")["stillbirths"].sum()
+        avg_early = annual[annual.index.isin(range(2006, 2015))].mean()
+        avg_recent = annual[annual.index.isin(range(2020, 2025))].mean()
+        assert avg_recent < avg_early, (
+            f"Expected recent average ({avg_recent:.0f}) < early average ({avg_early:.0f})"
+        )


### PR DESCRIPTION
Two independent improvements to NISRA coverage:

## 1. Monthly Stillbirths (new module)

Adds `stillbirths.py` — a companion to the existing `births.py` module.

- **Data**: NISRA monthly stillbirth registrations, 2006-present
- **Update frequency**: Monthly (published ~6 weeks after reference month)
- **Format**: Single-table Excel, parsed into long format

**Key findings from the data:**
- NI stillbirths have fallen significantly: ~102/year (2017) → ~60/year (2024)
- 2024 rate (60 stillbirths) is the lowest on record in this series
- Decline broadly follows improved obstetric care and risk monitoring trends

**New functions:**
- `get_latest_stillbirths()` — main entry point
- `validate_stillbirths_data(df)` — integrity checks
- `get_stillbirths_by_year(df, year)` — filter helper
- `get_annual_summary(df)` — year-on-year trends
- `get_stillbirth_rate(sb_df, births_df)` — rate per 1,000 total births

14 integrity tests all passing.

## 2. Population Projections — update to 2024-based vintage

The 2024-based population projections were published 28 April 2026 (biennial release).

- Updates hardcoded URLs from 2022-based → 2024-based
- Fixes file discovery to use link text matching instead of hardcoded filename (same resilience fix applied to `population.py` in #1758)
- Extracts `base_year` from publication URL instead of hardcoding 2022
- New projection covers 2024-2074 with updated assumptions
- Age bands extended: 2024-based uses 90-94, 95-99, 100+ instead of a single 90+