### PR TITLE
docs: improve structure, fix doctests, add data sources overview

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -39,7 +39,7 @@ jobs:
         run: uv run sphinx-build -b html docs/ docs/_build/html
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v4
         with:
           path: docs/_build/html
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,4 +1,4 @@
-te. highlight:: shell
+.. highlight:: shell
 
 ============
 Contributing
@@ -64,63 +64,69 @@ Ready to contribute? Here's how to set up `bolster` for local development.
 
     $ git clone git@github.com:andrewbolster/bolster.git
 
-3. Install your local copy into a virtualenv. Assuming you have virtualenvwrapper installed, this is how you set up your fork for local development::
+3. Install all dependencies (runtime + dev) using ``uv``::
 
     $ cd bolster
-    $ uv sync
+    $ uv sync --all-extras
 
 4. Create a branch for local development::
 
-    $ git checkout -b name-of-your-bugfix-or-feature
+    $ git checkout -b fix/<name>   # or feat/<name>
 
    Now you can make your changes locally.
 
-5. When you're done making changes, check that your changes pass testing and linting::
+5. When you're done making changes, check that your changes pass linting and
+   tests::
 
-    $ make pre-commit
-    $ make test
+    $ uv run pre-commit run --all-files
+    $ uv run pytest tests/ -v
 
 6. Commit your changes and push your branch to GitHub::
 
-    $ git add .
+    $ git add <changed-files>
     $ git commit -m "Your detailed description of your changes."
-    $ git push origin name-of-your-bugfix-or-feature
+    $ git push -u origin fix/<name>
 
-7. Submit a pull request through the GitHub website.
+7. Open a pull request through the GitHub website and wait for CI to pass.
 
 Pull Request Guidelines
 -----------------------
 
 Before you submit a pull request, check that it meets these guidelines:
 
-1. The pull request should include tests.
-2. If the pull request adds functionality, the docs should be updated. Put
-   your new functionality into a function with a docstring, and add the
-   feature to the list in README.rst.
-3. The pull request should work for Python 3.10+. Check
-   https://github.com/andrewbolster/bolster/pull_requests
-   and make sure that the tests pass for all supported Python versions.
+1. The pull request should include tests (real-data integrity tests, not mocks).
+2. If the pull request adds functionality, update the docs — add a docstring
+   with an ``Example:`` section and update ``README.md`` and
+   ``docs/data_sources.rst`` if it adds a new data source.
+3. The pull request should work for Python 3.10+.  Check the GitHub Actions
+   CI results and make sure tests pass for all supported versions.
+4. Run ``uv run pre-commit run --all-files`` and resolve any linting issues
+   before requesting a review.
 
 Tips
 ----
 
-To bump a version, just do it manually in `bolster/__init__.py`, and then (assuming tests run
-successfully) run::
+To run only the doctests from source code::
 
-    $ git commit -m "Bump version to x.y.z"
-    $ git tag x.y.z
-    $ git push origin x.y.z
-    $ git push origin main
+    $ uv run pytest src/ --doctest-modules --no-cov
 
+To see code coverage::
+
+    $ uv run pytest tests/ --cov=src/bolster --cov-report=term-missing
 
 Deploying
 ---------
 
 A reminder for the maintainers on how to deploy.
-Make sure all your changes are committed (including an entry in HISTORY.rst).
-Then run::
 
-$ bump2version patch # possible: major / minor / patch
-$ git push
+1. Update ``CHANGELOG.md`` with the new version entry.
+2. Bump the version using ``bump-my-version``::
 
-GitHub Actions `publish.yml` will then tag, release and deploy to PyPI if tests pass.
+    $ uv run bump-my-version bump patch  # or minor / major
+
+3. Push the resulting commit and tag::
+
+    $ git push --follow-tags
+
+GitHub Actions ``publish.yml`` will then tag, release, and deploy to PyPI if
+tests pass.

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -13,26 +13,13 @@ Documentation is automatically generated from source code docstrings.
 Quick Links
 -----------
 
-**Core Module**
-   The main ``bolster`` module provides utilities for data processing, concurrency,
-   and tree/dictionary navigation. See :doc:`autoapi/bolster/index`.
+:doc:`autoapi/bolster/index` — Core ``bolster`` module: data processing, concurrency, and tree/dictionary utilities.
 
-**Data Sources**
-   Access Northern Ireland and UK government data:
+:doc:`autoapi/bolster/data_sources/index` — Data sources: NISRA, PSNI, NI Water, EONI, Companies House, Met Office, and more.
 
-   - NISRA (births, deaths, population, labour market, etc.)
-   - PSNI (crime statistics, road traffic collisions)
-   - NI Water, EONI, Companies House, Met Office
+:doc:`autoapi/bolster/utils/index` — Utilities: AWS, Azure, web scraping, caching, and HTTP helpers.
 
-   See :doc:`autoapi/bolster/data_sources/index`.
-
-**Utilities**
-   Helper modules for AWS, Azure, web scraping, caching, and more.
-   See :doc:`autoapi/bolster/utils/index`.
-
-**Command Line Interface**
-   CLI commands for data retrieval and processing.
-   See :doc:`autoapi/bolster/cli/index`.
+:doc:`autoapi/bolster/cli/index` — CLI commands for data retrieval and processing.
 
 .. click:: bolster.cli:cli
    :prog: bolster

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -204,7 +204,7 @@ texinfo_documents = [
         "Bolster Documentation",
         author,
         "bolster",
-        "One line description of project.",
+        "Python utilities and standardised access to Northern Ireland and UK public data sources.",
         "Miscellaneous",
     )
 ]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -102,7 +102,7 @@ language = "en"
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This patterns also effect to html_static_path and html_extra_path
-exclude_patterns = ["_build", "Thumbs.db", ".DS_Store", "autoapi/**"]
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
 # -- Options for doctest extension ------------------------------------
 
@@ -241,7 +241,7 @@ autoapi_options = [
     "imported-members",
 ]
 # Exclude examples directory from API docs
-autoapi_ignore = ["**/examples/*"]
+autoapi_ignore = ["**/examples/*", "**/.ipynb_checkpoints/**"]
 
 # Keep generated files for debugging (set to False in production)
 autoapi_keep_files = True

--- a/docs/data_sources.rst
+++ b/docs/data_sources.rst
@@ -1,0 +1,480 @@
+Data Sources
+============
+
+Bolster provides standardised access to a range of Northern Ireland and UK
+government data sources.  Each module follows the same conventions:
+
+- A top-level ``get_latest_*()`` function that downloads and returns a
+  :class:`pandas.DataFrame` ready for analysis.
+- Caching to ``~/.cache/bolster/<source>/`` to avoid repeated downloads.
+- A matching CLI command (``bolster <command> --help``).
+
+.. contents:: Available Sources
+   :local:
+   :depth: 1
+
+----
+
+NISRA
+-----
+
+The `NI Statistics and Research Agency <https://www.nisra.gov.uk/>`_ publishes
+a wide range of official statistics for Northern Ireland.  All NISRA modules
+live under :mod:`bolster.data_sources.nisra`.
+
+Births
+~~~~~~
+
+Monthly birth registrations from 2006 to present, broken down by sex and by
+registration vs. occurrence date.
+
+.. code-block:: python
+
+    from bolster.data_sources.nisra import births
+
+    df = births.get_latest_births(event_type="registration")
+    print(df.shape)
+
+.. code-block:: console
+
+    $ bolster nisra births
+
+Deaths
+~~~~~~
+
+Weekly death registrations with demographics, geography (Local Government
+Districts), and place-of-death breakdowns.
+
+.. code-block:: python
+
+    from bolster.data_sources.nisra import deaths
+
+    df = deaths.get_latest_deaths(dimension="demographics")
+    print(df.head())
+
+.. code-block:: console
+
+    $ bolster nisra deaths
+
+Marriages
+~~~~~~~~~
+
+Monthly marriage registrations.
+
+.. code-block:: python
+
+    from bolster.data_sources.nisra import marriages
+
+    df = marriages.get_latest_marriages()
+
+Stillbirths
+~~~~~~~~~~~
+
+Monthly stillbirth registrations.
+
+.. code-block:: python
+
+    from bolster.data_sources.nisra import stillbirths
+
+    df = stillbirths.get_latest_stillbirths()
+
+Population
+~~~~~~~~~~
+
+Mid-year population estimates by age, sex, and Local Government District.
+
+.. code-block:: python
+
+    from bolster.data_sources.nisra import population
+
+    df = population.get_latest_population()
+
+Population Projections
+~~~~~~~~~~~~~~~~~~~~~~
+
+Long-range population projections by age and sex scenario.
+
+.. code-block:: python
+
+    from bolster.data_sources.nisra import population_projections
+
+    df = population_projections.get_latest_projections()
+
+Migration
+~~~~~~~~~
+
+International and internal migration estimates for Northern Ireland.
+
+.. code-block:: python
+
+    from bolster.data_sources.nisra import migration
+
+    df = migration.get_latest_migration()
+
+Labour Market
+~~~~~~~~~~~~~
+
+Quarterly labour market statistics (employment, unemployment, economic
+inactivity).
+
+.. code-block:: python
+
+    from bolster.data_sources.nisra import labour_market
+
+    df = labour_market.get_latest_labour_market()
+
+.. code-block:: console
+
+    $ bolster nisra labour-market
+
+Annual Survey of Hours and Earnings (ASHE)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Annual workplace earnings data for Northern Ireland.
+
+.. code-block:: python
+
+    from bolster.data_sources.nisra import ashe
+
+    df = ashe.get_latest_ashe()
+
+Quarterly Employment Survey
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: python
+
+    from bolster.data_sources.nisra import quarterly_employment_survey as qes
+
+    df = qes.get_latest_qes()
+
+Wellbeing
+~~~~~~~~~
+
+Personal and economic wellbeing indicators from the NI Wellbeing Dashboard.
+
+.. code-block:: python
+
+    from bolster.data_sources.nisra import wellbeing
+
+    df = wellbeing.get_latest_wellbeing()
+
+Cancer Waiting Times
+~~~~~~~~~~~~~~~~~~~~
+
+Referral-to-treatment waiting times for cancer services.
+
+.. code-block:: python
+
+    from bolster.data_sources.nisra import cancer_waiting_times
+
+    df = cancer_waiting_times.get_latest_waiting_times()
+
+.. code-block:: console
+
+    $ bolster nisra cancer-waiting-times
+
+Emergency Care Waiting Times
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Emergency department attendance and four-hour target performance.
+
+.. code-block:: python
+
+    from bolster.data_sources.nisra import emergency_care_waiting_times
+
+    df = emergency_care_waiting_times.get_latest_waiting_times()
+
+Construction Output
+~~~~~~~~~~~~~~~~~~~
+
+Quarterly construction output index for Northern Ireland.
+
+.. code-block:: python
+
+    from bolster.data_sources.nisra import construction_output
+
+    df = construction_output.get_latest_construction_output()
+
+Economic Indicators
+~~~~~~~~~~~~~~~~~~~
+
+Composite economic indicators including GVA and productivity measures.
+
+.. code-block:: python
+
+    from bolster.data_sources.nisra import economic_indicators
+
+    df = economic_indicators.get_latest_economic_indicators()
+
+Index of Production / Services
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Monthly production and services indices.
+
+.. code-block:: python
+
+    from bolster.data_sources.nisra import index_of_production, index_of_services
+
+    df_prod = index_of_production.get_latest_index()
+    df_serv = index_of_services.get_latest_index()
+
+Composite Economic Index
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+The headline NI Composite Economic Index.
+
+.. code-block:: python
+
+    from bolster.data_sources.nisra import composite_index
+
+    df = composite_index.get_latest_composite_index()
+
+Registrar General Annual Report
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Annual summary of births, deaths, marriages, and divorces.
+
+.. code-block:: python
+
+    from bolster.data_sources.nisra import registrar_general
+
+    df = registrar_general.get_latest_registrar_general()
+
+Tourism — Occupancy
+~~~~~~~~~~~~~~~~~~~
+
+Monthly occupancy rates for hotels and guest accommodation.
+
+.. code-block:: python
+
+    from bolster.data_sources.nisra.tourism import occupancy
+
+    df = occupancy.get_latest_occupancy()
+
+Tourism — Visitor Statistics
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Quarterly visitor numbers and spend.
+
+.. code-block:: python
+
+    from bolster.data_sources.nisra.tourism import visitor_statistics
+
+    df = visitor_statistics.get_latest_visitor_statistics()
+
+----
+
+PSNI
+----
+
+The `Police Service of Northern Ireland <https://www.psni.police.uk/>`_
+publishes open-data releases covering crime and road safety.  All PSNI modules
+live under :mod:`bolster.data_sources.psni`.
+
+Crime Statistics
+~~~~~~~~~~~~~~~~
+
+Monthly crime statistics broken down by offence type, district command unit,
+and outcome.
+
+.. code-block:: python
+
+    from bolster.data_sources.psni import crime_statistics
+
+    df = crime_statistics.get_latest_crime_statistics()
+
+.. code-block:: console
+
+    $ bolster nisra crime-statistics   # proxied via nisra group
+
+Road Traffic Collisions
+~~~~~~~~~~~~~~~~~~~~~~~
+
+Annual road traffic collision data with casualty severity and road type.
+
+.. code-block:: python
+
+    from bolster.data_sources.psni import road_traffic_collisions
+
+    df = road_traffic_collisions.get_latest_collisions()
+
+----
+
+DVA — Driver and Vehicle Agency
+--------------------------------
+
+Monthly test statistics from the NI Driver and Vehicle Agency.
+
+.. code-block:: python
+
+    from bolster.data_sources import dva
+
+    vehicles = dva.get_vehicle_test_statistics()
+    drivers  = dva.get_driver_test_statistics()
+    theory   = dva.get_theory_test_statistics()
+
+.. code-block:: console
+
+    $ bolster dva vehicle-tests
+    $ bolster dva driver-tests
+    $ bolster dva theory-tests
+
+----
+
+NI Water
+--------
+
+Drinking water quality data for all NI supply zones.
+
+.. code-block:: python
+
+    from bolster.data_sources.ni_water import get_water_quality, get_water_quality_by_zone
+
+    df = get_water_quality()
+    zone = get_water_quality_by_zone("BALM")  # Belfast Malone
+
+.. code-block:: console
+
+    $ bolster water-quality --postcode "BT1 1AA"
+
+----
+
+EONI — Electoral Office for Northern Ireland
+--------------------------------------------
+
+NI Assembly election results (2016 and 2022).
+
+.. code-block:: python
+
+    from bolster.data_sources.eoni import get_results
+
+    df_2022 = get_results(2022)
+    df_2016 = get_results(2016)
+
+.. code-block:: console
+
+    $ bolster ni-elections 2022
+
+----
+
+NI House Price Index
+--------------------
+
+Standardised house price index for Northern Ireland.
+
+.. code-block:: python
+
+    from bolster.data_sources.ni_house_price_index import build
+
+    df = build()
+
+.. code-block:: console
+
+    $ bolster ni-house-prices
+
+----
+
+Companies House
+---------------
+
+UK Companies House public data — basic company details and registered
+companies connected to a given address (useful for research on specific
+organisations).
+
+.. code-block:: python
+
+    from bolster.data_sources.companies_house import (
+        query_basic_company_data,
+        get_companies_house_records_that_might_be_in_farset,
+    )
+
+    details = query_basic_company_data("12345678")
+
+.. code-block:: console
+
+    $ bolster companies-house --query "Farset Labs"
+
+----
+
+Met Office
+----------
+
+UK precipitation maps from the Met Office DataPoint API.
+
+Requires the environment variable ``MET_OFFICE_API_KEY``.
+
+.. code-block:: python
+
+    from bolster.data_sources.metoffice import get_uk_precipitation
+
+    img = get_uk_precipitation(order_name="my-order")
+
+.. code-block:: console
+
+    $ bolster get-precipitation --order-name "my-order"
+
+----
+
+Gender Pay Gap
+--------------
+
+UK Gender Pay Gap reporting data from 2017 to present (all employers with
+250+ employees).
+
+.. code-block:: python
+
+    from bolster.data_sources import gender_pay_gap
+
+    df = gender_pay_gap.get_gender_pay_gap_data()
+
+.. code-block:: console
+
+    $ bolster gender-pay-gap
+
+----
+
+Wikipedia
+---------
+
+Structured data from NI-related Wikipedia tables (e.g. the NI Executive
+composition table).
+
+.. code-block:: python
+
+    from bolster.data_sources.wikipedia import get_ni_executive_basic_table
+
+    df = get_ni_executive_basic_table()
+
+.. code-block:: console
+
+    $ bolster ni-executive
+
+----
+
+Discovering New Publications
+-----------------------------
+
+NISRA publishes new datasets regularly.  Use the RSS feed integration to
+discover publications before they are implemented as modules:
+
+.. code-block:: console
+
+    $ bolster nisra feed --limit 20
+
+Or programmatically:
+
+.. code-block:: python
+
+    from bolster.utils.rss import get_nisra_statistics_feed
+
+    feed = get_nisra_statistics_feed(limit=20)
+    for entry in feed.entries:
+        print(entry.published.date(), entry.title)
+
+----
+
+See Also
+--------
+
+- :doc:`data_source_development` — how to add a new data source module
+- :doc:`api` — full API reference for all modules

--- a/docs/development/auto-versioning.md
+++ b/docs/development/auto-versioning.md
@@ -46,7 +46,7 @@ The system uses multiple signals to determine version bump:
 
 ### Workflow Steps
 
-```mermaid
+```text
 graph TD
     A[PR Merged to main] --> B[Analyze Changes]
     B --> C{Should Release?}

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,27 +1,35 @@
 Welcome to Bolster's documentation!
 ======================================
 
-Bolster is a comprehensive Python utility library for data science, web scraping,
-cloud services, and general development workflows. It provides tools for data processing,
-concurrency management, and access to Northern Ireland and UK data sources.
+Bolster is a Python utility library that provides standardised, ready-to-use
+access to Northern Ireland and UK government data sources alongside a set of
+general-purpose helpers for data processing, web scraping, and cloud
+integrations.
+
+**Key areas:**
+
+- :doc:`Data sources <data_sources>` — NISRA, PSNI, DVA, NI Water, EONI, Companies House, Met Office, and more
+- :doc:`CLI <api>` — command-line access to every data source (``bolster --help``)
+- :doc:`Usage examples <usage>` — concurrency helpers, data transformation, HTTP utilities
 
 .. toctree::
    :maxdepth: 2
-   :caption: User Guide:
+   :caption: User Guide
 
    readme
    installation
    usage
+   data_sources
 
 .. toctree::
    :maxdepth: 3
-   :caption: API Reference:
+   :caption: API Reference
 
    api
 
 .. toctree::
    :maxdepth: 2
-   :caption: Development:
+   :caption: Development
 
    contributing
    data_source_development

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -33,6 +33,8 @@ integrations.
 
    contributing
    data_source_development
+   development/auto-versioning
+   quality-gate-system
    authors
    history
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -4,48 +4,40 @@
 Installation
 ============
 
-
 Stable release
 --------------
 
-To install Bolster, run this command in your terminal:
+Install Bolster from PyPI with ``pip``:
 
 .. code-block:: console
 
     $ pip install bolster
 
-This is the preferred method to install Bolster, as it will always install the most recent stable release.
+Or with `uv <https://docs.astral.sh/uv/>`_ (recommended for development):
 
-If you don't have `pip`_ installed, this `Python installation guide`_ can guide
-you through the process.
+.. code-block:: console
 
-.. _pip: https://pip.pypa.io
-.. _Python installation guide: http://docs.python-guide.org/en/latest/starting/installation/
-
+    $ uv add bolster
 
 From sources
 ------------
 
-The sources for Bolster can be downloaded from the `Github repo`_.
-
-You can either clone the public repository:
+Clone the repository and install in editable mode using ``uv``:
 
 .. code-block:: console
 
-    $ git clone git://github.com/andrewbolster/bolster
+    $ git clone https://github.com/andrewbolster/bolster.git
+    $ cd bolster
+    $ uv sync --all-extras
 
-Or download the `tarball`_:
+This installs all runtime and development dependencies (test, docs, cloud
+extras) into an isolated virtual environment managed by ``uv``.
+
+To activate the environment or run a one-off command:
 
 .. code-block:: console
 
-    $ curl -OJL https://github.com/andrewbolster/bolster/tarball/master
-
-Once you have a copy of the source, you can install it with:
-
-.. code-block:: console
-
-    $ python setup.py install
-
+    $ uv run pytest tests/ -v
+    $ uv run bolster --help
 
 .. _Github repo: https://github.com/andrewbolster/bolster
-.. _tarball: https://github.com/andrewbolster/bolster/tarball/master

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,6 +94,9 @@ markers = [
     "network: marks tests requiring network access (deselect with '-m \"not network\"')",
     "integration: marks optional integration tests requiring real network (run with '-m integration')"
 ]
+filterwarnings = [
+    "ignore::UserWarning:openpyxl",  # header/footer parse errors in government Excel files
+]
 
 [tool.ruff]
 # Select rule categories - adding more for quality gate

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,7 +91,8 @@ addopts = [
 ]
 markers = [
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",
-    "network: marks tests requiring network access (deselect with '-m \"not network\"')"
+    "network: marks tests requiring network access (deselect with '-m \"not network\"')",
+    "integration: marks optional integration tests requiring real network (run with '-m integration')"
 ]
 
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,9 +94,7 @@ markers = [
     "network: marks tests requiring network access (deselect with '-m \"not network\"')",
     "integration: marks optional integration tests requiring real network (run with '-m integration')"
 ]
-filterwarnings = [
-    "ignore::UserWarning:openpyxl",  # header/footer parse errors in government Excel files
-]
+filterwarnings = []
 
 [tool.ruff]
 # Select rule categories - adding more for quality gate

--- a/src/bolster/__init__.py
+++ b/src/bolster/__init__.py
@@ -13,7 +13,7 @@ What's in here:
 Quick examples:
 
     >>> from bolster.data_sources import ni_water
-    >>> quality_data = ni_water.get_water_quality_by_zone('BALM')  # doctest: +SKIP
+    >>> quality_data = ni_water.get_water_quality_by_zone('BALM')
 
     >>> from bolster.stats import add_totals
     >>> import pandas as pd

--- a/src/bolster/__init__.py
+++ b/src/bolster/__init__.py
@@ -13,7 +13,7 @@ What's in here:
 Quick examples:
 
     >>> from bolster.data_sources import ni_water
-    >>> quality_data = ni_water.get_water_quality_by_zone('BALM')
+    >>> quality_data = ni_water.get_water_quality_by_zone('BALM')  # doctest: +SKIP
 
     >>> from bolster.stats import add_totals
     >>> import pandas as pd

--- a/src/bolster/__init__.py
+++ b/src/bolster/__init__.py
@@ -13,8 +13,8 @@ What's in here:
 Quick examples:
 
     >>> from bolster.data_sources import ni_water
-    >>> quality_data = ni_water.get_water_quality_by_zone('BALM')
-    >>> 'NI Hardness Classification' in quality_data
+    >>> quality_data = ni_water.get_water_quality()
+    >>> 'NI Hardness Classification' in quality_data.columns
     True
 
     >>> from bolster.stats import add_totals

--- a/src/bolster/__init__.py
+++ b/src/bolster/__init__.py
@@ -14,6 +14,8 @@ Quick examples:
 
     >>> from bolster.data_sources import ni_water
     >>> quality_data = ni_water.get_water_quality_by_zone('BALM')
+    >>> 'NI Hardness Classification' in quality_data
+    True
 
     >>> from bolster.stats import add_totals
     >>> import pandas as pd

--- a/src/bolster/cli.py
+++ b/src/bolster/cli.py
@@ -1427,7 +1427,7 @@ def nisra_deaths_cmd(latest, dimension, output_format, force_refresh, save):
     - Place of death (hospital, home, care home, etc.)
 
     Examples:
-    --------
+    ---------
     Get COVID-19 and flu/pneumonia deaths::
 
         bolster nisra deaths --latest --dimension totals
@@ -1449,7 +1449,7 @@ def nisra_deaths_cmd(latest, dimension, output_format, force_refresh, save):
         bolster nisra deaths --latest --force-refresh
 
     Notes:
-    -----
+    ------
     - Based on registration date, not death occurrence date
     - Most deaths registered within 5 days in Northern Ireland
     - Weekly files are provisional and subject to revision
@@ -1589,7 +1589,7 @@ def nisra_labour_market_cmd(latest, table, output_format, force_refresh, save):
     internationally agreed concepts and definitions.
 
     Examples:
-    --------
+    ---------
     Get latest employment data by age and sex::
 
         bolster nisra labour-market --latest --table employment
@@ -1615,7 +1615,7 @@ def nisra_labour_market_cmd(latest, table, output_format, force_refresh, save):
         bolster nisra labour-market --latest --force-refresh
 
     Notes:
-    -----
+    ------
     - Survey data with sampling variability (see NISRA notes on confidence intervals)
     - Quarterly publications covering 3-month rolling periods
     - Some estimates based on small samples (indicated by shading in source)
@@ -1794,7 +1794,7 @@ def nisra_births_cmd(latest, event_type, output_format, force_refresh, save):
     Most births are registered within 42 days in Northern Ireland.
 
     Examples:
-    --------
+    ---------
     Get latest births by registration date::
 
         bolster nisra births --latest --event-type registration
@@ -1820,7 +1820,7 @@ def nisra_births_cmd(latest, event_type, output_format, force_refresh, save):
         bolster nisra births --latest --force-refresh
 
     Notes:
-    -----
+    ------
     - Monthly time series from 2006 to present
     - Final data for years up to and including 2024
     - Provisional and subject to change for current year
@@ -1846,7 +1846,7 @@ def nisra_births_cmd(latest, event_type, output_format, force_refresh, save):
         • Helps identify registration delays/backlogs
 
     Returns:
-    -------
+    --------
     DataFrame
         - month: First day of month (datetime)
         - sex: Persons (total), Male, or Female
@@ -1986,7 +1986,7 @@ def nisra_population_cmd(latest, area, year, output_format, force_refresh, save)
     Mid-year estimates are referenced to June 30th of each year.
 
     Examples:
-    --------
+    ---------
     Get latest NI overall population::
 
         bolster nisra population --latest
@@ -2012,7 +2012,7 @@ def nisra_population_cmd(latest, area, year, output_format, force_refresh, save)
         bolster nisra population --latest --format json
 
     Notes:
-    -----
+    ------
     - Published annually ~6 months after reference date
     - Reference date: June 30th of each year
     - Historical data for NI overall from 1971
@@ -2032,7 +2032,7 @@ def nisra_population_cmd(latest, area, year, output_format, force_refresh, save)
         All geographic breakdowns
 
     Returns:
-    -------
+    --------
     DataFrame
         - area, area_code, area_name: Geographic identifiers
         - year: Reference year (mid-year estimate as of June 30th)
@@ -2131,7 +2131,7 @@ def nisra_marriages_cmd(latest, year, output_format, force_refresh, save):
     current year and final figures for previous years.
 
     Examples:
-    --------
+    ---------
     Get latest marriages data::
 
         bolster nisra marriages --latest
@@ -2153,7 +2153,7 @@ def nisra_marriages_cmd(latest, year, output_format, force_refresh, save):
         bolster nisra marriages --latest --force-refresh
 
     Notes:
-    -----
+    ------
     - Monthly time series from 2006 to present
     - Final data for years up to and including 2024
     - Provisional and subject to change for current year
@@ -2168,7 +2168,7 @@ def nisra_marriages_cmd(latest, year, output_format, force_refresh, save):
     • January-February typically have the lowest numbers
 
     Returns:
-    -------
+    --------
     DataFrame
         - date: First day of month (datetime)
         - year: Year of registration
@@ -2432,7 +2432,7 @@ def nisra_occupancy_cmd(latest, year, accommodation, data_type, output_format, f
         sold : Number of rooms and beds sold monthly
 
     Examples:
-    --------
+    ---------
     Get latest hotel occupancy rates (default)::
 
         bolster nisra occupancy --latest
@@ -2466,7 +2466,7 @@ def nisra_occupancy_cmd(latest, year, accommodation, data_type, output_format, f
         bolster nisra occupancy --latest --save occupancy.csv
 
     Notes:
-    -----
+    ------
     - Hotel data: 2011-present (~65% average room occupancy)
     - SSA data: 2013-present (~33% average room occupancy)
     - Room occupancy is typically higher than bed occupancy
@@ -2481,7 +2481,7 @@ def nisra_occupancy_cmd(latest, year, accommodation, data_type, output_format, f
     - January-February typically have the lowest occupancy
 
     Returns:
-    -------
+    --------
     DataFrame (rates)
         - date: First day of month (datetime)
         - year: Year
@@ -3406,7 +3406,7 @@ def nisra_index_of_production_cmd(
 def nisra_construction_output_cmd(
     latest, year, quarter, start_year, end_year, output_format, force_refresh, save, summary, growth
 ):
-    """NISRA Construction Output Statistics - Quarterly Economic Indicator.
+    r"""NISRA Construction Output Statistics - Quarterly Economic Indicator.
 
     Measures volume and value of construction output in Northern Ireland across
     all work, new work, and repair & maintenance. Chained volume measure data
@@ -3465,7 +3465,7 @@ def nisra_construction_output_cmd(
             - all_work_index: Total construction output index (NSA)
             - new_work_index: New construction work index (NSA)
             - repair_maintenance_index: Repair & maintenance index (SA)
-            - *_yoy_growth: YoY % change (if --growth specified)
+            - \*_yoy_growth: YoY % change (if --growth specified)
 
     Note:
         Source: NISRA Economic & Labour Market Statistics Branch
@@ -3974,12 +3974,12 @@ def nisra_wellbeing_cmd(latest, metric, year, output_format, force_refresh, save
         force_refresh: Force re-download even if cached
         save: Save data to file (specify filename)
 
-    Metrics:
-        personal: ONS4 measures: Life Satisfaction, Worthwhile, Happiness, Anxiety
-            Scores from 0-10 (higher is better, except Anxiety where lower is better)
-        loneliness: Proportion feeling lonely at least some of the time
-        self-efficacy: Mean self-efficacy scores (range 5-25)
-        summary: Combined latest values for all measures
+    Metrics (personal, loneliness, self-efficacy, summary):
+        personal - ONS4 measures (Life Satisfaction, Worthwhile, Happiness, Anxiety);
+        scores 0-10 (higher is better, except Anxiety).
+        loneliness - Proportion feeling lonely at least some of the time.
+        self-efficacy - Mean self-efficacy scores (range 5-25).
+        summary - Combined latest values for all measures.
 
     Examples:
         Get personal wellbeing (ONS4 measures)::
@@ -4144,57 +4144,22 @@ def nisra_cancer_cmd(latest, target, dimension, year, output_format, force_refre
     Retrieves cancer waiting times performance data for Northern Ireland from the
     Department of Health, tracking progress against ministerial targets.
 
-    Parameters
-    ----------
-    target : str
-        14-day : Urgent breast referrals seen within 14 days (breast cancer only)
-        31-day : Treatment within 31 days of decision to treat (all cancers)
-        62-day : Treatment within 62 days of urgent GP referral (all cancers)
-        referrals : Monthly breast cancer referral volumes
-    dimension : str
-        trust : Breakdown by HSC Trust (Belfast, Northern, South Eastern, Southern, Western)
-        tumour : Breakdown by Tumour Site (Breast, Lung, Skin, Urological, etc.)
-                 Note: 14-day target only available for breast cancer
+    Targets: 14-day (urgent breast referrals), 31-day (decision to treat),
+    62-day (urgent GP referral), referrals (monthly breast volumes).
+    Dimensions: trust (HSC Trust breakdown) or tumour (tumour site breakdown).
 
-    Examples:
-    --------
-    Get latest 31-day performance by trust::
+    Examples::
 
         bolster nisra cancer-waiting-times --latest
-
-    Get 62-day performance by tumour site::
-
         bolster nisra cancer-waiting-times --latest --target 62-day --dimension tumour
-
-    Get 14-day breast cancer performance::
-
         bolster nisra cancer-waiting-times --latest --target 14-day
-
-    Get NI-wide summary for 2024::
-
         bolster nisra cancer-waiting-times --latest --year 2024 --summary
-
-    Save to file::
-
         bolster nisra cancer-waiting-times --latest --save cancer.csv
 
-    Key Insights (as of 2025)
-    -------------------------
-    - 31-day target (95%): NI achieving ~90% average
-    - 62-day target (95%): Performance collapsed to ~32% (crisis level)
-    - 14-day breast target: Dropped from 77% (2020) to 17% (2025)
-    - Trust disparities: Belfast 82% vs Western 97% for 31-day
+    Key insights (as of 2025): 31-day target NI at ~90%; 62-day collapsed to ~32%;
+    14-day breast dropped from 77% (2020) to 17% (2025). Data from Q1 2008 to present.
 
-    Notes:
-    -----
-    - Data from Q1 2008 to present (monthly)
-    - Some Belfast Trust data missing Q2-Q3 2024 (encompass system rollout)
-    - Regional breast service transition from May 2025
-    - COVID-19 impact visible in 2020 volumes and post-2020 backlogs
-
-    Source
-    ------
-    https://www.health-ni.gov.uk/articles/cancer-waiting-times
+    Source: https://www.health-ni.gov.uk/articles/cancer-waiting-times
     """
     console = Console()
 
@@ -4343,7 +4308,7 @@ def nisra_emergency_care_cmd(output_format, trust, attendance_type, year, save):
         Belfast, Northern, South Eastern, Southern, Western
 
     Examples:
-    --------
+    ---------
     Get all data as CSV::
 
         bolster nisra emergency-care

--- a/src/bolster/data_sources/cineworld.py
+++ b/src/bolster/data_sources/cineworld.py
@@ -17,20 +17,20 @@ Data is refreshed multiple times daily to maintain accuracy for current and upco
 Example:
     Retrieve current cinema listings for Belfast Cineworld:
 
-        >>> from bolster.data_sources import cineworld
+        >>> from bolster.data_sources import cineworld  # doctest: +SKIP
         >>> # Get today's listings for Belfast cinema (site code 117)
-        >>> listings = cineworld.get_cinema_listings(117)
-        >>> print(f"Found {len(listings)} films showing today")
+        >>> listings = cineworld.get_cinema_listings(117)  # doctest: +SKIP
+        >>> print(f"Found {len(listings)} films showing today")  # doctest: +SKIP
 
         >>> # Check what data is available for each film
-        >>> first_film = listings[0]
-        >>> print(f"Film: {first_film['name']}")
-        >>> print(f"Release Year: {first_film['releaseYear']}")
+        >>> first_film = listings[0]  # doctest: +SKIP
+        >>> print(f"Film: {first_film['name']}")  # doctest: +SKIP
+        >>> print(f"Release Year: {first_film['releaseYear']}")  # doctest: +SKIP
 
         >>> # Get listings for a specific date
-        >>> from datetime import date, timedelta
-        >>> tomorrow = date.today() + timedelta(days=1)
-        >>> tomorrow_listings = cineworld.get_cinema_listings(117, tomorrow)
+        >>> from datetime import date, timedelta  # doctest: +SKIP
+        >>> tomorrow = date.today() + timedelta(days=1)  # doctest: +SKIP
+        >>> tomorrow_listings = cineworld.get_cinema_listings(117, tomorrow)  # doctest: +SKIP
 
 Site Code 117 maps to Belfast, you're on your own for the rest.
 """
@@ -57,10 +57,10 @@ def get_cinema_listings(site_code: int = 117, screening_date: date = None) -> li
     Raises:
         Exception: If there was an error making the API request.
 
-    >>> cinema_listings = get_cinema_listings(117)
-    >>> set(cinema_listings[0].keys()).issuperset({'id', 'name','link','weight','releaseYear','releaseDate','attributeIds','date','site_code'})
+    >>> cinema_listings = get_cinema_listings(117)  # doctest: +SKIP
+    >>> set(cinema_listings[0].keys()).issuperset({'id', 'name','link','weight','releaseYear','releaseDate','attributeIds','date','site_code'})  # doctest: +SKIP
     True
-    >>> list(cinema_listings[0].keys()) # This is likely to break from upstream changes
+    >>> list(cinema_listings[0].keys()) # This is likely to break from upstream changes  # doctest: +SKIP
     ['id', 'name', 'length', 'posterLink', 'videoLink', 'link', 'weight', 'releaseYear', 'releaseDate', 'attributeIds', 'date', 'site_code']
 
     """

--- a/src/bolster/data_sources/cineworld.py
+++ b/src/bolster/data_sources/cineworld.py
@@ -17,20 +17,17 @@ Data is refreshed multiple times daily to maintain accuracy for current and upco
 Example:
     Retrieve current cinema listings for Belfast Cineworld:
 
-        >>> from bolster.data_sources import cineworld  # doctest: +SKIP
+        >>> from bolster.data_sources import cineworld
         >>> # Get today's listings for Belfast cinema (site code 117)
-        >>> listings = cineworld.get_cinema_listings(117)  # doctest: +SKIP
-        >>> print(f"Found {len(listings)} films showing today")  # doctest: +SKIP
+        >>> listings = cineworld.get_cinema_listings(117)
 
         >>> # Check what data is available for each film
-        >>> first_film = listings[0]  # doctest: +SKIP
-        >>> print(f"Film: {first_film['name']}")  # doctest: +SKIP
-        >>> print(f"Release Year: {first_film['releaseYear']}")  # doctest: +SKIP
+        >>> first_film = listings[0]
 
         >>> # Get listings for a specific date
-        >>> from datetime import date, timedelta  # doctest: +SKIP
-        >>> tomorrow = date.today() + timedelta(days=1)  # doctest: +SKIP
-        >>> tomorrow_listings = cineworld.get_cinema_listings(117, tomorrow)  # doctest: +SKIP
+        >>> from datetime import date, timedelta
+        >>> tomorrow = date.today() + timedelta(days=1)
+        >>> tomorrow_listings = cineworld.get_cinema_listings(117, tomorrow)
 
 Site Code 117 maps to Belfast, you're on your own for the rest.
 """
@@ -57,10 +54,10 @@ def get_cinema_listings(site_code: int = 117, screening_date: date = None) -> li
     Raises:
         Exception: If there was an error making the API request.
 
-    >>> cinema_listings = get_cinema_listings(117)  # doctest: +SKIP
-    >>> set(cinema_listings[0].keys()).issuperset({'id', 'name','link','weight','releaseYear','releaseDate','attributeIds','date','site_code'})  # doctest: +SKIP
+    >>> cinema_listings = get_cinema_listings(117)
+    >>> set(cinema_listings[0].keys()).issuperset({'id', 'name','link','weight','releaseYear','releaseDate','attributeIds','date','site_code'})
     True
-    >>> list(cinema_listings[0].keys()) # This is likely to break from upstream changes  # doctest: +SKIP
+    >>> list(cinema_listings[0].keys()) # This is likely to break from upstream changes
     ['id', 'name', 'length', 'posterLink', 'videoLink', 'link', 'weight', 'releaseYear', 'releaseDate', 'attributeIds', 'date', 'site_code']
 
     """

--- a/src/bolster/data_sources/cineworld.py
+++ b/src/bolster/data_sources/cineworld.py
@@ -18,16 +18,11 @@ Example:
     Retrieve current cinema listings for Belfast Cineworld:
 
         >>> from bolster.data_sources import cineworld
-        >>> # Get today's listings for Belfast cinema (site code 117)
         >>> listings = cineworld.get_cinema_listings(117)
-
-        >>> # Check what data is available for each film
-        >>> first_film = listings[0]
-
-        >>> # Get listings for a specific date
-        >>> from datetime import date, timedelta
-        >>> tomorrow = date.today() + timedelta(days=1)
-        >>> tomorrow_listings = cineworld.get_cinema_listings(117, tomorrow)
+        >>> len(listings) > 0
+        True
+        >>> 'name' in listings[0]
+        True
 
 Site Code 117 maps to Belfast, you're on your own for the rest.
 """

--- a/src/bolster/data_sources/companies_house.py
+++ b/src/bolster/data_sources/companies_house.py
@@ -43,7 +43,7 @@ def get_basic_company_data_url() -> str:
     """
     base_url = "http://download.companieshouse.gov.uk/en_output.html"
     # TODO: Network integration testing - requires active Companies House website
-    s = bs4.BeautifulSoup(session.get(base_url).content)  # pragma: no cover
+    s = bs4.BeautifulSoup(session.get(base_url).content, features="lxml")  # pragma: no cover
     for a in s.find_all("a"):  # pragma: no cover
         if a.get("href").startswith("BasicCompanyDataAsOneFile"):  # pragma: no cover
             url = f"http://download.companieshouse.gov.uk/{a.get('href')}"  # pragma: no cover

--- a/src/bolster/data_sources/companies_house.py
+++ b/src/bolster/data_sources/companies_house.py
@@ -12,17 +12,17 @@ as of the snapshot date.
 Example:
     Basic usage for querying company data:
 
-        >>> from bolster.data_sources import companies_house
+        >>> from bolster.data_sources import companies_house  # doctest: +SKIP
         >>> # Get all companies (warning: this is very large!)
-        >>> for company in companies_house.query_basic_company_data():
-        ...     print(company['CompanyName'], company['CompanyNumber'])
-        ...     break  # Just show first result
+        >>> for company in companies_house.query_basic_company_data():  # doctest: +SKIP
+        ...     print(company['CompanyName'], company['CompanyNumber'])  # doctest: +SKIP
+        ...     break  # Just show first result  # doctest: +SKIP
 
         >>> # Query companies that might be associated with Farset Labs
-        >>> farset_companies = list(companies_house.query_basic_company_data(
-        ...     companies_house.companies_house_record_might_be_farset
-        ... ))
-        >>> print(f"Found {len(farset_companies)} potential Farset-related companies")
+        >>> farset_companies = list(companies_house.query_basic_company_data(  # doctest: +SKIP
+        ...     companies_house.companies_house_record_might_be_farset  # doctest: +SKIP
+        ... ))  # doctest: +SKIP
+        >>> print(f"Found {len(farset_companies)} potential Farset-related companies")  # doctest: +SKIP
 
 The module provides utilities for downloading and parsing the complete UK company registry,
 with built-in filtering capabilities for targeted analysis.

--- a/src/bolster/data_sources/companies_house.py
+++ b/src/bolster/data_sources/companies_house.py
@@ -13,15 +13,11 @@ Example:
     Basic usage for querying company data:
 
         >>> from bolster.data_sources import companies_house
-        >>> # Get all companies (warning: this is very large!)
-        >>> for company in companies_house.query_basic_company_data():
-        ...     break  # Just show first result
-
-        >>> # Query companies that might be associated with Farset Labs
         >>> farset_companies = list(companies_house.query_basic_company_data(
         ...     companies_house.companies_house_record_might_be_farset
         ... ))
-        >>> print(f"Found {len(farset_companies)} potential Farset-related companies")
+        >>> len(farset_companies) > 0
+        True
 
 The module provides utilities for downloading and parsing the complete UK company registry,
 with built-in filtering capabilities for targeted analysis.

--- a/src/bolster/data_sources/companies_house.py
+++ b/src/bolster/data_sources/companies_house.py
@@ -12,17 +12,16 @@ as of the snapshot date.
 Example:
     Basic usage for querying company data:
 
-        >>> from bolster.data_sources import companies_house  # doctest: +SKIP
+        >>> from bolster.data_sources import companies_house
         >>> # Get all companies (warning: this is very large!)
-        >>> for company in companies_house.query_basic_company_data():  # doctest: +SKIP
-        ...     print(company['CompanyName'], company['CompanyNumber'])  # doctest: +SKIP
-        ...     break  # Just show first result  # doctest: +SKIP
+        >>> for company in companies_house.query_basic_company_data():
+        ...     break  # Just show first result
 
         >>> # Query companies that might be associated with Farset Labs
-        >>> farset_companies = list(companies_house.query_basic_company_data(  # doctest: +SKIP
-        ...     companies_house.companies_house_record_might_be_farset  # doctest: +SKIP
-        ... ))  # doctest: +SKIP
-        >>> print(f"Found {len(farset_companies)} potential Farset-related companies")  # doctest: +SKIP
+        >>> farset_companies = list(companies_house.query_basic_company_data(
+        ...     companies_house.companies_house_record_might_be_farset
+        ... ))
+        >>> print(f"Found {len(farset_companies)} potential Farset-related companies")
 
 The module provides utilities for downloading and parsing the complete UK company registry,
 with built-in filtering capabilities for targeted analysis.

--- a/src/bolster/data_sources/dva.py
+++ b/src/bolster/data_sources/dva.py
@@ -26,22 +26,22 @@ Publication Details:
     - Data Source: DVA Business & Regulatory Statistics
 
 Example:
-    >>> from bolster.data_sources import dva
+    >>> from bolster.data_sources import dva  # doctest: +SKIP
     >>> # Get latest vehicle test statistics
-    >>> df = dva.get_latest_vehicle_tests()
-    >>> print(df.tail())
+    >>> df = dva.get_latest_vehicle_tests()  # doctest: +SKIP
+    >>> print(df.tail())  # doctest: +SKIP
 
     >>> # Get latest driver test statistics
-    >>> df = dva.get_latest_driver_tests()
-    >>> print(f"Latest month: {df.iloc[-1]['month']}")
+    >>> df = dva.get_latest_driver_tests()  # doctest: +SKIP
+    >>> print(f"Latest month: {df.iloc[-1]['month']}")  # doctest: +SKIP
 
     >>> # Get latest theory test statistics
-    >>> df = dva.get_latest_theory_tests()
-    >>> print(f"Total tests: {df['tests_conducted'].sum():,}")
+    >>> df = dva.get_latest_theory_tests()  # doctest: +SKIP
+    >>> print(f"Total tests: {df['tests_conducted'].sum():,}")  # doctest: +SKIP
 
     >>> # Get all test types combined
-    >>> data = dva.get_latest_all_tests()
-    >>> print(data.keys())  # ['vehicle', 'driver', 'theory']
+    >>> data = dva.get_latest_all_tests()  # doctest: +SKIP
+    >>> print(data.keys())  # ['vehicle', 'driver', 'theory']  # doctest: +SKIP
 """
 
 import contextlib
@@ -135,8 +135,8 @@ def get_latest_dva_publication_url() -> tuple[str, str, datetime]:
         DVADataNotFoundError: If unable to find any recent publication
 
     Example:
-        >>> url, title, pub_date = get_latest_dva_publication_url()
-        >>> print(f"Latest: {title} (published {pub_date.strftime('%Y-%m-%d')})")
+        >>> url, title, pub_date = get_latest_dva_publication_url()  # doctest: +SKIP
+        >>> print(f"Latest: {title} (published {pub_date.strftime('%Y-%m-%d')})")  # doctest: +SKIP
     """
     from dateutil.relativedelta import relativedelta
 
@@ -263,8 +263,8 @@ def parse_vehicle_tests(file_path: str | Path) -> pd.DataFrame:
             - rolling_12_month_total: int (optional, rolling 12-month sum)
 
     Example:
-        >>> df = parse_vehicle_tests("dva-monthly-tests-december-2025.xlsx")
-        >>> print(df.tail())
+        >>> df = parse_vehicle_tests("dva-monthly-tests-december-2025.xlsx")  # doctest: +SKIP
+        >>> print(df.tail())  # doctest: +SKIP
     """
     from openpyxl import load_workbook
 
@@ -342,8 +342,8 @@ def parse_driver_tests(file_path: str | Path) -> pd.DataFrame:
             - rolling_12_month_total: int (optional, rolling 12-month sum)
 
     Example:
-        >>> df = parse_driver_tests("dva-monthly-tests-december-2025.xlsx")
-        >>> print(df.tail())
+        >>> df = parse_driver_tests("dva-monthly-tests-december-2025.xlsx")  # doctest: +SKIP
+        >>> print(df.tail())  # doctest: +SKIP
     """
     from openpyxl import load_workbook
 
@@ -421,8 +421,8 @@ def parse_theory_tests(file_path: str | Path) -> pd.DataFrame:
             - rolling_12_month_total: int (optional, rolling 12-month sum)
 
     Example:
-        >>> df = parse_theory_tests("dva-monthly-tests-december-2025.xlsx")
-        >>> print(df.tail())
+        >>> df = parse_theory_tests("dva-monthly-tests-december-2025.xlsx")  # doctest: +SKIP
+        >>> print(df.tail())  # doctest: +SKIP
     """
     from openpyxl import load_workbook
 
@@ -501,9 +501,9 @@ def get_latest_vehicle_tests(force_refresh: bool = False) -> pd.DataFrame:
         DataFrame with monthly vehicle test data
 
     Example:
-        >>> df = get_latest_vehicle_tests()
-        >>> print(f"Latest month: {df.iloc[-1]['month']} {df.iloc[-1]['year']}")
-        >>> print(f"Tests conducted: {df.iloc[-1]['tests_conducted']:,}")
+        >>> df = get_latest_vehicle_tests()  # doctest: +SKIP
+        >>> print(f"Latest month: {df.iloc[-1]['month']} {df.iloc[-1]['year']}")  # doctest: +SKIP
+        >>> print(f"Tests conducted: {df.iloc[-1]['tests_conducted']:,}")  # doctest: +SKIP
     """
     excel_url, _, _ = get_latest_dva_publication_url()
     file_path = _download_file(excel_url, cache_ttl_hours=168, force_refresh=force_refresh)
@@ -523,9 +523,9 @@ def get_latest_driver_tests(force_refresh: bool = False) -> pd.DataFrame:
         DataFrame with monthly driver test data
 
     Example:
-        >>> df = get_latest_driver_tests()
-        >>> print(f"Latest month: {df.iloc[-1]['month']} {df.iloc[-1]['year']}")
-        >>> print(f"Tests conducted: {df.iloc[-1]['tests_conducted']:,}")
+        >>> df = get_latest_driver_tests()  # doctest: +SKIP
+        >>> print(f"Latest month: {df.iloc[-1]['month']} {df.iloc[-1]['year']}")  # doctest: +SKIP
+        >>> print(f"Tests conducted: {df.iloc[-1]['tests_conducted']:,}")  # doctest: +SKIP
     """
     excel_url, _, _ = get_latest_dva_publication_url()
     file_path = _download_file(excel_url, cache_ttl_hours=168, force_refresh=force_refresh)
@@ -545,9 +545,9 @@ def get_latest_theory_tests(force_refresh: bool = False) -> pd.DataFrame:
         DataFrame with monthly theory test data
 
     Example:
-        >>> df = get_latest_theory_tests()
-        >>> print(f"Latest month: {df.iloc[-1]['month']} {df.iloc[-1]['year']}")
-        >>> print(f"Tests conducted: {df.iloc[-1]['tests_conducted']:,}")
+        >>> df = get_latest_theory_tests()  # doctest: +SKIP
+        >>> print(f"Latest month: {df.iloc[-1]['month']} {df.iloc[-1]['year']}")  # doctest: +SKIP
+        >>> print(f"Tests conducted: {df.iloc[-1]['tests_conducted']:,}")  # doctest: +SKIP
     """
     excel_url, _, _ = get_latest_dva_publication_url()
     file_path = _download_file(excel_url, cache_ttl_hours=168, force_refresh=force_refresh)
@@ -566,10 +566,10 @@ def get_latest_all_tests(force_refresh: bool = False) -> dict[str, pd.DataFrame]
         Dictionary with keys 'vehicle', 'driver', 'theory' containing DataFrames
 
     Example:
-        >>> data = get_latest_all_tests()
-        >>> print(f"Vehicle tests: {len(data['vehicle'])} months")
-        >>> print(f"Driver tests: {len(data['driver'])} months")
-        >>> print(f"Theory tests: {len(data['theory'])} months")
+        >>> data = get_latest_all_tests()  # doctest: +SKIP
+        >>> print(f"Vehicle tests: {len(data['vehicle'])} months")  # doctest: +SKIP
+        >>> print(f"Driver tests: {len(data['driver'])} months")  # doctest: +SKIP
+        >>> print(f"Theory tests: {len(data['theory'])} months")  # doctest: +SKIP
     """
     excel_url, _, _ = get_latest_dva_publication_url()
     file_path = _download_file(excel_url, cache_ttl_hours=168, force_refresh=force_refresh)
@@ -597,9 +597,9 @@ def get_tests_by_year(df: pd.DataFrame, year: int) -> pd.DataFrame:
         DataFrame with only the specified year's data
 
     Example:
-        >>> df = get_latest_vehicle_tests()
-        >>> df_2024 = get_tests_by_year(df, 2024)
-        >>> print(f"2024 total: {df_2024['tests_conducted'].sum():,}")
+        >>> df = get_latest_vehicle_tests()  # doctest: +SKIP
+        >>> df_2024 = get_tests_by_year(df, 2024)  # doctest: +SKIP
+        >>> print(f"2024 total: {df_2024['tests_conducted'].sum():,}")  # doctest: +SKIP
     """
     return df[df["year"] == year].reset_index(drop=True)
 
@@ -616,9 +616,9 @@ def get_tests_by_month(df: pd.DataFrame, month: str, year: int) -> pd.DataFrame:
         DataFrame with single row for the specified month
 
     Example:
-        >>> df = get_latest_vehicle_tests()
-        >>> dec_2025 = get_tests_by_month(df, 'December', 2025)
-        >>> print(f"December 2025: {dec_2025['tests_conducted'].values[0]:,}")
+        >>> df = get_latest_vehicle_tests()  # doctest: +SKIP
+        >>> dec_2025 = get_tests_by_month(df, 'December', 2025)  # doctest: +SKIP
+        >>> print(f"December 2025: {dec_2025['tests_conducted'].values[0]:,}")  # doctest: +SKIP
     """
     return df[(df["month"] == month) & (df["year"] == year)].reset_index(drop=True)
 
@@ -635,9 +635,9 @@ def calculate_growth_rates(df: pd.DataFrame, periods: int = 12) -> pd.DataFrame:
             - yoy_growth: Percentage change vs same month previous year
 
     Example:
-        >>> df = get_latest_vehicle_tests()
-        >>> df_growth = calculate_growth_rates(df)
-        >>> print(df_growth[['date', 'tests_conducted', 'yoy_growth']].tail())
+        >>> df = get_latest_vehicle_tests()  # doctest: +SKIP
+        >>> df_growth = calculate_growth_rates(df)  # doctest: +SKIP
+        >>> print(df_growth[['date', 'tests_conducted', 'yoy_growth']].tail())  # doctest: +SKIP
     """
     result = df.copy()
     result["yoy_growth"] = result["tests_conducted"].pct_change(periods=periods) * 100
@@ -662,9 +662,9 @@ def get_summary_statistics(df: pd.DataFrame, start_year: int | None = None, end_
             - months_count: Number of months included
 
     Example:
-        >>> df = get_latest_vehicle_tests()
-        >>> stats = get_summary_statistics(df, start_year=2020)
-        >>> print(f"Average monthly tests since 2020: {stats['monthly_mean']:,.0f}")
+        >>> df = get_latest_vehicle_tests()  # doctest: +SKIP
+        >>> stats = get_summary_statistics(df, start_year=2020)  # doctest: +SKIP
+        >>> print(f"Average monthly tests since 2020: {stats['monthly_mean']:,.0f}")  # doctest: +SKIP
     """
     filtered = df.copy()
 

--- a/src/bolster/data_sources/dva.py
+++ b/src/bolster/data_sources/dva.py
@@ -26,22 +26,19 @@ Publication Details:
     - Data Source: DVA Business & Regulatory Statistics
 
 Example:
-    >>> from bolster.data_sources import dva  # doctest: +SKIP
+    >>> from bolster.data_sources import dva
     >>> # Get latest vehicle test statistics
-    >>> df = dva.get_latest_vehicle_tests()  # doctest: +SKIP
-    >>> print(df.tail())  # doctest: +SKIP
+    >>> df = dva.get_latest_vehicle_tests()
 
     >>> # Get latest driver test statistics
-    >>> df = dva.get_latest_driver_tests()  # doctest: +SKIP
-    >>> print(f"Latest month: {df.iloc[-1]['month']}")  # doctest: +SKIP
+    >>> df = dva.get_latest_driver_tests()
 
     >>> # Get latest theory test statistics
-    >>> df = dva.get_latest_theory_tests()  # doctest: +SKIP
-    >>> print(f"Total tests: {df['tests_conducted'].sum():,}")  # doctest: +SKIP
+    >>> df = dva.get_latest_theory_tests()
 
     >>> # Get all test types combined
-    >>> data = dva.get_latest_all_tests()  # doctest: +SKIP
-    >>> print(data.keys())  # ['vehicle', 'driver', 'theory']  # doctest: +SKIP
+    >>> data = dva.get_latest_all_tests()
+    >>> print(data.keys())  # ['vehicle', 'driver', 'theory']
 """
 
 import contextlib
@@ -135,8 +132,7 @@ def get_latest_dva_publication_url() -> tuple[str, str, datetime]:
         DVADataNotFoundError: If unable to find any recent publication
 
     Example:
-        >>> url, title, pub_date = get_latest_dva_publication_url()  # doctest: +SKIP
-        >>> print(f"Latest: {title} (published {pub_date.strftime('%Y-%m-%d')})")  # doctest: +SKIP
+        >>> url, title, pub_date = get_latest_dva_publication_url()
     """
     from dateutil.relativedelta import relativedelta
 
@@ -263,8 +259,7 @@ def parse_vehicle_tests(file_path: str | Path) -> pd.DataFrame:
             - rolling_12_month_total: int (optional, rolling 12-month sum)
 
     Example:
-        >>> df = parse_vehicle_tests("dva-monthly-tests-december-2025.xlsx")  # doctest: +SKIP
-        >>> print(df.tail())  # doctest: +SKIP
+        >>> df = parse_vehicle_tests("dva-monthly-tests-december-2025.xlsx")
     """
     from openpyxl import load_workbook
 
@@ -342,8 +337,7 @@ def parse_driver_tests(file_path: str | Path) -> pd.DataFrame:
             - rolling_12_month_total: int (optional, rolling 12-month sum)
 
     Example:
-        >>> df = parse_driver_tests("dva-monthly-tests-december-2025.xlsx")  # doctest: +SKIP
-        >>> print(df.tail())  # doctest: +SKIP
+        >>> df = parse_driver_tests("dva-monthly-tests-december-2025.xlsx")
     """
     from openpyxl import load_workbook
 
@@ -421,8 +415,7 @@ def parse_theory_tests(file_path: str | Path) -> pd.DataFrame:
             - rolling_12_month_total: int (optional, rolling 12-month sum)
 
     Example:
-        >>> df = parse_theory_tests("dva-monthly-tests-december-2025.xlsx")  # doctest: +SKIP
-        >>> print(df.tail())  # doctest: +SKIP
+        >>> df = parse_theory_tests("dva-monthly-tests-december-2025.xlsx")
     """
     from openpyxl import load_workbook
 
@@ -501,9 +494,7 @@ def get_latest_vehicle_tests(force_refresh: bool = False) -> pd.DataFrame:
         DataFrame with monthly vehicle test data
 
     Example:
-        >>> df = get_latest_vehicle_tests()  # doctest: +SKIP
-        >>> print(f"Latest month: {df.iloc[-1]['month']} {df.iloc[-1]['year']}")  # doctest: +SKIP
-        >>> print(f"Tests conducted: {df.iloc[-1]['tests_conducted']:,}")  # doctest: +SKIP
+        >>> df = get_latest_vehicle_tests()
     """
     excel_url, _, _ = get_latest_dva_publication_url()
     file_path = _download_file(excel_url, cache_ttl_hours=168, force_refresh=force_refresh)
@@ -523,9 +514,7 @@ def get_latest_driver_tests(force_refresh: bool = False) -> pd.DataFrame:
         DataFrame with monthly driver test data
 
     Example:
-        >>> df = get_latest_driver_tests()  # doctest: +SKIP
-        >>> print(f"Latest month: {df.iloc[-1]['month']} {df.iloc[-1]['year']}")  # doctest: +SKIP
-        >>> print(f"Tests conducted: {df.iloc[-1]['tests_conducted']:,}")  # doctest: +SKIP
+        >>> df = get_latest_driver_tests()
     """
     excel_url, _, _ = get_latest_dva_publication_url()
     file_path = _download_file(excel_url, cache_ttl_hours=168, force_refresh=force_refresh)
@@ -545,9 +534,7 @@ def get_latest_theory_tests(force_refresh: bool = False) -> pd.DataFrame:
         DataFrame with monthly theory test data
 
     Example:
-        >>> df = get_latest_theory_tests()  # doctest: +SKIP
-        >>> print(f"Latest month: {df.iloc[-1]['month']} {df.iloc[-1]['year']}")  # doctest: +SKIP
-        >>> print(f"Tests conducted: {df.iloc[-1]['tests_conducted']:,}")  # doctest: +SKIP
+        >>> df = get_latest_theory_tests()
     """
     excel_url, _, _ = get_latest_dva_publication_url()
     file_path = _download_file(excel_url, cache_ttl_hours=168, force_refresh=force_refresh)
@@ -566,10 +553,7 @@ def get_latest_all_tests(force_refresh: bool = False) -> dict[str, pd.DataFrame]
         Dictionary with keys 'vehicle', 'driver', 'theory' containing DataFrames
 
     Example:
-        >>> data = get_latest_all_tests()  # doctest: +SKIP
-        >>> print(f"Vehicle tests: {len(data['vehicle'])} months")  # doctest: +SKIP
-        >>> print(f"Driver tests: {len(data['driver'])} months")  # doctest: +SKIP
-        >>> print(f"Theory tests: {len(data['theory'])} months")  # doctest: +SKIP
+        >>> data = get_latest_all_tests()
     """
     excel_url, _, _ = get_latest_dva_publication_url()
     file_path = _download_file(excel_url, cache_ttl_hours=168, force_refresh=force_refresh)
@@ -597,9 +581,8 @@ def get_tests_by_year(df: pd.DataFrame, year: int) -> pd.DataFrame:
         DataFrame with only the specified year's data
 
     Example:
-        >>> df = get_latest_vehicle_tests()  # doctest: +SKIP
-        >>> df_2024 = get_tests_by_year(df, 2024)  # doctest: +SKIP
-        >>> print(f"2024 total: {df_2024['tests_conducted'].sum():,}")  # doctest: +SKIP
+        >>> df = get_latest_vehicle_tests()
+        >>> df_2024 = get_tests_by_year(df, 2024)
     """
     return df[df["year"] == year].reset_index(drop=True)
 
@@ -616,9 +599,8 @@ def get_tests_by_month(df: pd.DataFrame, month: str, year: int) -> pd.DataFrame:
         DataFrame with single row for the specified month
 
     Example:
-        >>> df = get_latest_vehicle_tests()  # doctest: +SKIP
-        >>> dec_2025 = get_tests_by_month(df, 'December', 2025)  # doctest: +SKIP
-        >>> print(f"December 2025: {dec_2025['tests_conducted'].values[0]:,}")  # doctest: +SKIP
+        >>> df = get_latest_vehicle_tests()
+        >>> dec_2025 = get_tests_by_month(df, 'December', 2025)
     """
     return df[(df["month"] == month) & (df["year"] == year)].reset_index(drop=True)
 
@@ -635,9 +617,8 @@ def calculate_growth_rates(df: pd.DataFrame, periods: int = 12) -> pd.DataFrame:
             - yoy_growth: Percentage change vs same month previous year
 
     Example:
-        >>> df = get_latest_vehicle_tests()  # doctest: +SKIP
-        >>> df_growth = calculate_growth_rates(df)  # doctest: +SKIP
-        >>> print(df_growth[['date', 'tests_conducted', 'yoy_growth']].tail())  # doctest: +SKIP
+        >>> df = get_latest_vehicle_tests()
+        >>> df_growth = calculate_growth_rates(df)
     """
     result = df.copy()
     result["yoy_growth"] = result["tests_conducted"].pct_change(periods=periods) * 100
@@ -662,9 +643,8 @@ def get_summary_statistics(df: pd.DataFrame, start_year: int | None = None, end_
             - months_count: Number of months included
 
     Example:
-        >>> df = get_latest_vehicle_tests()  # doctest: +SKIP
-        >>> stats = get_summary_statistics(df, start_year=2020)  # doctest: +SKIP
-        >>> print(f"Average monthly tests since 2020: {stats['monthly_mean']:,.0f}")  # doctest: +SKIP
+        >>> df = get_latest_vehicle_tests()
+        >>> stats = get_summary_statistics(df, start_year=2020)
     """
     filtered = df.copy()
 

--- a/src/bolster/data_sources/dva.py
+++ b/src/bolster/data_sources/dva.py
@@ -29,16 +29,23 @@ Example:
     >>> from bolster.data_sources import dva
     >>> # Get latest vehicle test statistics
     >>> df = dva.get_latest_vehicle_tests()
+    >>> 'tests_conducted' in df.columns
+    True
 
     >>> # Get latest driver test statistics
     >>> df = dva.get_latest_driver_tests()
+    >>> len(df) > 0
+    True
 
     >>> # Get latest theory test statistics
     >>> df = dva.get_latest_theory_tests()
+    >>> len(df) > 0
+    True
 
     >>> # Get all test types combined
     >>> data = dva.get_latest_all_tests()
-    >>> print(data.keys())  # ['vehicle', 'driver', 'theory']
+    >>> sorted(data.keys())
+    ['driver', 'theory', 'vehicle']
 """
 
 import contextlib
@@ -133,6 +140,8 @@ def get_latest_dva_publication_url() -> tuple[str, str, datetime]:
 
     Example:
         >>> url, title, pub_date = get_latest_dva_publication_url()
+        >>> url.startswith('https://')
+        True
     """
     from dateutil.relativedelta import relativedelta
 
@@ -495,6 +504,8 @@ def get_latest_vehicle_tests(force_refresh: bool = False) -> pd.DataFrame:
 
     Example:
         >>> df = get_latest_vehicle_tests()
+        >>> 'tests_conducted' in df.columns
+        True
     """
     excel_url, _, _ = get_latest_dva_publication_url()
     file_path = _download_file(excel_url, cache_ttl_hours=168, force_refresh=force_refresh)
@@ -515,6 +526,8 @@ def get_latest_driver_tests(force_refresh: bool = False) -> pd.DataFrame:
 
     Example:
         >>> df = get_latest_driver_tests()
+        >>> len(df) > 0
+        True
     """
     excel_url, _, _ = get_latest_dva_publication_url()
     file_path = _download_file(excel_url, cache_ttl_hours=168, force_refresh=force_refresh)
@@ -535,6 +548,8 @@ def get_latest_theory_tests(force_refresh: bool = False) -> pd.DataFrame:
 
     Example:
         >>> df = get_latest_theory_tests()
+        >>> len(df) > 0
+        True
     """
     excel_url, _, _ = get_latest_dva_publication_url()
     file_path = _download_file(excel_url, cache_ttl_hours=168, force_refresh=force_refresh)
@@ -554,6 +569,8 @@ def get_latest_all_tests(force_refresh: bool = False) -> dict[str, pd.DataFrame]
 
     Example:
         >>> data = get_latest_all_tests()
+        >>> sorted(data.keys())
+        ['driver', 'theory', 'vehicle']
     """
     excel_url, _, _ = get_latest_dva_publication_url()
     file_path = _download_file(excel_url, cache_ttl_hours=168, force_refresh=force_refresh)
@@ -583,6 +600,8 @@ def get_tests_by_year(df: pd.DataFrame, year: int) -> pd.DataFrame:
     Example:
         >>> df = get_latest_vehicle_tests()
         >>> df_2024 = get_tests_by_year(df, 2024)
+        >>> 'tests_conducted' in df_2024.columns
+        True
     """
     return df[df["year"] == year].reset_index(drop=True)
 
@@ -601,6 +620,8 @@ def get_tests_by_month(df: pd.DataFrame, month: str, year: int) -> pd.DataFrame:
     Example:
         >>> df = get_latest_vehicle_tests()
         >>> dec_2025 = get_tests_by_month(df, 'December', 2025)
+        >>> 'tests_conducted' in dec_2025.columns
+        True
     """
     return df[(df["month"] == month) & (df["year"] == year)].reset_index(drop=True)
 
@@ -619,6 +640,8 @@ def calculate_growth_rates(df: pd.DataFrame, periods: int = 12) -> pd.DataFrame:
     Example:
         >>> df = get_latest_vehicle_tests()
         >>> df_growth = calculate_growth_rates(df)
+        >>> 'yoy_growth' in df_growth.columns
+        True
     """
     result = df.copy()
     result["yoy_growth"] = result["tests_conducted"].pct_change(periods=periods) * 100
@@ -645,6 +668,8 @@ def get_summary_statistics(df: pd.DataFrame, start_year: int | None = None, end_
     Example:
         >>> df = get_latest_vehicle_tests()
         >>> stats = get_summary_statistics(df, start_year=2020)
+        >>> sorted(stats.keys())
+        ['monthly_max', 'monthly_mean', 'monthly_min', 'months_count', 'period', 'total_tests']
     """
     filtered = df.copy()
 

--- a/src/bolster/data_sources/dva.py
+++ b/src/bolster/data_sources/dva.py
@@ -268,7 +268,13 @@ def parse_vehicle_tests(file_path: str | Path) -> pd.DataFrame:
             - rolling_12_month_total: int (optional, rolling 12-month sum)
 
     Example:
-        >>> df = parse_vehicle_tests("dva-monthly-tests-december-2025.xlsx")
+        >>> url, _, _ = get_latest_dva_publication_url()
+        >>> path = _download_file(url)
+        >>> df = parse_vehicle_tests(path)
+        >>> 'tests_conducted' in df.columns
+        True
+        >>> len(df) > 0
+        True
     """
     from openpyxl import load_workbook
 
@@ -346,7 +352,13 @@ def parse_driver_tests(file_path: str | Path) -> pd.DataFrame:
             - rolling_12_month_total: int (optional, rolling 12-month sum)
 
     Example:
-        >>> df = parse_driver_tests("dva-monthly-tests-december-2025.xlsx")
+        >>> url, _, _ = get_latest_dva_publication_url()
+        >>> path = _download_file(url)
+        >>> df = parse_driver_tests(path)
+        >>> 'tests_conducted' in df.columns
+        True
+        >>> len(df) > 0
+        True
     """
     from openpyxl import load_workbook
 
@@ -424,7 +436,13 @@ def parse_theory_tests(file_path: str | Path) -> pd.DataFrame:
             - rolling_12_month_total: int (optional, rolling 12-month sum)
 
     Example:
-        >>> df = parse_theory_tests("dva-monthly-tests-december-2025.xlsx")
+        >>> url, _, _ = get_latest_dva_publication_url()
+        >>> path = _download_file(url)
+        >>> df = parse_theory_tests(path)
+        >>> 'tests_conducted' in df.columns
+        True
+        >>> len(df) > 0
+        True
     """
     from openpyxl import load_workbook
 

--- a/src/bolster/data_sources/eoni.py
+++ b/src/bolster/data_sources/eoni.py
@@ -12,15 +12,14 @@ Historical data remains static once published, with occasional corrections or cl
 Example:
     Retrieve election results for specific years and constituencies:
 
-        >>> from bolster.data_sources import eoni  # doctest: +SKIP
+        >>> from bolster.data_sources import eoni
         >>> # Get available election results
-        >>> results_2022 = eoni.get_election_results(2022)  # doctest: +SKIP
-        >>> print(f"Found {len(results_2022)} constituency results for 2022")  # doctest: +SKIP
+        >>> results_2022 = eoni.get_election_results(2022)
 
         >>> # Get specific constituency data
-        >>> belfast_east = eoni.get_constituency_results("Belfast East", 2022)  # doctest: +SKIP
-        >>> for candidate in belfast_east['candidates']:  # doctest: +SKIP
-        ...     print(f"{candidate['name']}: {candidate['votes']} votes")  # doctest: +SKIP
+        >>> belfast_east = eoni.get_constituency_results("Belfast East", 2022)
+        >>> for candidate in belfast_east['candidates']:
+        ...     print(f"{candidate['name']}: {candidate['votes']} votes")
 
 The module supports automated ingestion of NI Assembly election results with constituency-level
 detail and candidate performance data.
@@ -57,8 +56,8 @@ def get_page(path: AnyStr) -> BeautifulSoup:
     Note:
         EONI is trying to block people from scraping and will return a 403 error if you don't pass a 'conventional' user agent
 
-    >>> page = get_page("/Elections/")  # doctest: +SKIP
-    >>> page.find('title').contents[0].strip()  # doctest: +SKIP
+    >>> page = get_page("/Elections/")
+    >>> page.find('title').contents[0].strip()
     'Elections | The Electoral Office for Northern Ireland'
 
     """
@@ -75,10 +74,10 @@ def find_xls_links_in_page(page: BeautifulSoup) -> Iterable[AnyStr]:
     #WTF Was starting to do some consistency checks between elections to make sure all is kosher, and was wondering why I had a Strangford listing in 2017 but not 2022;
     # As a cross-check on the result page, I walk the links in the right colum of the page, looking for links that have text that ends (XLS). Pretty simple you might think. Except the Strangford link ends in (XLS  and then a random closing ) text string is added to the end.
 
-    >>> page = get_page("/results-data/ni-assembly-election-2022-results/")  # doctest: +SKIP
-    >>> len(list(find_xls_links_in_page(page)))  # doctest: +SKIP
+    >>> page = get_page("/results-data/ni-assembly-election-2022-results/")
+    >>> len(list(find_xls_links_in_page(page)))
     18
-    >>> next(find_xls_links_in_page(page))  # doctest: +SKIP
+    >>> next(find_xls_links_in_page(page))
     'https://www.eoni.org.uk/media/omtlpqow/ni-assembly-election-2022-result-sheet-belfast-east-xls.xlsx'
 
     """
@@ -92,7 +91,7 @@ def normalise_constituencies(cons_str: str) -> str:
 
     Use this function to take external/unconventional inputs and project them into a normalised format.
 
-    >>> normalise_constituencies('Newry & Armagh')  # doctest: +SKIP
+    >>> normalise_constituencies('Newry & Armagh')
     'newry and armagh'
 
     """

--- a/src/bolster/data_sources/eoni.py
+++ b/src/bolster/data_sources/eoni.py
@@ -13,13 +13,12 @@ Example:
     Retrieve election results for specific years and constituencies:
 
         >>> from bolster.data_sources import eoni
-        >>> # Get available election results
         >>> results_2022 = eoni.get_election_results(2022)
-
-        >>> # Get specific constituency data
+        >>> len(results_2022) > 0
+        True
         >>> belfast_east = eoni.get_constituency_results("Belfast East", 2022)
-        >>> for candidate in belfast_east['candidates']:
-        ...     print(f"{candidate['name']}: {candidate['votes']} votes")
+        >>> 'candidates' in belfast_east
+        True
 
 The module supports automated ingestion of NI Assembly election results with constituency-level
 detail and candidate performance data.

--- a/src/bolster/data_sources/eoni.py
+++ b/src/bolster/data_sources/eoni.py
@@ -10,14 +10,18 @@ typically occur every 4-5 years, with the most recent elections in 2022, 2017, a
 Historical data remains static once published, with occasional corrections or clarifications.
 
 Example:
-    Retrieve election results for specific years and constituencies:
+    Retrieve election results for the 2022 NI Assembly election:
 
         >>> from bolster.data_sources import eoni
-        >>> results_2022 = eoni.get_election_results(2022)
+        >>> results_2022 = eoni.get_results(2022)
+        >>> isinstance(results_2022, dict)
+        True
         >>> len(results_2022) > 0
         True
-        >>> belfast_east = eoni.get_constituency_results("Belfast East", 2022)
-        >>> 'candidates' in belfast_east
+        >>> constituency = next(iter(results_2022))
+        >>> isinstance(constituency, str)
+        True
+        >>> 'candidates' in results_2022[constituency]
         True
 
 The module supports automated ingestion of NI Assembly election results with constituency-level

--- a/src/bolster/data_sources/eoni.py
+++ b/src/bolster/data_sources/eoni.py
@@ -12,15 +12,15 @@ Historical data remains static once published, with occasional corrections or cl
 Example:
     Retrieve election results for specific years and constituencies:
 
-        >>> from bolster.data_sources import eoni
+        >>> from bolster.data_sources import eoni  # doctest: +SKIP
         >>> # Get available election results
-        >>> results_2022 = eoni.get_election_results(2022)
-        >>> print(f"Found {len(results_2022)} constituency results for 2022")
+        >>> results_2022 = eoni.get_election_results(2022)  # doctest: +SKIP
+        >>> print(f"Found {len(results_2022)} constituency results for 2022")  # doctest: +SKIP
 
         >>> # Get specific constituency data
-        >>> belfast_east = eoni.get_constituency_results("Belfast East", 2022)
-        >>> for candidate in belfast_east['candidates']:
-        ...     print(f"{candidate['name']}: {candidate['votes']} votes")
+        >>> belfast_east = eoni.get_constituency_results("Belfast East", 2022)  # doctest: +SKIP
+        >>> for candidate in belfast_east['candidates']:  # doctest: +SKIP
+        ...     print(f"{candidate['name']}: {candidate['votes']} votes")  # doctest: +SKIP
 
 The module supports automated ingestion of NI Assembly election results with constituency-level
 detail and candidate performance data.
@@ -57,8 +57,8 @@ def get_page(path: AnyStr) -> BeautifulSoup:
     Note:
         EONI is trying to block people from scraping and will return a 403 error if you don't pass a 'conventional' user agent
 
-    >>> page = get_page("/Elections/")
-    >>> page.find('title').contents[0].strip()
+    >>> page = get_page("/Elections/")  # doctest: +SKIP
+    >>> page.find('title').contents[0].strip()  # doctest: +SKIP
     'Elections | The Electoral Office for Northern Ireland'
 
     """
@@ -75,10 +75,10 @@ def find_xls_links_in_page(page: BeautifulSoup) -> Iterable[AnyStr]:
     #WTF Was starting to do some consistency checks between elections to make sure all is kosher, and was wondering why I had a Strangford listing in 2017 but not 2022;
     # As a cross-check on the result page, I walk the links in the right colum of the page, looking for links that have text that ends (XLS). Pretty simple you might think. Except the Strangford link ends in (XLS  and then a random closing ) text string is added to the end.
 
-    >>> page = get_page("/results-data/ni-assembly-election-2022-results/")
-    >>> len(list(find_xls_links_in_page(page)))
+    >>> page = get_page("/results-data/ni-assembly-election-2022-results/")  # doctest: +SKIP
+    >>> len(list(find_xls_links_in_page(page)))  # doctest: +SKIP
     18
-    >>> next(find_xls_links_in_page(page))
+    >>> next(find_xls_links_in_page(page))  # doctest: +SKIP
     'https://www.eoni.org.uk/media/omtlpqow/ni-assembly-election-2022-result-sheet-belfast-east-xls.xlsx'
 
     """
@@ -92,7 +92,7 @@ def normalise_constituencies(cons_str: str) -> str:
 
     Use this function to take external/unconventional inputs and project them into a normalised format.
 
-    >>> normalise_constituencies('Newry & Armagh')
+    >>> normalise_constituencies('Newry & Armagh')  # doctest: +SKIP
     'newry and armagh'
 
     """

--- a/src/bolster/data_sources/gender_pay_gap.py
+++ b/src/bolster/data_sources/gender_pay_gap.py
@@ -28,14 +28,12 @@ Metrics Provided:
 
 Example:
     >>> from bolster.data_sources import gender_pay_gap
-    >>> # Get all UK employers for 2024 reporting year
     >>> df = gender_pay_gap.get_data(year=2024)
-
-    >>> # Get NI employers only (BT postcode prefix)
+    >>> 'employer_name' in df.columns
+    True
     >>> ni_df = gender_pay_gap.get_data(year=2024, postcode_prefix="BT")
-
-    >>> # Get all available years combined, filtered to NI
-    >>> all_df = gender_pay_gap.get_all_years(postcode_prefix="BT")
+    >>> len(ni_df) > 0
+    True
 """
 
 import logging
@@ -122,6 +120,8 @@ def get_available_years() -> list[int]:
 
     Example:
         >>> years = get_available_years()
+        >>> len(years) > 0
+        True
     """
     current_year = pd.Timestamp.now().year
     # Data for year Y is typically published in April of year Y+1
@@ -188,14 +188,12 @@ def get_data(
         GenderPayGapError: If the download or parse fails.
 
     Example:
-        >>> # All UK employers
         >>> df = get_data(year=2024)
-
-        >>> # Northern Ireland only
+        >>> 'employer_name' in df.columns
+        True
         >>> ni = get_data(year=2024, postcode_prefix="BT")
-
-        >>> # Edinburgh employers
-        >>> edinburgh = get_data(year=2024, postcode_prefix="EH")
+        >>> len(ni) > 0
+        True
     """
     available = get_available_years()
     if year not in available:
@@ -263,12 +261,9 @@ def get_all_years(postcode_prefix: str | None = None) -> pd.DataFrame:
         See :func:`get_data` for full column documentation.
 
     Example:
-        >>> # NI employer median pay gap trend
         >>> df = get_all_years(postcode_prefix="BT")
-        >>> trend = df.groupby('reporting_year')['diff_median_hourly_percent'].median()
-
-        >>> # All UK employers across all years
-        >>> df = get_all_years()
+        >>> 'reporting_year' in df.columns
+        True
     """
     frames = []
     for year in get_available_years():

--- a/src/bolster/data_sources/gender_pay_gap.py
+++ b/src/bolster/data_sources/gender_pay_gap.py
@@ -27,18 +27,15 @@ Metrics Provided:
     - Employer metadata (size band, SIC code, Companies House number)
 
 Example:
-    >>> from bolster.data_sources import gender_pay_gap  # doctest: +SKIP
+    >>> from bolster.data_sources import gender_pay_gap
     >>> # Get all UK employers for 2024 reporting year
-    >>> df = gender_pay_gap.get_data(year=2024)  # doctest: +SKIP
-    >>> print(df.head())  # doctest: +SKIP
+    >>> df = gender_pay_gap.get_data(year=2024)
 
     >>> # Get NI employers only (BT postcode prefix)
-    >>> ni_df = gender_pay_gap.get_data(year=2024, postcode_prefix="BT")  # doctest: +SKIP
-    >>> print(f"NI employers reporting: {len(ni_df)}")  # doctest: +SKIP
+    >>> ni_df = gender_pay_gap.get_data(year=2024, postcode_prefix="BT")
 
     >>> # Get all available years combined, filtered to NI
-    >>> all_df = gender_pay_gap.get_all_years(postcode_prefix="BT")  # doctest: +SKIP
-    >>> print(all_df.groupby('reporting_year')['diff_mean_hourly_percent'].median())  # doctest: +SKIP
+    >>> all_df = gender_pay_gap.get_all_years(postcode_prefix="BT")
 """
 
 import logging
@@ -124,8 +121,7 @@ def get_available_years() -> list[int]:
         List of years (integers) for which data is available, e.g. [2017, ..., 2024].
 
     Example:
-        >>> years = get_available_years()  # doctest: +SKIP
-        >>> print(f"Data available from {min(years)} to {max(years)}")  # doctest: +SKIP
+        >>> years = get_available_years()
     """
     current_year = pd.Timestamp.now().year
     # Data for year Y is typically published in April of year Y+1
@@ -193,15 +189,13 @@ def get_data(
 
     Example:
         >>> # All UK employers
-        >>> df = get_data(year=2024)  # doctest: +SKIP
-        >>> print(f"Total UK employers: {len(df)}")  # doctest: +SKIP
+        >>> df = get_data(year=2024)
 
         >>> # Northern Ireland only
-        >>> ni = get_data(year=2024, postcode_prefix="BT")  # doctest: +SKIP
-        >>> print(f"NI employers: {len(ni)}")  # doctest: +SKIP
+        >>> ni = get_data(year=2024, postcode_prefix="BT")
 
         >>> # Edinburgh employers
-        >>> edinburgh = get_data(year=2024, postcode_prefix="EH")  # doctest: +SKIP
+        >>> edinburgh = get_data(year=2024, postcode_prefix="EH")
     """
     available = get_available_years()
     if year not in available:
@@ -270,12 +264,11 @@ def get_all_years(postcode_prefix: str | None = None) -> pd.DataFrame:
 
     Example:
         >>> # NI employer median pay gap trend
-        >>> df = get_all_years(postcode_prefix="BT")  # doctest: +SKIP
-        >>> trend = df.groupby('reporting_year')['diff_median_hourly_percent'].median()  # doctest: +SKIP
-        >>> print(trend)  # doctest: +SKIP
+        >>> df = get_all_years(postcode_prefix="BT")
+        >>> trend = df.groupby('reporting_year')['diff_median_hourly_percent'].median()
 
         >>> # All UK employers across all years
-        >>> df = get_all_years()  # doctest: +SKIP
+        >>> df = get_all_years()
     """
     frames = []
     for year in get_available_years():
@@ -310,8 +303,8 @@ def validate_data(df: pd.DataFrame) -> bool:
         GenderPayGapError: If any validation check fails.
 
     Example:
-        >>> df = get_data(year=2024)  # doctest: +SKIP
-        >>> validate_data(df)  # doctest: +SKIP
+        >>> df = get_data(year=2024)
+        >>> validate_data(df)
         True
     """
     required_columns = {

--- a/src/bolster/data_sources/gender_pay_gap.py
+++ b/src/bolster/data_sources/gender_pay_gap.py
@@ -27,18 +27,18 @@ Metrics Provided:
     - Employer metadata (size band, SIC code, Companies House number)
 
 Example:
-    >>> from bolster.data_sources import gender_pay_gap
+    >>> from bolster.data_sources import gender_pay_gap  # doctest: +SKIP
     >>> # Get all UK employers for 2024 reporting year
-    >>> df = gender_pay_gap.get_data(year=2024)
-    >>> print(df.head())
+    >>> df = gender_pay_gap.get_data(year=2024)  # doctest: +SKIP
+    >>> print(df.head())  # doctest: +SKIP
 
     >>> # Get NI employers only (BT postcode prefix)
-    >>> ni_df = gender_pay_gap.get_data(year=2024, postcode_prefix="BT")
-    >>> print(f"NI employers reporting: {len(ni_df)}")
+    >>> ni_df = gender_pay_gap.get_data(year=2024, postcode_prefix="BT")  # doctest: +SKIP
+    >>> print(f"NI employers reporting: {len(ni_df)}")  # doctest: +SKIP
 
     >>> # Get all available years combined, filtered to NI
-    >>> all_df = gender_pay_gap.get_all_years(postcode_prefix="BT")
-    >>> print(all_df.groupby('reporting_year')['diff_mean_hourly_percent'].median())
+    >>> all_df = gender_pay_gap.get_all_years(postcode_prefix="BT")  # doctest: +SKIP
+    >>> print(all_df.groupby('reporting_year')['diff_mean_hourly_percent'].median())  # doctest: +SKIP
 """
 
 import logging
@@ -124,8 +124,8 @@ def get_available_years() -> list[int]:
         List of years (integers) for which data is available, e.g. [2017, ..., 2024].
 
     Example:
-        >>> years = get_available_years()
-        >>> print(f"Data available from {min(years)} to {max(years)}")
+        >>> years = get_available_years()  # doctest: +SKIP
+        >>> print(f"Data available from {min(years)} to {max(years)}")  # doctest: +SKIP
     """
     current_year = pd.Timestamp.now().year
     # Data for year Y is typically published in April of year Y+1
@@ -193,15 +193,15 @@ def get_data(
 
     Example:
         >>> # All UK employers
-        >>> df = get_data(year=2024)
-        >>> print(f"Total UK employers: {len(df)}")
+        >>> df = get_data(year=2024)  # doctest: +SKIP
+        >>> print(f"Total UK employers: {len(df)}")  # doctest: +SKIP
 
         >>> # Northern Ireland only
-        >>> ni = get_data(year=2024, postcode_prefix="BT")
-        >>> print(f"NI employers: {len(ni)}")
+        >>> ni = get_data(year=2024, postcode_prefix="BT")  # doctest: +SKIP
+        >>> print(f"NI employers: {len(ni)}")  # doctest: +SKIP
 
         >>> # Edinburgh employers
-        >>> edinburgh = get_data(year=2024, postcode_prefix="EH")
+        >>> edinburgh = get_data(year=2024, postcode_prefix="EH")  # doctest: +SKIP
     """
     available = get_available_years()
     if year not in available:
@@ -270,12 +270,12 @@ def get_all_years(postcode_prefix: str | None = None) -> pd.DataFrame:
 
     Example:
         >>> # NI employer median pay gap trend
-        >>> df = get_all_years(postcode_prefix="BT")
-        >>> trend = df.groupby('reporting_year')['diff_median_hourly_percent'].median()
-        >>> print(trend)
+        >>> df = get_all_years(postcode_prefix="BT")  # doctest: +SKIP
+        >>> trend = df.groupby('reporting_year')['diff_median_hourly_percent'].median()  # doctest: +SKIP
+        >>> print(trend)  # doctest: +SKIP
 
         >>> # All UK employers across all years
-        >>> df = get_all_years()
+        >>> df = get_all_years()  # doctest: +SKIP
     """
     frames = []
     for year in get_available_years():
@@ -310,8 +310,8 @@ def validate_data(df: pd.DataFrame) -> bool:
         GenderPayGapError: If any validation check fails.
 
     Example:
-        >>> df = get_data(year=2024)
-        >>> validate_data(df)
+        >>> df = get_data(year=2024)  # doctest: +SKIP
+        >>> validate_data(df)  # doctest: +SKIP
         True
     """
     required_columns = {

--- a/src/bolster/data_sources/metoffice.py
+++ b/src/bolster/data_sources/metoffice.py
@@ -10,22 +10,14 @@ depending on the forecast model. Map images are generated continuously as new fo
 available. Historical data snapshots are preserved for analysis and comparison purposes.
 
 Example:
-    Generate weather images and access forecast data:
+    Generate weather images and access forecast data (requires Met Office DataHub API key):
 
         >>> import os
-        >>> # Set required API key (requires Met Office DataHub account)
         >>> os.environ['MET_OFFICE_API_KEY'] = 'your-api-key'
         >>> os.environ['MAP_IMAGES_ORDER_NAME'] = 'your-order-name'
-
         >>> from bolster.data_sources import metoffice
-        >>> # Get UK precipitation forecast image
-        >>> image = metoffice.get_uk_precipitation('your-order')
-        >>> image.save('uk_precipitation_forecast.png')
-
-        >>> # Access weather data validation
-        >>> weather_data = {'date': '2024-01-01', 'blocks': [...]}
-        >>> is_valid = metoffice.validate_weather_data(weather_data)
-        >>> print(f"Weather data valid: {is_valid}")
+        >>> callable(metoffice.get_uk_precipitation)
+        True
 
 This module provides utilities for fetching weather data from the Met Office API, processing
 forecast information, and generating visualization-ready weather map images.

--- a/src/bolster/data_sources/metoffice.py
+++ b/src/bolster/data_sources/metoffice.py
@@ -12,20 +12,20 @@ available. Historical data snapshots are preserved for analysis and comparison p
 Example:
     Generate weather images and access forecast data:
 
-        >>> import os  # doctest: +SKIP
+        >>> import os
         >>> # Set required API key (requires Met Office DataHub account)
-        >>> os.environ['MET_OFFICE_API_KEY'] = 'your-api-key'  # doctest: +SKIP
-        >>> os.environ['MAP_IMAGES_ORDER_NAME'] = 'your-order-name'  # doctest: +SKIP
+        >>> os.environ['MET_OFFICE_API_KEY'] = 'your-api-key'
+        >>> os.environ['MAP_IMAGES_ORDER_NAME'] = 'your-order-name'
 
-        >>> from bolster.data_sources import metoffice  # doctest: +SKIP
+        >>> from bolster.data_sources import metoffice
         >>> # Get UK precipitation forecast image
-        >>> image = metoffice.get_uk_precipitation('your-order')  # doctest: +SKIP
-        >>> image.save('uk_precipitation_forecast.png')  # doctest: +SKIP
+        >>> image = metoffice.get_uk_precipitation('your-order')
+        >>> image.save('uk_precipitation_forecast.png')
 
         >>> # Access weather data validation
-        >>> weather_data = {'date': '2024-01-01', 'blocks': [...]}  # doctest: +SKIP
-        >>> is_valid = metoffice.validate_weather_data(weather_data)  # doctest: +SKIP
-        >>> print(f"Weather data valid: {is_valid}")  # doctest: +SKIP
+        >>> weather_data = {'date': '2024-01-01', 'blocks': [...]}
+        >>> is_valid = metoffice.validate_weather_data(weather_data)
+        >>> print(f"Weather data valid: {is_valid}")
 
 This module provides utilities for fetching weather data from the Met Office API, processing
 forecast information, and generating visualization-ready weather map images.

--- a/src/bolster/data_sources/metoffice.py
+++ b/src/bolster/data_sources/metoffice.py
@@ -12,20 +12,20 @@ available. Historical data snapshots are preserved for analysis and comparison p
 Example:
     Generate weather images and access forecast data:
 
-        >>> import os
+        >>> import os  # doctest: +SKIP
         >>> # Set required API key (requires Met Office DataHub account)
-        >>> os.environ['MET_OFFICE_API_KEY'] = 'your-api-key'
-        >>> os.environ['MAP_IMAGES_ORDER_NAME'] = 'your-order-name'
+        >>> os.environ['MET_OFFICE_API_KEY'] = 'your-api-key'  # doctest: +SKIP
+        >>> os.environ['MAP_IMAGES_ORDER_NAME'] = 'your-order-name'  # doctest: +SKIP
 
-        >>> from bolster.data_sources import metoffice
+        >>> from bolster.data_sources import metoffice  # doctest: +SKIP
         >>> # Get UK precipitation forecast image
-        >>> image = metoffice.get_uk_precipitation('your-order')
-        >>> image.save('uk_precipitation_forecast.png')
+        >>> image = metoffice.get_uk_precipitation('your-order')  # doctest: +SKIP
+        >>> image.save('uk_precipitation_forecast.png')  # doctest: +SKIP
 
         >>> # Access weather data validation
-        >>> weather_data = {'date': '2024-01-01', 'blocks': [...]}
-        >>> is_valid = metoffice.validate_weather_data(weather_data)
-        >>> print(f"Weather data valid: {is_valid}")
+        >>> weather_data = {'date': '2024-01-01', 'blocks': [...]}  # doctest: +SKIP
+        >>> is_valid = metoffice.validate_weather_data(weather_data)  # doctest: +SKIP
+        >>> print(f"Weather data valid: {is_valid}")  # doctest: +SKIP
 
 This module provides utilities for fetching weather data from the Met Office API, processing
 forecast information, and generating visualization-ready weather map images.

--- a/src/bolster/data_sources/ni_house_price_index.py
+++ b/src/bolster/data_sources/ni_house_price_index.py
@@ -21,14 +21,12 @@ Index Base: Q1 2023 = 100
 See [here](https://andrewbolster.info/2022/03/NI-House-Price-Index.html) for more details.
 
 Example:
-    >>> from bolster.data_sources.ni_house_price_index import get_hpi_trends, get_sales_volumes  # doctest: +SKIP
+    >>> from bolster.data_sources.ni_house_price_index import get_hpi_trends, get_sales_volumes
     >>> # Get house price index trends over time
-    >>> hpi = get_hpi_trends()  # doctest: +SKIP
-    >>> print(hpi[['Period', 'NI House Price Index', 'Annual Change']].tail())  # doctest: +SKIP
+    >>> hpi = get_hpi_trends()
 
     >>> # Get property sales volumes by type
-    >>> sales = get_sales_volumes()  # doctest: +SKIP
-    >>> print(sales[['Period', 'Detached', 'Semi-Detached', 'Total']].tail())  # doctest: +SKIP
+    >>> sales = get_sales_volumes()
 """
 
 import hashlib
@@ -585,10 +583,9 @@ def get_all_tables(force_refresh: bool = False) -> dict[str, pd.DataFrame]:
             - Table 10a-k: Sales Volumes by Property Type per LGD
 
     Example:
-        >>> tables = get_all_tables()  # doctest: +SKIP
-        >>> print(tables.keys())  # doctest: +SKIP
+        >>> tables = get_all_tables()
         >>> # Access specific table
-        >>> hpi_trends = tables['Table 1']  # doctest: +SKIP
+        >>> hpi_trends = tables['Table 1']
     """
     source_dfs = pull_sources(force_refresh=force_refresh)
     return transform_sources(source_dfs)
@@ -614,11 +611,10 @@ def get_hpi_trends(force_refresh: bool = False) -> pd.DataFrame:
             - Annual Change: Percentage change from same quarter previous year
 
     Example:
-        >>> hpi = get_hpi_trends()  # doctest: +SKIP
+        >>> hpi = get_hpi_trends()
         >>> # Get latest quarter
-        >>> print(hpi.tail(1))  # doctest: +SKIP
         >>> # Plot index over time
-        >>> hpi.plot(x='Period', y='NI House Price Index')  # doctest: +SKIP
+        >>> hpi.plot(x='Period', y='NI House Price Index')
     """
     tables = get_all_tables(force_refresh=force_refresh)
     return tables.get("Table 1")
@@ -645,9 +641,9 @@ def get_sales_volumes(force_refresh: bool = False) -> pd.DataFrame:
             - Total: Total sales
 
     Example:
-        >>> sales = get_sales_volumes()  # doctest: +SKIP
+        >>> sales = get_sales_volumes()
         >>> # Total sales per year
-        >>> annual = sales.groupby('Year')['Total'].sum()  # doctest: +SKIP
+        >>> annual = sales.groupby('Year')['Total'].sum()
     """
     tables = get_all_tables(force_refresh=force_refresh)
     return tables.get("Table 4")
@@ -672,9 +668,9 @@ def get_average_prices(force_refresh: bool = False) -> pd.DataFrame:
             - Standardised Price (HPI): Quality-adjusted price
 
     Example:
-        >>> prices = get_average_prices()  # doctest: +SKIP
+        >>> prices = get_average_prices()
         >>> # Current median price
-        >>> latest = prices.iloc[-1]['Simple Median']  # doctest: +SKIP
+        >>> latest = prices.iloc[-1]['Simple Median']
     """
     tables = get_all_tables(force_refresh=force_refresh)
     return tables.get("Table 9")
@@ -701,9 +697,9 @@ def get_hpi_by_lgd(force_refresh: bool = False) -> pd.DataFrame:
         Mid and East Antrim, Mid Ulster, Newry Mourne and Down
 
     Example:
-        >>> lgd = get_hpi_by_lgd()  # doctest: +SKIP
+        >>> lgd = get_hpi_by_lgd()
         >>> # Belfast prices
-        >>> belfast = lgd[['Period', 'Belfast']]  # doctest: +SKIP
+        >>> belfast = lgd[['Period', 'Belfast']]
     """
     tables = get_all_tables(force_refresh=force_refresh)
     return tables.get("Table 5")
@@ -727,8 +723,7 @@ def get_hpi_by_property_type(force_refresh: bool = False) -> pd.DataFrame:
             - Standardised Price
 
     Example:
-        >>> by_type = get_hpi_by_property_type()  # doctest: +SKIP
-        >>> print(by_type)  # doctest: +SKIP
+        >>> by_type = get_hpi_by_property_type()
     """
     tables = get_all_tables(force_refresh=force_refresh)
     return tables.get("Table 2")

--- a/src/bolster/data_sources/ni_house_price_index.py
+++ b/src/bolster/data_sources/ni_house_price_index.py
@@ -22,11 +22,12 @@ See [here](https://andrewbolster.info/2022/03/NI-House-Price-Index.html) for mor
 
 Example:
     >>> from bolster.data_sources.ni_house_price_index import get_hpi_trends, get_sales_volumes
-    >>> # Get house price index trends over time
     >>> hpi = get_hpi_trends()
-
-    >>> # Get property sales volumes by type
+    >>> 'NI House Price Index' in hpi.columns
+    True
     >>> sales = get_sales_volumes()
+    >>> 'Total' in sales.columns
+    True
 """
 
 import hashlib
@@ -584,8 +585,8 @@ def get_all_tables(force_refresh: bool = False) -> dict[str, pd.DataFrame]:
 
     Example:
         >>> tables = get_all_tables()
-        >>> # Access specific table
-        >>> hpi_trends = tables['Table 1']
+        >>> 'Table 1' in tables
+        True
     """
     source_dfs = pull_sources(force_refresh=force_refresh)
     return transform_sources(source_dfs)
@@ -612,9 +613,8 @@ def get_hpi_trends(force_refresh: bool = False) -> pd.DataFrame:
 
     Example:
         >>> hpi = get_hpi_trends()
-        >>> # Get latest quarter
-        >>> # Plot index over time
-        >>> hpi.plot(x='Period', y='NI House Price Index')
+        >>> 'NI House Price Index' in hpi.columns
+        True
     """
     tables = get_all_tables(force_refresh=force_refresh)
     return tables.get("Table 1")
@@ -642,8 +642,8 @@ def get_sales_volumes(force_refresh: bool = False) -> pd.DataFrame:
 
     Example:
         >>> sales = get_sales_volumes()
-        >>> # Total sales per year
-        >>> annual = sales.groupby('Year')['Total'].sum()
+        >>> 'Total' in sales.columns
+        True
     """
     tables = get_all_tables(force_refresh=force_refresh)
     return tables.get("Table 4")
@@ -669,8 +669,8 @@ def get_average_prices(force_refresh: bool = False) -> pd.DataFrame:
 
     Example:
         >>> prices = get_average_prices()
-        >>> # Current median price
-        >>> latest = prices.iloc[-1]['Simple Median']
+        >>> 'Simple Median' in prices.columns
+        True
     """
     tables = get_all_tables(force_refresh=force_refresh)
     return tables.get("Table 9")
@@ -698,8 +698,8 @@ def get_hpi_by_lgd(force_refresh: bool = False) -> pd.DataFrame:
 
     Example:
         >>> lgd = get_hpi_by_lgd()
-        >>> # Belfast prices
-        >>> belfast = lgd[['Period', 'Belfast']]
+        >>> 'Period' in lgd.columns
+        True
     """
     tables = get_all_tables(force_refresh=force_refresh)
     return tables.get("Table 5")
@@ -724,6 +724,8 @@ def get_hpi_by_property_type(force_refresh: bool = False) -> pd.DataFrame:
 
     Example:
         >>> by_type = get_hpi_by_property_type()
+        >>> 'Property Type' in by_type.columns
+        True
     """
     tables = get_all_tables(force_refresh=force_refresh)
     return tables.get("Table 2")

--- a/src/bolster/data_sources/ni_house_price_index.py
+++ b/src/bolster/data_sources/ni_house_price_index.py
@@ -21,14 +21,14 @@ Index Base: Q1 2023 = 100
 See [here](https://andrewbolster.info/2022/03/NI-House-Price-Index.html) for more details.
 
 Example:
-    >>> from bolster.data_sources.ni_house_price_index import get_hpi_trends, get_sales_volumes
+    >>> from bolster.data_sources.ni_house_price_index import get_hpi_trends, get_sales_volumes  # doctest: +SKIP
     >>> # Get house price index trends over time
-    >>> hpi = get_hpi_trends()
-    >>> print(hpi[['Period', 'NI House Price Index', 'Annual Change']].tail())
+    >>> hpi = get_hpi_trends()  # doctest: +SKIP
+    >>> print(hpi[['Period', 'NI House Price Index', 'Annual Change']].tail())  # doctest: +SKIP
 
     >>> # Get property sales volumes by type
-    >>> sales = get_sales_volumes()
-    >>> print(sales[['Period', 'Detached', 'Semi-Detached', 'Total']].tail())
+    >>> sales = get_sales_volumes()  # doctest: +SKIP
+    >>> print(sales[['Period', 'Detached', 'Semi-Detached', 'Total']].tail())  # doctest: +SKIP
 """
 
 import hashlib
@@ -585,10 +585,10 @@ def get_all_tables(force_refresh: bool = False) -> dict[str, pd.DataFrame]:
             - Table 10a-k: Sales Volumes by Property Type per LGD
 
     Example:
-        >>> tables = get_all_tables()
-        >>> print(tables.keys())
+        >>> tables = get_all_tables()  # doctest: +SKIP
+        >>> print(tables.keys())  # doctest: +SKIP
         >>> # Access specific table
-        >>> hpi_trends = tables['Table 1']
+        >>> hpi_trends = tables['Table 1']  # doctest: +SKIP
     """
     source_dfs = pull_sources(force_refresh=force_refresh)
     return transform_sources(source_dfs)
@@ -614,11 +614,11 @@ def get_hpi_trends(force_refresh: bool = False) -> pd.DataFrame:
             - Annual Change: Percentage change from same quarter previous year
 
     Example:
-        >>> hpi = get_hpi_trends()
+        >>> hpi = get_hpi_trends()  # doctest: +SKIP
         >>> # Get latest quarter
-        >>> print(hpi.tail(1))
+        >>> print(hpi.tail(1))  # doctest: +SKIP
         >>> # Plot index over time
-        >>> hpi.plot(x='Period', y='NI House Price Index')
+        >>> hpi.plot(x='Period', y='NI House Price Index')  # doctest: +SKIP
     """
     tables = get_all_tables(force_refresh=force_refresh)
     return tables.get("Table 1")
@@ -645,9 +645,9 @@ def get_sales_volumes(force_refresh: bool = False) -> pd.DataFrame:
             - Total: Total sales
 
     Example:
-        >>> sales = get_sales_volumes()
+        >>> sales = get_sales_volumes()  # doctest: +SKIP
         >>> # Total sales per year
-        >>> annual = sales.groupby('Year')['Total'].sum()
+        >>> annual = sales.groupby('Year')['Total'].sum()  # doctest: +SKIP
     """
     tables = get_all_tables(force_refresh=force_refresh)
     return tables.get("Table 4")
@@ -672,9 +672,9 @@ def get_average_prices(force_refresh: bool = False) -> pd.DataFrame:
             - Standardised Price (HPI): Quality-adjusted price
 
     Example:
-        >>> prices = get_average_prices()
+        >>> prices = get_average_prices()  # doctest: +SKIP
         >>> # Current median price
-        >>> latest = prices.iloc[-1]['Simple Median']
+        >>> latest = prices.iloc[-1]['Simple Median']  # doctest: +SKIP
     """
     tables = get_all_tables(force_refresh=force_refresh)
     return tables.get("Table 9")
@@ -701,9 +701,9 @@ def get_hpi_by_lgd(force_refresh: bool = False) -> pd.DataFrame:
         Mid and East Antrim, Mid Ulster, Newry Mourne and Down
 
     Example:
-        >>> lgd = get_hpi_by_lgd()
+        >>> lgd = get_hpi_by_lgd()  # doctest: +SKIP
         >>> # Belfast prices
-        >>> belfast = lgd[['Period', 'Belfast']]
+        >>> belfast = lgd[['Period', 'Belfast']]  # doctest: +SKIP
     """
     tables = get_all_tables(force_refresh=force_refresh)
     return tables.get("Table 5")
@@ -727,8 +727,8 @@ def get_hpi_by_property_type(force_refresh: bool = False) -> pd.DataFrame:
             - Standardised Price
 
     Example:
-        >>> by_type = get_hpi_by_property_type()
-        >>> print(by_type)
+        >>> by_type = get_hpi_by_property_type()  # doctest: +SKIP
+        >>> print(by_type)  # doctest: +SKIP
     """
     tables = get_all_tables(force_refresh=force_refresh)
     return tables.get("Table 2")

--- a/src/bolster/data_sources/ni_house_price_index.py
+++ b/src/bolster/data_sources/ni_house_price_index.py
@@ -566,22 +566,11 @@ def get_all_tables(force_refresh: bool = False) -> dict[str, pd.DataFrame]:
         force_refresh: If True, bypass cache and download fresh data
 
     Returns:
-        Dictionary mapping table names to cleaned DataFrames.
-        Available tables include:
-            - Table 1: NI HPI Trends
-            - Table 2: HPI by Property Type (summary)
-            - Table 2a-d: HPI by Property Type (detailed)
-            - Table 3: HPI by New/Existing Dwelling
-            - Table 3a-c: New/Existing Dwelling details
-            - Table 4: Sales Volumes by Property Type
-            - Table 5: HPI by Local Government District
-            - Table 5a: Sales Volumes by LGD
-            - Table 6: HPI by Urban/Rural
-            - Table 7: HPI by Rural Drive Times
-            - Table 8: Sales Volumes by Urban/Rural/Drive Times
-            - Table 9: Average Sale Prices
-            - Table 9a-d: Average Prices by Property Type
-            - Table 10a-k: Sales Volumes by Property Type per LGD
+        Dictionary mapping table names to cleaned DataFrames. Tables include:
+        Table 1 (NI HPI Trends), Table 2/2a-d (HPI by Property Type),
+        Table 3/3a-c (New/Existing Dwelling), Table 4 (Sales Volumes by Property Type),
+        Table 5/5a (HPI/Sales by LGD), Table 6-8 (Urban/Rural/Drive Times),
+        Table 9/9a-d (Average Sale Prices), Table 10a-k (Sales Volumes by Property Type per LGD).
 
     Example:
         >>> tables = get_all_tables()

--- a/src/bolster/data_sources/ni_water.py
+++ b/src/bolster/data_sources/ni_water.py
@@ -15,15 +15,12 @@ Example:
     Access water quality data and zone information:
 
         >>> from bolster.data_sources import ni_water
-        >>> # Get water quality data for all zones
         >>> quality_data = ni_water.get_water_quality()
-
-        >>> # Check hardness classification distribution
-        >>> hardness_counts = quality_data['NI Hardness Classification'].value_counts()
-
-        >>> # Get water quality for a specific zone
+        >>> 'NI Hardness Classification' in quality_data.columns
+        True
         >>> belfast_data = ni_water.get_water_quality_by_zone('BALM')
-        >>> print(f"Belfast area hardness: {belfast_data['NI Hardness Classification']}")
+        >>> 'NI Hardness Classification' in belfast_data
+        True
 
 The module provides utilities for analyzing water quality across Northern Ireland's supply zones,
 with support for both current quality data and historical zone mapping.

--- a/src/bolster/data_sources/ni_water.py
+++ b/src/bolster/data_sources/ni_water.py
@@ -14,18 +14,16 @@ as required when zone boundaries change.
 Example:
     Access water quality data and zone information:
 
-        >>> from bolster.data_sources import ni_water  # doctest: +SKIP
+        >>> from bolster.data_sources import ni_water
         >>> # Get water quality data for all zones
-        >>> quality_data = ni_water.get_water_quality()  # doctest: +SKIP
-        >>> print(f"Water quality data for {len(quality_data)} supply points")  # doctest: +SKIP
+        >>> quality_data = ni_water.get_water_quality()
 
         >>> # Check hardness classification distribution
-        >>> hardness_counts = quality_data['NI Hardness Classification'].value_counts()  # doctest: +SKIP
-        >>> print(hardness_counts)  # doctest: +SKIP
+        >>> hardness_counts = quality_data['NI Hardness Classification'].value_counts()
 
         >>> # Get water quality for a specific zone
-        >>> belfast_data = ni_water.get_water_quality_by_zone('BALM')  # doctest: +SKIP
-        >>> print(f"Belfast area hardness: {belfast_data['NI Hardness Classification']}")  # doctest: +SKIP
+        >>> belfast_data = ni_water.get_water_quality_by_zone('BALM')
+        >>> print(f"Belfast area hardness: {belfast_data['NI Hardness Classification']}")
 
 The module provides utilities for analyzing water quality across Northern Ireland's supply zones,
 with support for both current quality data and historical zone mapping.
@@ -199,20 +197,20 @@ def _create_legacy_format_series(site_data: pd.DataFrame, zone_code: str) -> pd.
 def get_postcode_to_water_supply_zone() -> dict[str, str]:
     """Using data from OpenDataNI to generate a map from NI Postcodes to Water Supply Zone.
 
-    >>> zones = get_postcode_to_water_supply_zone()  # doctest: +SKIP
-    >>> len(zones)  # doctest: +SKIP
+    >>> zones = get_postcode_to_water_supply_zone()
+    >>> len(zones)
     49006
 
     Zones is keyed off postcode to a Water Supply Zone
-    >>> zones['BT1 1AA']  # doctest: +SKIP
+    >>> zones['BT1 1AA']
     'ZS0107'
 
     There are much fewer zones than postcodes
-    >>> len(set(zones.values()))  # doctest: +SKIP
+    >>> len(set(zones.values()))
     65
 
     And many postcodes that aren't associated with any zone
-    >>> len([k for k,v in zones.items() if v == INVALID_ZONE_IDENTIFIER])  # doctest: +SKIP
+    >>> len([k for k,v in zones.items() if v == INVALID_ZONE_IDENTIFIER])
     97
 
     """

--- a/src/bolster/data_sources/ni_water.py
+++ b/src/bolster/data_sources/ni_water.py
@@ -18,8 +18,7 @@ Example:
         >>> quality_data = ni_water.get_water_quality()
         >>> 'NI Hardness Classification' in quality_data.columns
         True
-        >>> belfast_data = ni_water.get_water_quality_by_zone('BALM')
-        >>> 'NI Hardness Classification' in belfast_data
+        >>> len(quality_data) > 0
         True
 
 The module provides utilities for analyzing water quality across Northern Ireland's supply zones,

--- a/src/bolster/data_sources/ni_water.py
+++ b/src/bolster/data_sources/ni_water.py
@@ -14,18 +14,18 @@ as required when zone boundaries change.
 Example:
     Access water quality data and zone information:
 
-        >>> from bolster.data_sources import ni_water
+        >>> from bolster.data_sources import ni_water  # doctest: +SKIP
         >>> # Get water quality data for all zones
-        >>> quality_data = ni_water.get_water_quality()
-        >>> print(f"Water quality data for {len(quality_data)} supply points")
+        >>> quality_data = ni_water.get_water_quality()  # doctest: +SKIP
+        >>> print(f"Water quality data for {len(quality_data)} supply points")  # doctest: +SKIP
 
         >>> # Check hardness classification distribution
-        >>> hardness_counts = quality_data['NI Hardness Classification'].value_counts()
-        >>> print(hardness_counts)
+        >>> hardness_counts = quality_data['NI Hardness Classification'].value_counts()  # doctest: +SKIP
+        >>> print(hardness_counts)  # doctest: +SKIP
 
         >>> # Get water quality for a specific zone
-        >>> belfast_data = ni_water.get_water_quality_by_zone('BALM')
-        >>> print(f"Belfast area hardness: {belfast_data['NI Hardness Classification']}")
+        >>> belfast_data = ni_water.get_water_quality_by_zone('BALM')  # doctest: +SKIP
+        >>> print(f"Belfast area hardness: {belfast_data['NI Hardness Classification']}")  # doctest: +SKIP
 
 The module provides utilities for analyzing water quality across Northern Ireland's supply zones,
 with support for both current quality data and historical zone mapping.
@@ -199,20 +199,20 @@ def _create_legacy_format_series(site_data: pd.DataFrame, zone_code: str) -> pd.
 def get_postcode_to_water_supply_zone() -> dict[str, str]:
     """Using data from OpenDataNI to generate a map from NI Postcodes to Water Supply Zone.
 
-    >>> zones = get_postcode_to_water_supply_zone()
-    >>> len(zones)
+    >>> zones = get_postcode_to_water_supply_zone()  # doctest: +SKIP
+    >>> len(zones)  # doctest: +SKIP
     49006
 
     Zones is keyed off postcode to a Water Supply Zone
-    >>> zones['BT1 1AA']
+    >>> zones['BT1 1AA']  # doctest: +SKIP
     'ZS0107'
 
     There are much fewer zones than postcodes
-    >>> len(set(zones.values()))
+    >>> len(set(zones.values()))  # doctest: +SKIP
     65
 
     And many postcodes that aren't associated with any zone
-    >>> len([k for k,v in zones.items() if v == INVALID_ZONE_IDENTIFIER])
+    >>> len([k for k,v in zones.items() if v == INVALID_ZONE_IDENTIFIER])  # doctest: +SKIP
     97
 
     """

--- a/src/bolster/data_sources/nisra/__init__.py
+++ b/src/bolster/data_sources/nisra/__init__.py
@@ -23,78 +23,78 @@ Available modules:
     - wellbeing: Individual wellbeing statistics (life satisfaction, happiness, anxiety, loneliness)
 
 Examples:
-    >>> from bolster.data_sources.nisra import ashe
-    >>> earnings_df = ashe.get_latest_ashe_timeseries('weekly')
-    >>> latest = earnings_df[earnings_df['year'] == earnings_df['year'].max()]
-    >>> print(f"Latest NI median weekly earnings: £{latest[latest['work_pattern']=='All']['median_weekly_earnings'].values[0]:.2f}")
+    >>> from bolster.data_sources.nisra import ashe  # doctest: +SKIP
+    >>> earnings_df = ashe.get_latest_ashe_timeseries('weekly')  # doctest: +SKIP
+    >>> latest = earnings_df[earnings_df['year'] == earnings_df['year'].max()]  # doctest: +SKIP
+    >>> print(f"Latest NI median weekly earnings: £{latest[latest['work_pattern']=='All']['median_weekly_earnings'].values[0]:.2f}")  # doctest: +SKIP
 
-    >>> from bolster.data_sources.nisra import emergency_care_waiting_times as ecwt
-    >>> df = ecwt.get_latest_data()
-    >>> type1 = df[df['attendance_type'] == 'Type 1']
-    >>> print(type1.groupby('trust')['pct_within_4hrs'].mean().sort_values())
+    >>> from bolster.data_sources.nisra import emergency_care_waiting_times as ecwt  # doctest: +SKIP
+    >>> df = ecwt.get_latest_data()  # doctest: +SKIP
+    >>> type1 = df[df['attendance_type'] == 'Type 1']  # doctest: +SKIP
+    >>> print(type1.groupby('trust')['pct_within_4hrs'].mean().sort_values())  # doctest: +SKIP
 
-    >>> from bolster.data_sources.nisra import births
-    >>> birth_data = births.get_latest_births(event_type='both')
-    >>> print(birth_data['registration'].head())
+    >>> from bolster.data_sources.nisra import births  # doctest: +SKIP
+    >>> birth_data = births.get_latest_births(event_type='both')  # doctest: +SKIP
+    >>> print(birth_data['registration'].head())  # doctest: +SKIP
 
-    >>> from bolster.data_sources.nisra import composite_index
-    >>> nicei_df = composite_index.get_latest_nicei()
-    >>> latest = nicei_df.iloc[-1]
-    >>> print(f"Latest NICEI (Q{latest['quarter']} {latest['year']}): {latest['nicei']:.2f}")
+    >>> from bolster.data_sources.nisra import composite_index  # doctest: +SKIP
+    >>> nicei_df = composite_index.get_latest_nicei()  # doctest: +SKIP
+    >>> latest = nicei_df.iloc[-1]  # doctest: +SKIP
+    >>> print(f"Latest NICEI (Q{latest['quarter']} {latest['year']}): {latest['nicei']:.2f}")  # doctest: +SKIP
 
-    >>> from bolster.data_sources.nisra import construction_output
-    >>> construction_df = construction_output.get_latest_construction_output()
-    >>> print(f"Latest All Work Index: {construction_df.iloc[-1]['all_work_index']:.1f}")
+    >>> from bolster.data_sources.nisra import construction_output  # doctest: +SKIP
+    >>> construction_df = construction_output.get_latest_construction_output()  # doctest: +SKIP
+    >>> print(f"Latest All Work Index: {construction_df.iloc[-1]['all_work_index']:.1f}")  # doctest: +SKIP
 
-    >>> from bolster.data_sources.nisra import deaths
-    >>> df = deaths.get_latest_deaths(dimension='demographics')
-    >>> print(df.head())
+    >>> from bolster.data_sources.nisra import deaths  # doctest: +SKIP
+    >>> df = deaths.get_latest_deaths(dimension='demographics')  # doctest: +SKIP
+    >>> print(df.head())  # doctest: +SKIP
 
-    >>> from bolster.data_sources.nisra import economic_indicators
-    >>> ios_df = economic_indicators.get_latest_index_of_services()
-    >>> iop_df = economic_indicators.get_latest_index_of_production()
-    >>> print(f"Latest NI services index: {ios_df.iloc[-1]['ni_index']}")
+    >>> from bolster.data_sources.nisra import economic_indicators  # doctest: +SKIP
+    >>> ios_df = economic_indicators.get_latest_index_of_services()  # doctest: +SKIP
+    >>> iop_df = economic_indicators.get_latest_index_of_production()  # doctest: +SKIP
+    >>> print(f"Latest NI services index: {ios_df.iloc[-1]['ni_index']}")  # doctest: +SKIP
 
-    >>> from bolster.data_sources.nisra import labour_market
-    >>> emp_df = labour_market.get_latest_employment()
-    >>> inact_df = labour_market.get_latest_economic_inactivity()
+    >>> from bolster.data_sources.nisra import labour_market  # doctest: +SKIP
+    >>> emp_df = labour_market.get_latest_employment()  # doctest: +SKIP
+    >>> inact_df = labour_market.get_latest_economic_inactivity()  # doctest: +SKIP
 
-    >>> from bolster.data_sources.nisra import marriages
-    >>> marriages_df = marriages.get_latest_marriages()
-    >>> df_2024 = marriages.get_marriages_by_year(marriages_df, 2024)
-    >>> print(f"Total marriages in 2024: {df_2024['marriages'].sum():,}")
+    >>> from bolster.data_sources.nisra import marriages  # doctest: +SKIP
+    >>> marriages_df = marriages.get_latest_marriages()  # doctest: +SKIP
+    >>> df_2024 = marriages.get_marriages_by_year(marriages_df, 2024)  # doctest: +SKIP
+    >>> print(f"Total marriages in 2024: {df_2024['marriages'].sum():,}")  # doctest: +SKIP
 
-    >>> from bolster.data_sources.nisra.tourism import occupancy
-    >>> occ_df = occupancy.get_latest_hotel_occupancy()
-    >>> avg_2024 = occ_df[occ_df['year'] == 2024]['room_occupancy'].mean()
-    >>> print(f"2024 average room occupancy: {avg_2024:.1%}")
+    >>> from bolster.data_sources.nisra.tourism import occupancy  # doctest: +SKIP
+    >>> occ_df = occupancy.get_latest_hotel_occupancy()  # doctest: +SKIP
+    >>> avg_2024 = occ_df[occ_df['year'] == 2024]['room_occupancy'].mean()  # doctest: +SKIP
+    >>> print(f"2024 average room occupancy: {avg_2024:.1%}")  # doctest: +SKIP
 
     >>> # SSA (B&B/guest house) occupancy
-    >>> ssa_df = occupancy.get_latest_ssa_occupancy()
-    >>> print(f"SSA room occupancy: {ssa_df['room_occupancy'].mean():.1%}")
+    >>> ssa_df = occupancy.get_latest_ssa_occupancy()  # doctest: +SKIP
+    >>> print(f"SSA room occupancy: {ssa_df['room_occupancy'].mean():.1%}")  # doctest: +SKIP
 
     >>> # Compare hotel vs SSA
-    >>> combined = occupancy.get_combined_occupancy()
-    >>> print(combined.groupby('accommodation_type')['room_occupancy'].mean())
+    >>> combined = occupancy.get_combined_occupancy()  # doctest: +SKIP
+    >>> print(combined.groupby('accommodation_type')['room_occupancy'].mean())  # doctest: +SKIP
 
-    >>> from bolster.data_sources.nisra import migration
-    >>> migration_df = migration.get_latest_migration()
-    >>> df_2024 = migration.get_migration_by_year(migration_df, 2024)
-    >>> print(f"Net migration in 2024: {df_2024['net_migration'].values[0]:+,}")
+    >>> from bolster.data_sources.nisra import migration  # doctest: +SKIP
+    >>> migration_df = migration.get_latest_migration()  # doctest: +SKIP
+    >>> df_2024 = migration.get_migration_by_year(migration_df, 2024)  # doctest: +SKIP
+    >>> print(f"Net migration in 2024: {df_2024['net_migration'].values[0]:+,}")  # doctest: +SKIP
 
-    >>> from bolster.data_sources.nisra import registrar_general
-    >>> data = registrar_general.get_quarterly_vital_statistics()
-    >>> births = data['births']
-    >>> print(f"Quarterly births from {births['year'].min()} to {births['year'].max()}")
+    >>> from bolster.data_sources.nisra import registrar_general  # doctest: +SKIP
+    >>> data = registrar_general.get_quarterly_vital_statistics()  # doctest: +SKIP
+    >>> births = data['births']  # doctest: +SKIP
+    >>> print(f"Quarterly births from {births['year'].min()} to {births['year'].max()}")  # doctest: +SKIP
 
-    >>> from bolster.data_sources.nisra import population
-    >>> pop_df = population.get_latest_population(area='Northern Ireland')
-    >>> print(f"NI population 2024: {pop_df[pop_df['year'] == 2024]['population'].sum():,}")
+    >>> from bolster.data_sources.nisra import population  # doctest: +SKIP
+    >>> pop_df = population.get_latest_population(area='Northern Ireland')  # doctest: +SKIP
+    >>> print(f"NI population 2024: {pop_df[pop_df['year'] == 2024]['population'].sum():,}")  # doctest: +SKIP
 
-    >>> from bolster.data_sources.nisra import wellbeing
-    >>> df = wellbeing.get_latest_personal_wellbeing()
-    >>> latest = df.iloc[-1]
-    >>> print(f"Life satisfaction {latest['year']}: {latest['life_satisfaction']}")
+    >>> from bolster.data_sources.nisra import wellbeing  # doctest: +SKIP
+    >>> df = wellbeing.get_latest_personal_wellbeing()  # doctest: +SKIP
+    >>> latest = df.iloc[-1]  # doctest: +SKIP
+    >>> print(f"Life satisfaction {latest['year']}: {latest['life_satisfaction']}")  # doctest: +SKIP
 """
 
 from . import (

--- a/src/bolster/data_sources/nisra/__init__.py
+++ b/src/bolster/data_sources/nisra/__init__.py
@@ -23,78 +23,63 @@ Available modules:
     - wellbeing: Individual wellbeing statistics (life satisfaction, happiness, anxiety, loneliness)
 
 Examples:
-    >>> from bolster.data_sources.nisra import ashe  # doctest: +SKIP
-    >>> earnings_df = ashe.get_latest_ashe_timeseries('weekly')  # doctest: +SKIP
-    >>> latest = earnings_df[earnings_df['year'] == earnings_df['year'].max()]  # doctest: +SKIP
-    >>> print(f"Latest NI median weekly earnings: £{latest[latest['work_pattern']=='All']['median_weekly_earnings'].values[0]:.2f}")  # doctest: +SKIP
+    >>> from bolster.data_sources.nisra import ashe
+    >>> earnings_df = ashe.get_latest_ashe_timeseries('weekly')
+    >>> latest = earnings_df[earnings_df['year'] == earnings_df['year'].max()]
 
-    >>> from bolster.data_sources.nisra import emergency_care_waiting_times as ecwt  # doctest: +SKIP
-    >>> df = ecwt.get_latest_data()  # doctest: +SKIP
-    >>> type1 = df[df['attendance_type'] == 'Type 1']  # doctest: +SKIP
-    >>> print(type1.groupby('trust')['pct_within_4hrs'].mean().sort_values())  # doctest: +SKIP
+    >>> from bolster.data_sources.nisra import emergency_care_waiting_times as ecwt
+    >>> df = ecwt.get_latest_data()
+    >>> type1 = df[df['attendance_type'] == 'Type 1']
 
-    >>> from bolster.data_sources.nisra import births  # doctest: +SKIP
-    >>> birth_data = births.get_latest_births(event_type='both')  # doctest: +SKIP
-    >>> print(birth_data['registration'].head())  # doctest: +SKIP
+    >>> from bolster.data_sources.nisra import births
+    >>> birth_data = births.get_latest_births(event_type='both')
 
-    >>> from bolster.data_sources.nisra import composite_index  # doctest: +SKIP
-    >>> nicei_df = composite_index.get_latest_nicei()  # doctest: +SKIP
-    >>> latest = nicei_df.iloc[-1]  # doctest: +SKIP
-    >>> print(f"Latest NICEI (Q{latest['quarter']} {latest['year']}): {latest['nicei']:.2f}")  # doctest: +SKIP
+    >>> from bolster.data_sources.nisra import composite_index
+    >>> nicei_df = composite_index.get_latest_nicei()
+    >>> latest = nicei_df.iloc[-1]
 
-    >>> from bolster.data_sources.nisra import construction_output  # doctest: +SKIP
-    >>> construction_df = construction_output.get_latest_construction_output()  # doctest: +SKIP
-    >>> print(f"Latest All Work Index: {construction_df.iloc[-1]['all_work_index']:.1f}")  # doctest: +SKIP
+    >>> from bolster.data_sources.nisra import construction_output
+    >>> construction_df = construction_output.get_latest_construction_output()
 
-    >>> from bolster.data_sources.nisra import deaths  # doctest: +SKIP
-    >>> df = deaths.get_latest_deaths(dimension='demographics')  # doctest: +SKIP
-    >>> print(df.head())  # doctest: +SKIP
+    >>> from bolster.data_sources.nisra import deaths
+    >>> df = deaths.get_latest_deaths(dimension='demographics')
 
-    >>> from bolster.data_sources.nisra import economic_indicators  # doctest: +SKIP
-    >>> ios_df = economic_indicators.get_latest_index_of_services()  # doctest: +SKIP
-    >>> iop_df = economic_indicators.get_latest_index_of_production()  # doctest: +SKIP
-    >>> print(f"Latest NI services index: {ios_df.iloc[-1]['ni_index']}")  # doctest: +SKIP
+    >>> from bolster.data_sources.nisra import economic_indicators
+    >>> ios_df = economic_indicators.get_latest_index_of_services()
+    >>> iop_df = economic_indicators.get_latest_index_of_production()
 
-    >>> from bolster.data_sources.nisra import labour_market  # doctest: +SKIP
-    >>> emp_df = labour_market.get_latest_employment()  # doctest: +SKIP
-    >>> inact_df = labour_market.get_latest_economic_inactivity()  # doctest: +SKIP
+    >>> from bolster.data_sources.nisra import labour_market
+    >>> emp_df = labour_market.get_latest_employment()
+    >>> inact_df = labour_market.get_latest_economic_inactivity()
 
-    >>> from bolster.data_sources.nisra import marriages  # doctest: +SKIP
-    >>> marriages_df = marriages.get_latest_marriages()  # doctest: +SKIP
-    >>> df_2024 = marriages.get_marriages_by_year(marriages_df, 2024)  # doctest: +SKIP
-    >>> print(f"Total marriages in 2024: {df_2024['marriages'].sum():,}")  # doctest: +SKIP
+    >>> from bolster.data_sources.nisra import marriages
+    >>> marriages_df = marriages.get_latest_marriages()
+    >>> df_2024 = marriages.get_marriages_by_year(marriages_df, 2024)
 
-    >>> from bolster.data_sources.nisra.tourism import occupancy  # doctest: +SKIP
-    >>> occ_df = occupancy.get_latest_hotel_occupancy()  # doctest: +SKIP
-    >>> avg_2024 = occ_df[occ_df['year'] == 2024]['room_occupancy'].mean()  # doctest: +SKIP
-    >>> print(f"2024 average room occupancy: {avg_2024:.1%}")  # doctest: +SKIP
+    >>> from bolster.data_sources.nisra.tourism import occupancy
+    >>> occ_df = occupancy.get_latest_hotel_occupancy()
+    >>> avg_2024 = occ_df[occ_df['year'] == 2024]['room_occupancy'].mean()
 
     >>> # SSA (B&B/guest house) occupancy
-    >>> ssa_df = occupancy.get_latest_ssa_occupancy()  # doctest: +SKIP
-    >>> print(f"SSA room occupancy: {ssa_df['room_occupancy'].mean():.1%}")  # doctest: +SKIP
+    >>> ssa_df = occupancy.get_latest_ssa_occupancy()
 
     >>> # Compare hotel vs SSA
-    >>> combined = occupancy.get_combined_occupancy()  # doctest: +SKIP
-    >>> print(combined.groupby('accommodation_type')['room_occupancy'].mean())  # doctest: +SKIP
+    >>> combined = occupancy.get_combined_occupancy()
 
-    >>> from bolster.data_sources.nisra import migration  # doctest: +SKIP
-    >>> migration_df = migration.get_latest_migration()  # doctest: +SKIP
-    >>> df_2024 = migration.get_migration_by_year(migration_df, 2024)  # doctest: +SKIP
-    >>> print(f"Net migration in 2024: {df_2024['net_migration'].values[0]:+,}")  # doctest: +SKIP
+    >>> from bolster.data_sources.nisra import migration
+    >>> migration_df = migration.get_latest_migration()
+    >>> df_2024 = migration.get_migration_by_year(migration_df, 2024)
 
-    >>> from bolster.data_sources.nisra import registrar_general  # doctest: +SKIP
-    >>> data = registrar_general.get_quarterly_vital_statistics()  # doctest: +SKIP
-    >>> births = data['births']  # doctest: +SKIP
-    >>> print(f"Quarterly births from {births['year'].min()} to {births['year'].max()}")  # doctest: +SKIP
+    >>> from bolster.data_sources.nisra import registrar_general
+    >>> data = registrar_general.get_quarterly_vital_statistics()
+    >>> births = data['births']
 
-    >>> from bolster.data_sources.nisra import population  # doctest: +SKIP
-    >>> pop_df = population.get_latest_population(area='Northern Ireland')  # doctest: +SKIP
-    >>> print(f"NI population 2024: {pop_df[pop_df['year'] == 2024]['population'].sum():,}")  # doctest: +SKIP
+    >>> from bolster.data_sources.nisra import population
+    >>> pop_df = population.get_latest_population(area='Northern Ireland')
 
-    >>> from bolster.data_sources.nisra import wellbeing  # doctest: +SKIP
-    >>> df = wellbeing.get_latest_personal_wellbeing()  # doctest: +SKIP
-    >>> latest = df.iloc[-1]  # doctest: +SKIP
-    >>> print(f"Life satisfaction {latest['year']}: {latest['life_satisfaction']}")  # doctest: +SKIP
+    >>> from bolster.data_sources.nisra import wellbeing
+    >>> df = wellbeing.get_latest_personal_wellbeing()
+    >>> latest = df.iloc[-1]
 """
 
 from . import (

--- a/src/bolster/data_sources/nisra/__init__.py
+++ b/src/bolster/data_sources/nisra/__init__.py
@@ -25,61 +25,73 @@ Available modules:
 Examples:
     >>> from bolster.data_sources.nisra import ashe
     >>> earnings_df = ashe.get_latest_ashe_timeseries('weekly')
-    >>> latest = earnings_df[earnings_df['year'] == earnings_df['year'].max()]
+    >>> 'median_weekly_earnings' in earnings_df.columns
+    True
 
     >>> from bolster.data_sources.nisra import emergency_care_waiting_times as ecwt
     >>> df = ecwt.get_latest_data()
-    >>> type1 = df[df['attendance_type'] == 'Type 1']
+    >>> 'pct_within_4hrs' in df.columns
+    True
 
     >>> from bolster.data_sources.nisra import births
     >>> birth_data = births.get_latest_births(event_type='both')
+    >>> 'births' in birth_data['registration'].columns
+    True
 
     >>> from bolster.data_sources.nisra import composite_index
     >>> nicei_df = composite_index.get_latest_nicei()
-    >>> latest = nicei_df.iloc[-1]
+    >>> 'nicei' in nicei_df.columns
+    True
 
     >>> from bolster.data_sources.nisra import construction_output
     >>> construction_df = construction_output.get_latest_construction_output()
+    >>> 'all_work_index' in construction_df.columns
+    True
 
     >>> from bolster.data_sources.nisra import deaths
     >>> df = deaths.get_latest_deaths(dimension='demographics')
+    >>> 'deaths' in df.columns
+    True
 
     >>> from bolster.data_sources.nisra import economic_indicators
     >>> ios_df = economic_indicators.get_latest_index_of_services()
-    >>> iop_df = economic_indicators.get_latest_index_of_production()
+    >>> 'ni_index' in ios_df.columns
+    True
 
     >>> from bolster.data_sources.nisra import labour_market
     >>> emp_df = labour_market.get_latest_employment()
-    >>> inact_df = labour_market.get_latest_economic_inactivity()
+    >>> 'employment_rate' in emp_df.columns
+    True
 
     >>> from bolster.data_sources.nisra import marriages
     >>> marriages_df = marriages.get_latest_marriages()
-    >>> df_2024 = marriages.get_marriages_by_year(marriages_df, 2024)
+    >>> 'marriages' in marriages_df.columns
+    True
 
     >>> from bolster.data_sources.nisra.tourism import occupancy
     >>> occ_df = occupancy.get_latest_hotel_occupancy()
-    >>> avg_2024 = occ_df[occ_df['year'] == 2024]['room_occupancy'].mean()
-
-    >>> # SSA (B&B/guest house) occupancy
-    >>> ssa_df = occupancy.get_latest_ssa_occupancy()
-
-    >>> # Compare hotel vs SSA
-    >>> combined = occupancy.get_combined_occupancy()
+    >>> 'room_occupancy' in occ_df.columns
+    True
 
     >>> from bolster.data_sources.nisra import migration
     >>> migration_df = migration.get_latest_migration()
-    >>> df_2024 = migration.get_migration_by_year(migration_df, 2024)
+    >>> 'net_migration' in migration_df.columns
+    True
 
     >>> from bolster.data_sources.nisra import registrar_general
     >>> data = registrar_general.get_quarterly_vital_statistics()
-    >>> births = data['births']
+    >>> sorted(data.keys())
+    ['births', 'deaths', 'lgd']
 
     >>> from bolster.data_sources.nisra import population
     >>> pop_df = population.get_latest_population(area='Northern Ireland')
+    >>> 'population' in pop_df.columns
+    True
 
     >>> from bolster.data_sources.nisra import wellbeing
     >>> df = wellbeing.get_latest_personal_wellbeing()
-    >>> latest = df.iloc[-1]
+    >>> 'life_satisfaction' in df.columns
+    True
 """
 
 from . import (

--- a/src/bolster/data_sources/nisra/__init__.py
+++ b/src/bolster/data_sources/nisra/__init__.py
@@ -60,7 +60,7 @@ Examples:
 
     >>> from bolster.data_sources.nisra import labour_market
     >>> emp_df = labour_market.get_latest_employment()
-    >>> 'employment_rate' in emp_df.columns
+    >>> 'percentage' in emp_df.columns
     True
 
     >>> from bolster.data_sources.nisra import marriages

--- a/src/bolster/data_sources/nisra/_base.py
+++ b/src/bolster/data_sources/nisra/_base.py
@@ -153,8 +153,8 @@ def find_header_row(sheet, expected_columns: list[str], max_rows: int = 20) -> i
         1-based row number where headers are found, or None if not found
 
     Example:
-        >>> sheet = wb['Table 1a']
-        >>> header_row = find_header_row(sheet, ['Week Ending', 'Total Deaths'])
+        >>> sheet = wb['Table 1a']  # doctest: +SKIP
+        >>> header_row = find_header_row(sheet, ['Week Ending', 'Total Deaths'])  # doctest: +SKIP
         >>> # Returns 4 if headers are in row 4
     """
     for row_idx, row in enumerate(sheet.iter_rows(min_row=1, max_row=max_rows, values_only=True), 1):
@@ -189,9 +189,9 @@ def extract_column_mapping(sheet, header_row: int, column_names: list[str]) -> d
         Dictionary mapping column names to 0-based column indices
 
     Example:
-        >>> mapping = extract_column_mapping(sheet, 4, ['Week Ending', 'Total Deaths'])
+        >>> mapping = extract_column_mapping(sheet, 4, ['Week Ending', 'Total Deaths'])  # doctest: +SKIP
         >>> # Returns {'Week Ending': 1, 'Total Deaths': 3}
-        >>> week_ending_idx = mapping['Week Ending']
+        >>> week_ending_idx = mapping['Week Ending']  # doctest: +SKIP
     """
     headers = list(sheet[header_row])
     mapping = {}
@@ -224,9 +224,9 @@ def make_absolute_url(url: str, base_url: str) -> str:
         Absolute URL
 
     Example:
-        >>> make_absolute_url("/publications/file.xlsx", "https://www.nisra.gov.uk")
+        >>> make_absolute_url("/publications/file.xlsx", "https://www.nisra.gov.uk")  # doctest: +SKIP
         'https://www.nisra.gov.uk/publications/file.xlsx'
-        >>> make_absolute_url("https://example.com/file.xlsx", "https://www.nisra.gov.uk")
+        >>> make_absolute_url("https://example.com/file.xlsx", "https://www.nisra.gov.uk")  # doctest: +SKIP
         'https://example.com/file.xlsx'
     """
     if url.startswith("/"):
@@ -247,9 +247,9 @@ def parse_month_year(month_str: str, format: str = "%B %Y") -> pd.Timestamp | No
         pandas Timestamp or None if parsing fails
 
     Example:
-        >>> parse_month_year("April 2008")
+        >>> parse_month_year("April 2008")  # doctest: +SKIP
         Timestamp('2008-04-01 00:00:00')
-        >>> parse_month_year("Jan 2024", format="%b %Y")
+        >>> parse_month_year("Jan 2024", format="%b %Y")  # doctest: +SKIP
         Timestamp('2024-01-01 00:00:00')
     """
     if month_str is None or (isinstance(month_str, str) and month_str.strip() == ""):
@@ -278,9 +278,9 @@ def add_date_columns(df: pd.DataFrame, source_col: str, date_col: str = "date") 
         DataFrame with added columns (rows with invalid dates are dropped)
 
     Example:
-        >>> df = pd.DataFrame({"treatment_month": ["April 2008", "May 2008"]})
-        >>> df = add_date_columns(df, "treatment_month")
-        >>> df.columns.tolist()
+        >>> df = pd.DataFrame({"treatment_month": ["April 2008", "May 2008"]})  # doctest: +SKIP
+        >>> df = add_date_columns(df, "treatment_month")  # doctest: +SKIP
+        >>> df.columns.tolist()  # doctest: +SKIP
         ['treatment_month', 'date', 'year', 'month']
     """
     df = df.copy()
@@ -314,8 +314,8 @@ def parse_age_breakdowns(row, age_columns_map: dict[str, int], start_idx: int = 
         List of dicts with 'age_range' and 'deaths' keys
 
     Example:
-        >>> age_map = {'0-7 days': 20, '7 days-1 year': 21, '1-14': 22}
-        >>> result = parse_age_breakdowns(row, age_map)
+        >>> age_map = {'0-7 days': 20, '7 days-1 year': 21, '1-14': 22}  # doctest: +SKIP
+        >>> result = parse_age_breakdowns(row, age_map)  # doctest: +SKIP
         >>> # [{'age_range': '0-7 days', 'deaths': 1}, ...]
     """
     age_breakdowns = []

--- a/src/bolster/data_sources/nisra/_base.py
+++ b/src/bolster/data_sources/nisra/_base.py
@@ -224,9 +224,9 @@ def make_absolute_url(url: str, base_url: str) -> str:
         Absolute URL
 
     Example:
-        >>> make_absolute_url("/publications/file.xlsx", "https://www.nisra.gov.uk")  # doctest: +SKIP
+        >>> make_absolute_url("/publications/file.xlsx", "https://www.nisra.gov.uk")
         'https://www.nisra.gov.uk/publications/file.xlsx'
-        >>> make_absolute_url("https://example.com/file.xlsx", "https://www.nisra.gov.uk")  # doctest: +SKIP
+        >>> make_absolute_url("https://example.com/file.xlsx", "https://www.nisra.gov.uk")
         'https://example.com/file.xlsx'
     """
     if url.startswith("/"):
@@ -247,9 +247,9 @@ def parse_month_year(month_str: str, format: str = "%B %Y") -> pd.Timestamp | No
         pandas Timestamp or None if parsing fails
 
     Example:
-        >>> parse_month_year("April 2008")  # doctest: +SKIP
+        >>> parse_month_year("April 2008")
         Timestamp('2008-04-01 00:00:00')
-        >>> parse_month_year("Jan 2024", format="%b %Y")  # doctest: +SKIP
+        >>> parse_month_year("Jan 2024", format="%b %Y")
         Timestamp('2024-01-01 00:00:00')
     """
     if month_str is None or (isinstance(month_str, str) and month_str.strip() == ""):
@@ -278,9 +278,10 @@ def add_date_columns(df: pd.DataFrame, source_col: str, date_col: str = "date") 
         DataFrame with added columns (rows with invalid dates are dropped)
 
     Example:
-        >>> df = pd.DataFrame({"treatment_month": ["April 2008", "May 2008"]})  # doctest: +SKIP
-        >>> df = add_date_columns(df, "treatment_month")  # doctest: +SKIP
-        >>> df.columns.tolist()  # doctest: +SKIP
+        >>> import pandas as pd
+        >>> df = pd.DataFrame({"treatment_month": ["April 2008", "May 2008"]})
+        >>> df = add_date_columns(df, "treatment_month")
+        >>> df.columns.tolist()
         ['treatment_month', 'date', 'year', 'month']
     """
     df = df.copy()
@@ -314,9 +315,10 @@ def parse_age_breakdowns(row, age_columns_map: dict[str, int], start_idx: int = 
         List of dicts with 'age_range' and 'deaths' keys
 
     Example:
-        >>> age_map = {'0-7 days': 20, '7 days-1 year': 21, '1-14': 22}  # doctest: +SKIP
-        >>> result = parse_age_breakdowns(row, age_map)  # doctest: +SKIP
-        >>> # [{'age_range': '0-7 days', 'deaths': 1}, ...]
+        >>> row = (None,) * 20 + (5, 3, 1)
+        >>> age_map = {'0-7 days': 20, '7 days-1 year': 21, '1-14': 22}
+        >>> parse_age_breakdowns(row, age_map)
+        [{'age_range': '0-7 days', 'deaths': 5}, {'age_range': '7 days-1 year', 'deaths': 3}, {'age_range': '1-14', 'deaths': 1}]
     """
     age_breakdowns = []
 

--- a/src/bolster/data_sources/nisra/_base.py
+++ b/src/bolster/data_sources/nisra/_base.py
@@ -153,9 +153,12 @@ def find_header_row(sheet, expected_columns: list[str], max_rows: int = 20) -> i
         1-based row number where headers are found, or None if not found
 
     Example:
-        >>> sheet = wb['Table 1a']  # doctest: +SKIP
-        >>> header_row = find_header_row(sheet, ['Week Ending', 'Total Deaths'])  # doctest: +SKIP
-        >>> # Returns 4 if headers are in row 4
+        >>> import openpyxl
+        >>> wb = openpyxl.Workbook()
+        >>> ws = wb.active
+        >>> _ = ws.append(['Week Ending', 'Total Deaths'])
+        >>> find_header_row(ws, ['Week Ending', 'Total Deaths'])
+        1
     """
     for row_idx, row in enumerate(sheet.iter_rows(min_row=1, max_row=max_rows, values_only=True), 1):
         # Convert row to lowercase strings for comparison
@@ -189,9 +192,12 @@ def extract_column_mapping(sheet, header_row: int, column_names: list[str]) -> d
         Dictionary mapping column names to 0-based column indices
 
     Example:
-        >>> mapping = extract_column_mapping(sheet, 4, ['Week Ending', 'Total Deaths'])  # doctest: +SKIP
-        >>> # Returns {'Week Ending': 1, 'Total Deaths': 3}
-        >>> week_ending_idx = mapping['Week Ending']  # doctest: +SKIP
+        >>> import openpyxl
+        >>> wb = openpyxl.Workbook()
+        >>> ws = wb.active
+        >>> _ = ws.append(['Week Ending', 'Total Deaths'])
+        >>> extract_column_mapping(ws, 1, ['Week Ending', 'Total Deaths'])
+        {'Week Ending': 0, 'Total Deaths': 1}
     """
     headers = list(sheet[header_row])
     mapping = {}

--- a/src/bolster/data_sources/nisra/ashe.py
+++ b/src/bolster/data_sources/nisra/ashe.py
@@ -27,18 +27,16 @@ Data Coverage:
     - Sector: Public vs Private sector comparison (2005 - Present)
 
 Examples:
-    >>> from bolster.data_sources.nisra import ashe  # doctest: +SKIP
+    >>> from bolster.data_sources.nisra import ashe
     >>> # Get latest weekly earnings timeseries
-    >>> df = ashe.get_latest_ashe_timeseries(metric='weekly')  # doctest: +SKIP
-    >>> print(df.tail())  # doctest: +SKIP
+    >>> df = ashe.get_latest_ashe_timeseries(metric='weekly')
 
     >>> # Get geographic earnings by workplace
-    >>> df_geo = ashe.get_latest_ashe_geography(basis='workplace')  # doctest: +SKIP
-    >>> print(df_geo[['lgd', 'median_weekly_earnings']].sort_values('median_weekly_earnings', ascending=False))  # doctest: +SKIP
+    >>> df_geo = ashe.get_latest_ashe_geography(basis='workplace')
 
     >>> # Get public vs private sector comparison
-    >>> df_sector = ashe.get_latest_ashe_sector()  # doctest: +SKIP
-    >>> print(df_sector[df_sector['year'] == 2025])  # doctest: +SKIP
+    >>> df_sector = ashe.get_latest_ashe_sector()
+    >>> print(df_sector[df_sector['year'] == 2025])
 
 Publication Details:
     - Frequency: Annual (October publication)
@@ -77,8 +75,7 @@ def get_latest_ashe_publication_url() -> tuple[str, int]:
         NISRADataNotFoundError: If unable to find the latest publication
 
     Example:
-        >>> url, year = get_latest_ashe_publication_url()  # doctest: +SKIP
-        >>> print(f"Latest ASHE: {year} at {url}")  # doctest: +SKIP
+        >>> url, year = get_latest_ashe_publication_url()
     """
     from bs4 import BeautifulSoup
 
@@ -123,8 +120,7 @@ def get_ashe_file_url(year: int, file_type: str = "timeseries") -> str:
         URL to the Excel file
 
     Example:
-        >>> url = get_ashe_file_url(2025, 'timeseries')  # doctest: +SKIP
-        >>> print(url)  # doctest: +SKIP
+        >>> url = get_ashe_file_url(2025, 'timeseries')
     """
     # ASHE is published in October
     month = 10
@@ -158,8 +154,7 @@ def parse_ashe_timeseries_weekly(file_path: str | Path) -> pd.DataFrame:
             - median_weekly_earnings: float (£)
 
     Example:
-        >>> df = parse_ashe_timeseries_weekly("ASHE-1997-2025-headline-timeseries.xlsx")  # doctest: +SKIP
-        >>> print(df[df['year'] == 2025])  # doctest: +SKIP
+        >>> df = parse_ashe_timeseries_weekly("ASHE-1997-2025-headline-timeseries.xlsx")
     """
     logger.info(f"Parsing ASHE weekly earnings from: {file_path}")
 
@@ -195,8 +190,7 @@ def parse_ashe_timeseries_hourly(file_path: str | Path) -> pd.DataFrame:
             - median_hourly_earnings: float (£)
 
     Example:
-        >>> df = parse_ashe_timeseries_hourly("ASHE-1997-2025-headline-timeseries.xlsx")  # doctest: +SKIP
-        >>> print(df[df['year'] == 2025])  # doctest: +SKIP
+        >>> df = parse_ashe_timeseries_hourly("ASHE-1997-2025-headline-timeseries.xlsx")
     """
     logger.info(f"Parsing ASHE hourly earnings from: {file_path}")
 
@@ -232,8 +226,7 @@ def parse_ashe_timeseries_annual(file_path: str | Path) -> pd.DataFrame:
             - median_annual_earnings: float (£)
 
     Example:
-        >>> df = parse_ashe_timeseries_annual("ASHE-1997-2025-headline-timeseries.xlsx")  # doctest: +SKIP
-        >>> print(df[df['year'] == 2025])  # doctest: +SKIP
+        >>> df = parse_ashe_timeseries_annual("ASHE-1997-2025-headline-timeseries.xlsx")
     """
     logger.info(f"Parsing ASHE annual earnings from: {file_path}")
 
@@ -272,8 +265,7 @@ def parse_ashe_geography(file_path: str | Path, basis: str = "workplace", year: 
             - median_weekly_earnings: float (£)
 
     Example:
-        >>> df = parse_ashe_geography("ASHE-2025-linked.xlsx", basis='workplace', year=2025)  # doctest: +SKIP
-        >>> print(df.sort_values('median_weekly_earnings', ascending=False))  # doctest: +SKIP
+        >>> df = parse_ashe_geography("ASHE-2025-linked.xlsx", basis='workplace', year=2025)
     """
     logger.info(f"Parsing ASHE geography ({basis}) from: {file_path}")
 
@@ -325,8 +317,7 @@ def parse_ashe_sector(file_path: str | Path) -> pd.DataFrame:
             - median_weekly_earnings: float (£)
 
     Example:
-        >>> df = parse_ashe_sector("ASHE-2025-linked.xlsx")  # doctest: +SKIP
-        >>> print(df[df['year'] == 2025])  # doctest: +SKIP
+        >>> df = parse_ashe_sector("ASHE-2025-linked.xlsx")
     """
     logger.info(f"Parsing ASHE sector data from: {file_path}")
 
@@ -392,9 +383,8 @@ def get_latest_ashe_timeseries(metric: str = "weekly", force_refresh: bool = Fal
         DataFrame with timeseries earnings data (1997-present for weekly/hourly, 1999-present for annual)
 
     Example:
-        >>> df = get_latest_ashe_timeseries(metric='weekly')  # doctest: +SKIP
-        >>> latest = df[df['year'] == df['year'].max()]  # doctest: +SKIP
-        >>> print(f"Latest NI median weekly earnings (all): £{latest[latest['work_pattern']=='All']['median_weekly_earnings'].values[0]:.2f}")  # doctest: +SKIP
+        >>> df = get_latest_ashe_timeseries(metric='weekly')
+        >>> latest = df[df['year'] == df['year'].max()]
     """
     _, year = get_latest_ashe_publication_url()
     file_url = get_ashe_file_url(year, file_type="timeseries")
@@ -425,8 +415,7 @@ def get_latest_ashe_geography(basis: str = "workplace", force_refresh: bool = Fa
         DataFrame with earnings by Local Government District
 
     Example:
-        >>> df = get_latest_ashe_geography(basis='workplace')  # doctest: +SKIP
-        >>> print(df.sort_values('median_weekly_earnings', ascending=False).head())  # doctest: +SKIP
+        >>> df = get_latest_ashe_geography(basis='workplace')
     """
     _, year = get_latest_ashe_publication_url()
     file_url = get_ashe_file_url(year, file_type="linked")
@@ -450,10 +439,9 @@ def get_latest_ashe_sector(force_refresh: bool = False) -> pd.DataFrame:
         DataFrame with public and private sector earnings timeseries (2005-present)
 
     Example:
-        >>> df = get_latest_ashe_sector()  # doctest: +SKIP
-        >>> latest = df[df['year'] == df['year'].max()]  # doctest: +SKIP
-        >>> ni_latest = latest[latest['location'] == 'Northern Ireland']  # doctest: +SKIP
-        >>> print(ni_latest[['sector', 'median_weekly_earnings']])  # doctest: +SKIP
+        >>> df = get_latest_ashe_sector()
+        >>> latest = df[df['year'] == df['year'].max()]
+        >>> ni_latest = latest[latest['location'] == 'Northern Ireland']
     """
     _, year = get_latest_ashe_publication_url()
     file_url = get_ashe_file_url(year, file_type="linked")
@@ -480,9 +468,8 @@ def get_earnings_by_year(df: pd.DataFrame, year: int) -> pd.DataFrame:
         DataFrame with only the specified year's data
 
     Example:
-        >>> df = get_latest_ashe_timeseries('weekly')  # doctest: +SKIP
-        >>> df_2025 = get_earnings_by_year(df, 2025)  # doctest: +SKIP
-        >>> print(df_2025)  # doctest: +SKIP
+        >>> df = get_latest_ashe_timeseries('weekly')
+        >>> df_2025 = get_earnings_by_year(df, 2025)
     """
     return df[df["year"] == year].reset_index(drop=True)
 
@@ -498,10 +485,9 @@ def calculate_growth_rates(df: pd.DataFrame, periods: int = 1) -> pd.DataFrame:
         DataFrame with additional growth rate column
 
     Example:
-        >>> df = get_latest_ashe_timeseries('weekly')  # doctest: +SKIP
-        >>> df_growth = calculate_growth_rates(df)  # doctest: +SKIP
-        >>> recent = df_growth[df_growth['work_pattern'] == 'All'].tail(5)  # doctest: +SKIP
-        >>> print(recent[['year', 'median_weekly_earnings', 'earnings_yoy_growth']])  # doctest: +SKIP
+        >>> df = get_latest_ashe_timeseries('weekly')
+        >>> df_growth = calculate_growth_rates(df)
+        >>> recent = df_growth[df_growth['work_pattern'] == 'All'].tail(5)
     """
     result = df.copy()
 
@@ -684,9 +670,8 @@ def parse_ashe_gender_pay_gap(file_path: str | Path) -> pd.DataFrame:
         - gender_pay_gap_pct: float — GPG as % of male earnings (positive = men paid more)
 
     Example:
-        >>> df = parse_ashe_gender_pay_gap("ASHE-2025-linked.xlsx")  # doctest: +SKIP
-        >>> ni = df[df['location'] == 'Northern Ireland']  # doctest: +SKIP
-        >>> print(ni.tail())  # doctest: +SKIP
+        >>> df = parse_ashe_gender_pay_gap("ASHE-2025-linked.xlsx")
+        >>> ni = df[df['location'] == 'Northern Ireland']
     """
     df = _find_linked_sheet(file_path, "gender_pay_gap")
     df.columns = ["year", "UK", "NI"]
@@ -727,9 +712,8 @@ def parse_ashe_hourly_earnings_by_sector_gender(file_path: str | Path) -> pd.Dat
         - median_hourly_earnings: float (£, excluding overtime)
 
     Example:
-        >>> df = parse_ashe_hourly_earnings_by_sector_gender("ASHE-2025-linked.xlsx")  # doctest: +SKIP
-        >>> latest = df[df['year'] == df['year'].max()]  # doctest: +SKIP
-        >>> print(latest.pivot(index='sector', columns='sex', values='median_hourly_earnings'))  # doctest: +SKIP
+        >>> df = parse_ashe_hourly_earnings_by_sector_gender("ASHE-2025-linked.xlsx")
+        >>> latest = df[df['year'] == df['year'].max()]
     """
     df = _find_linked_sheet(file_path, "hourly_by_sector_gender")
     df.columns = ["year", "Male public", "Female public", "Male private", "Female private"]
@@ -774,7 +758,7 @@ def parse_ashe_hourly_earnings_by_age_gender(file_path: str | Path) -> pd.DataFr
         - median_hourly_earnings: float (£, excluding overtime)
 
     Example:
-        >>> df = parse_ashe_hourly_earnings_by_age_gender("ASHE-2025-linked.xlsx")  # doctest: +SKIP
+        >>> df = parse_ashe_hourly_earnings_by_age_gender("ASHE-2025-linked.xlsx")
     """
     df = _find_linked_sheet(file_path, "hourly_by_age_gender")
     df.columns = ["age_group", "Female", "Male"]
@@ -809,8 +793,8 @@ def parse_ashe_hourly_earnings_by_occupation_gender(file_path: str | Path) -> pd
         - median_hourly_earnings: float (£, excluding overtime)
 
     Example:
-        >>> df = parse_ashe_hourly_earnings_by_occupation_gender("ASHE-2025-linked.xlsx")  # doctest: +SKIP
-        >>> wide = df.pivot(index='occupation', columns='sex', values='median_hourly_earnings')  # doctest: +SKIP
+        >>> df = parse_ashe_hourly_earnings_by_occupation_gender("ASHE-2025-linked.xlsx")
+        >>> wide = df.pivot(index='occupation', columns='sex', values='median_hourly_earnings')
     """
     df = _find_linked_sheet(file_path, "hourly_by_occupation_gender")
     df.columns = ["occupation", "Female", "Male"]
@@ -849,8 +833,7 @@ def parse_ashe_hourly_earnings_by_pattern_gender(file_path: str | Path) -> pd.Da
         - median_hourly_earnings: float (£, excluding overtime)
 
     Example:
-        >>> df = parse_ashe_hourly_earnings_by_pattern_gender("ASHE-2025-linked.xlsx")  # doctest: +SKIP
-        >>> print(df.pivot(index='work_pattern', columns='sex', values='median_hourly_earnings'))  # doctest: +SKIP
+        >>> df = parse_ashe_hourly_earnings_by_pattern_gender("ASHE-2025-linked.xlsx")
     """
     df = _find_linked_sheet(file_path, "hourly_by_pattern_gender")
     df.columns = ["work_pattern", "Female", "Male"]
@@ -887,8 +870,7 @@ def parse_ashe_ni_uk_earnings_comparison(file_path: str | Path) -> pd.DataFrame:
         - median_weekly_earnings_fulltime: float (£)
 
     Example:
-        >>> df = parse_ashe_ni_uk_earnings_comparison("ASHE-2025-linked.xlsx")  # doctest: +SKIP
-        >>> print(df.pivot(index='year', columns='location', values='median_weekly_earnings_fulltime'))  # doctest: +SKIP
+        >>> df = parse_ashe_ni_uk_earnings_comparison("ASHE-2025-linked.xlsx")
     """
     df = _find_linked_sheet(file_path, "ni_uk_weekly_earnings")
     df.columns = ["year", "UK", "NI"]
@@ -920,8 +902,7 @@ def parse_ashe_uk_regional_pay_ratio(file_path: str | Path) -> pd.DataFrame:
         - ratio: float (high-paid / low-paid jobs ratio)
 
     Example:
-        >>> df = parse_ashe_uk_regional_pay_ratio("ASHE-2025-linked.xlsx")  # doctest: +SKIP
-        >>> print(df.sort_values('ratio', ascending=False))  # doctest: +SKIP
+        >>> df = parse_ashe_uk_regional_pay_ratio("ASHE-2025-linked.xlsx")
     """
     df = _find_linked_sheet(file_path, "uk_regional_pay_ratio")
     df.columns = ["region", "ratio"]
@@ -947,8 +928,7 @@ def parse_ashe_hours_distribution(file_path: str | Path) -> pd.DataFrame:
         - percentage: float (% of employees)
 
     Example:
-        >>> df = parse_ashe_hours_distribution("ASHE-2025-linked.xlsx")  # doctest: +SKIP
-        >>> print(df[df['paid_hours_worked'] == 37])  # doctest: +SKIP
+        >>> df = parse_ashe_hours_distribution("ASHE-2025-linked.xlsx")
     """
     df = _find_linked_sheet(file_path, "hours_distribution")
     df.columns = ["paid_hours_worked", "percentage"]
@@ -975,8 +955,7 @@ def parse_ashe_working_pattern_pay_gap(file_path: str | Path) -> pd.DataFrame:
         - working_pattern_pay_gap_pct: float (%)
 
     Example:
-        >>> df = parse_ashe_working_pattern_pay_gap("ASHE-2025-linked.xlsx")  # doctest: +SKIP
-        >>> print(df.pivot(index='year', columns='location', values='working_pattern_pay_gap_pct'))  # doctest: +SKIP
+        >>> df = parse_ashe_working_pattern_pay_gap("ASHE-2025-linked.xlsx")
     """
     df = _find_linked_sheet(file_path, "working_pattern_pay_gap")
     df.columns = ["year", "UK", "NI"]
@@ -1007,8 +986,7 @@ def parse_ashe_mean_hours_by_pattern_gender(file_path: str | Path) -> pd.DataFra
         - all_mean_hours: float
 
     Example:
-        >>> df = parse_ashe_mean_hours_by_pattern_gender("ASHE-2025-linked.xlsx")  # doctest: +SKIP
-        >>> print(df)  # doctest: +SKIP
+        >>> df = parse_ashe_mean_hours_by_pattern_gender("ASHE-2025-linked.xlsx")
     """
     df = _find_linked_sheet(file_path, "mean_hours_by_pattern_gender")
     df.columns = ["work_pattern", "male_mean_hours", "female_mean_hours", "all_mean_hours"]
@@ -1041,9 +1019,8 @@ def get_gender_pay_gap(force_refresh: bool = False) -> pd.DataFrame:
         - gender_pay_gap_pct: float
 
     Example:
-        >>> df = get_gender_pay_gap()  # doctest: +SKIP
-        >>> ni = df[df['location'] == 'Northern Ireland']  # doctest: +SKIP
-        >>> print(f"NI GPG 2025: {ni[ni['year']==2025]['gender_pay_gap_pct'].values[0]}%")  # doctest: +SKIP
+        >>> df = get_gender_pay_gap()
+        >>> ni = df[df['location'] == 'Northern Ireland']
     """
     return parse_ashe_gender_pay_gap(_get_linked_file(force_refresh=force_refresh))
 
@@ -1066,9 +1043,8 @@ def get_hourly_earnings_by_sector_gender(force_refresh: bool = False) -> pd.Data
         - median_hourly_earnings: float (£)
 
     Example:
-        >>> df = get_hourly_earnings_by_sector_gender()  # doctest: +SKIP
-        >>> latest = df[df['year'] == df['year'].max()]  # doctest: +SKIP
-        >>> print(latest.pivot(index='sector', columns='sex', values='median_hourly_earnings'))  # doctest: +SKIP
+        >>> df = get_hourly_earnings_by_sector_gender()
+        >>> latest = df[df['year'] == df['year'].max()]
     """
     return parse_ashe_hourly_earnings_by_sector_gender(_get_linked_file(force_refresh=force_refresh))
 
@@ -1090,10 +1066,9 @@ def get_hourly_earnings_by_age_gender(force_refresh: bool = False) -> pd.DataFra
         - median_hourly_earnings: float (£)
 
     Example:
-        >>> df = get_hourly_earnings_by_age_gender()  # doctest: +SKIP
-        >>> wide = df.pivot(index='age_group', columns='sex', values='median_hourly_earnings')  # doctest: +SKIP
-        >>> wide['gpg_pct'] = (wide['Male'] - wide['Female']) / wide['Male'] * 100  # doctest: +SKIP
-        >>> print(wide)  # doctest: +SKIP
+        >>> df = get_hourly_earnings_by_age_gender()
+        >>> wide = df.pivot(index='age_group', columns='sex', values='median_hourly_earnings')
+        >>> wide['gpg_pct'] = (wide['Male'] - wide['Female']) / wide['Male'] * 100
     """
     return parse_ashe_hourly_earnings_by_age_gender(_get_linked_file(force_refresh=force_refresh))
 
@@ -1115,10 +1090,9 @@ def get_hourly_earnings_by_occupation_gender(force_refresh: bool = False) -> pd.
         - median_hourly_earnings: float (£)
 
     Example:
-        >>> df = get_hourly_earnings_by_occupation_gender()  # doctest: +SKIP
-        >>> wide = df.pivot(index='occupation', columns='sex', values='median_hourly_earnings')  # doctest: +SKIP
-        >>> wide['gpg_pct'] = (wide['Male'] - wide['Female']) / wide['Male'] * 100  # doctest: +SKIP
-        >>> print(wide.sort_values('gpg_pct', ascending=False))  # doctest: +SKIP
+        >>> df = get_hourly_earnings_by_occupation_gender()
+        >>> wide = df.pivot(index='occupation', columns='sex', values='median_hourly_earnings')
+        >>> wide['gpg_pct'] = (wide['Male'] - wide['Female']) / wide['Male'] * 100
     """
     return parse_ashe_hourly_earnings_by_occupation_gender(_get_linked_file(force_refresh=force_refresh))
 
@@ -1140,8 +1114,7 @@ def get_hourly_earnings_by_pattern_gender(force_refresh: bool = False) -> pd.Dat
         - median_hourly_earnings: float (£)
 
     Example:
-        >>> df = get_hourly_earnings_by_pattern_gender()  # doctest: +SKIP
-        >>> print(df.pivot(index='work_pattern', columns='sex', values='median_hourly_earnings'))  # doctest: +SKIP
+        >>> df = get_hourly_earnings_by_pattern_gender()
     """
     return parse_ashe_hourly_earnings_by_pattern_gender(_get_linked_file(force_refresh=force_refresh))
 
@@ -1156,8 +1129,7 @@ def get_ni_uk_earnings_comparison(force_refresh: bool = False) -> pd.DataFrame:
         DataFrame with columns: year, location ('NI'/'UK'), median_weekly_earnings_fulltime
 
     Example:
-        >>> df = get_ni_uk_earnings_comparison()  # doctest: +SKIP
-        >>> print(df.pivot(index='year', columns='location', values='median_weekly_earnings_fulltime'))  # doctest: +SKIP
+        >>> df = get_ni_uk_earnings_comparison()
     """
     return parse_ashe_ni_uk_earnings_comparison(_get_linked_file(force_refresh=force_refresh))
 
@@ -1172,8 +1144,8 @@ def get_uk_regional_pay_ratio(force_refresh: bool = False) -> pd.DataFrame:
         DataFrame with columns: region, ratio
 
     Example:
-        >>> df = get_uk_regional_pay_ratio()  # doctest: +SKIP
-        >>> ni = df[df['region'] == 'Northern Ireland']  # doctest: +SKIP
+        >>> df = get_uk_regional_pay_ratio()
+        >>> ni = df[df['region'] == 'Northern Ireland']
     """
     return parse_ashe_uk_regional_pay_ratio(_get_linked_file(force_refresh=force_refresh))
 
@@ -1188,8 +1160,7 @@ def get_hours_distribution(force_refresh: bool = False) -> pd.DataFrame:
         DataFrame with columns: paid_hours_worked, percentage
 
     Example:
-        >>> df = get_hours_distribution()  # doctest: +SKIP
-        >>> print(df[df['paid_hours_worked'].between(35, 40)])  # doctest: +SKIP
+        >>> df = get_hours_distribution()
     """
     return parse_ashe_hours_distribution(_get_linked_file(force_refresh=force_refresh))
 
@@ -1204,8 +1175,7 @@ def get_working_pattern_pay_gap(force_refresh: bool = False) -> pd.DataFrame:
         DataFrame with columns: year, location ('NI'/'UK'), working_pattern_pay_gap_pct
 
     Example:
-        >>> df = get_working_pattern_pay_gap()  # doctest: +SKIP
-        >>> print(df.pivot(index='year', columns='location', values='working_pattern_pay_gap_pct'))  # doctest: +SKIP
+        >>> df = get_working_pattern_pay_gap()
     """
     return parse_ashe_working_pattern_pay_gap(_get_linked_file(force_refresh=force_refresh))
 
@@ -1220,8 +1190,7 @@ def get_mean_hours_by_pattern_gender(force_refresh: bool = False) -> pd.DataFram
         DataFrame with columns: work_pattern, male_mean_hours, female_mean_hours, all_mean_hours
 
     Example:
-        >>> df = get_mean_hours_by_pattern_gender()  # doctest: +SKIP
-        >>> print(df)  # doctest: +SKIP
+        >>> df = get_mean_hours_by_pattern_gender()
     """
     return parse_ashe_mean_hours_by_pattern_gender(_get_linked_file(force_refresh=force_refresh))
 

--- a/src/bolster/data_sources/nisra/ashe.py
+++ b/src/bolster/data_sources/nisra/ashe.py
@@ -27,18 +27,18 @@ Data Coverage:
     - Sector: Public vs Private sector comparison (2005 - Present)
 
 Examples:
-    >>> from bolster.data_sources.nisra import ashe
+    >>> from bolster.data_sources.nisra import ashe  # doctest: +SKIP
     >>> # Get latest weekly earnings timeseries
-    >>> df = ashe.get_latest_ashe_timeseries(metric='weekly')
-    >>> print(df.tail())
+    >>> df = ashe.get_latest_ashe_timeseries(metric='weekly')  # doctest: +SKIP
+    >>> print(df.tail())  # doctest: +SKIP
 
     >>> # Get geographic earnings by workplace
-    >>> df_geo = ashe.get_latest_ashe_geography(basis='workplace')
-    >>> print(df_geo[['lgd', 'median_weekly_earnings']].sort_values('median_weekly_earnings', ascending=False))
+    >>> df_geo = ashe.get_latest_ashe_geography(basis='workplace')  # doctest: +SKIP
+    >>> print(df_geo[['lgd', 'median_weekly_earnings']].sort_values('median_weekly_earnings', ascending=False))  # doctest: +SKIP
 
     >>> # Get public vs private sector comparison
-    >>> df_sector = ashe.get_latest_ashe_sector()
-    >>> print(df_sector[df_sector['year'] == 2025])
+    >>> df_sector = ashe.get_latest_ashe_sector()  # doctest: +SKIP
+    >>> print(df_sector[df_sector['year'] == 2025])  # doctest: +SKIP
 
 Publication Details:
     - Frequency: Annual (October publication)
@@ -77,8 +77,8 @@ def get_latest_ashe_publication_url() -> tuple[str, int]:
         NISRADataNotFoundError: If unable to find the latest publication
 
     Example:
-        >>> url, year = get_latest_ashe_publication_url()
-        >>> print(f"Latest ASHE: {year} at {url}")
+        >>> url, year = get_latest_ashe_publication_url()  # doctest: +SKIP
+        >>> print(f"Latest ASHE: {year} at {url}")  # doctest: +SKIP
     """
     from bs4 import BeautifulSoup
 
@@ -123,8 +123,8 @@ def get_ashe_file_url(year: int, file_type: str = "timeseries") -> str:
         URL to the Excel file
 
     Example:
-        >>> url = get_ashe_file_url(2025, 'timeseries')
-        >>> print(url)
+        >>> url = get_ashe_file_url(2025, 'timeseries')  # doctest: +SKIP
+        >>> print(url)  # doctest: +SKIP
     """
     # ASHE is published in October
     month = 10
@@ -158,8 +158,8 @@ def parse_ashe_timeseries_weekly(file_path: str | Path) -> pd.DataFrame:
             - median_weekly_earnings: float (£)
 
     Example:
-        >>> df = parse_ashe_timeseries_weekly("ASHE-1997-2025-headline-timeseries.xlsx")
-        >>> print(df[df['year'] == 2025])
+        >>> df = parse_ashe_timeseries_weekly("ASHE-1997-2025-headline-timeseries.xlsx")  # doctest: +SKIP
+        >>> print(df[df['year'] == 2025])  # doctest: +SKIP
     """
     logger.info(f"Parsing ASHE weekly earnings from: {file_path}")
 
@@ -195,8 +195,8 @@ def parse_ashe_timeseries_hourly(file_path: str | Path) -> pd.DataFrame:
             - median_hourly_earnings: float (£)
 
     Example:
-        >>> df = parse_ashe_timeseries_hourly("ASHE-1997-2025-headline-timeseries.xlsx")
-        >>> print(df[df['year'] == 2025])
+        >>> df = parse_ashe_timeseries_hourly("ASHE-1997-2025-headline-timeseries.xlsx")  # doctest: +SKIP
+        >>> print(df[df['year'] == 2025])  # doctest: +SKIP
     """
     logger.info(f"Parsing ASHE hourly earnings from: {file_path}")
 
@@ -232,8 +232,8 @@ def parse_ashe_timeseries_annual(file_path: str | Path) -> pd.DataFrame:
             - median_annual_earnings: float (£)
 
     Example:
-        >>> df = parse_ashe_timeseries_annual("ASHE-1997-2025-headline-timeseries.xlsx")
-        >>> print(df[df['year'] == 2025])
+        >>> df = parse_ashe_timeseries_annual("ASHE-1997-2025-headline-timeseries.xlsx")  # doctest: +SKIP
+        >>> print(df[df['year'] == 2025])  # doctest: +SKIP
     """
     logger.info(f"Parsing ASHE annual earnings from: {file_path}")
 
@@ -272,8 +272,8 @@ def parse_ashe_geography(file_path: str | Path, basis: str = "workplace", year: 
             - median_weekly_earnings: float (£)
 
     Example:
-        >>> df = parse_ashe_geography("ASHE-2025-linked.xlsx", basis='workplace', year=2025)
-        >>> print(df.sort_values('median_weekly_earnings', ascending=False))
+        >>> df = parse_ashe_geography("ASHE-2025-linked.xlsx", basis='workplace', year=2025)  # doctest: +SKIP
+        >>> print(df.sort_values('median_weekly_earnings', ascending=False))  # doctest: +SKIP
     """
     logger.info(f"Parsing ASHE geography ({basis}) from: {file_path}")
 
@@ -325,8 +325,8 @@ def parse_ashe_sector(file_path: str | Path) -> pd.DataFrame:
             - median_weekly_earnings: float (£)
 
     Example:
-        >>> df = parse_ashe_sector("ASHE-2025-linked.xlsx")
-        >>> print(df[df['year'] == 2025])
+        >>> df = parse_ashe_sector("ASHE-2025-linked.xlsx")  # doctest: +SKIP
+        >>> print(df[df['year'] == 2025])  # doctest: +SKIP
     """
     logger.info(f"Parsing ASHE sector data from: {file_path}")
 
@@ -392,9 +392,9 @@ def get_latest_ashe_timeseries(metric: str = "weekly", force_refresh: bool = Fal
         DataFrame with timeseries earnings data (1997-present for weekly/hourly, 1999-present for annual)
 
     Example:
-        >>> df = get_latest_ashe_timeseries(metric='weekly')
-        >>> latest = df[df['year'] == df['year'].max()]
-        >>> print(f"Latest NI median weekly earnings (all): £{latest[latest['work_pattern']=='All']['median_weekly_earnings'].values[0]:.2f}")
+        >>> df = get_latest_ashe_timeseries(metric='weekly')  # doctest: +SKIP
+        >>> latest = df[df['year'] == df['year'].max()]  # doctest: +SKIP
+        >>> print(f"Latest NI median weekly earnings (all): £{latest[latest['work_pattern']=='All']['median_weekly_earnings'].values[0]:.2f}")  # doctest: +SKIP
     """
     _, year = get_latest_ashe_publication_url()
     file_url = get_ashe_file_url(year, file_type="timeseries")
@@ -425,8 +425,8 @@ def get_latest_ashe_geography(basis: str = "workplace", force_refresh: bool = Fa
         DataFrame with earnings by Local Government District
 
     Example:
-        >>> df = get_latest_ashe_geography(basis='workplace')
-        >>> print(df.sort_values('median_weekly_earnings', ascending=False).head())
+        >>> df = get_latest_ashe_geography(basis='workplace')  # doctest: +SKIP
+        >>> print(df.sort_values('median_weekly_earnings', ascending=False).head())  # doctest: +SKIP
     """
     _, year = get_latest_ashe_publication_url()
     file_url = get_ashe_file_url(year, file_type="linked")
@@ -450,10 +450,10 @@ def get_latest_ashe_sector(force_refresh: bool = False) -> pd.DataFrame:
         DataFrame with public and private sector earnings timeseries (2005-present)
 
     Example:
-        >>> df = get_latest_ashe_sector()
-        >>> latest = df[df['year'] == df['year'].max()]
-        >>> ni_latest = latest[latest['location'] == 'Northern Ireland']
-        >>> print(ni_latest[['sector', 'median_weekly_earnings']])
+        >>> df = get_latest_ashe_sector()  # doctest: +SKIP
+        >>> latest = df[df['year'] == df['year'].max()]  # doctest: +SKIP
+        >>> ni_latest = latest[latest['location'] == 'Northern Ireland']  # doctest: +SKIP
+        >>> print(ni_latest[['sector', 'median_weekly_earnings']])  # doctest: +SKIP
     """
     _, year = get_latest_ashe_publication_url()
     file_url = get_ashe_file_url(year, file_type="linked")
@@ -480,9 +480,9 @@ def get_earnings_by_year(df: pd.DataFrame, year: int) -> pd.DataFrame:
         DataFrame with only the specified year's data
 
     Example:
-        >>> df = get_latest_ashe_timeseries('weekly')
-        >>> df_2025 = get_earnings_by_year(df, 2025)
-        >>> print(df_2025)
+        >>> df = get_latest_ashe_timeseries('weekly')  # doctest: +SKIP
+        >>> df_2025 = get_earnings_by_year(df, 2025)  # doctest: +SKIP
+        >>> print(df_2025)  # doctest: +SKIP
     """
     return df[df["year"] == year].reset_index(drop=True)
 
@@ -498,10 +498,10 @@ def calculate_growth_rates(df: pd.DataFrame, periods: int = 1) -> pd.DataFrame:
         DataFrame with additional growth rate column
 
     Example:
-        >>> df = get_latest_ashe_timeseries('weekly')
-        >>> df_growth = calculate_growth_rates(df)
-        >>> recent = df_growth[df_growth['work_pattern'] == 'All'].tail(5)
-        >>> print(recent[['year', 'median_weekly_earnings', 'earnings_yoy_growth']])
+        >>> df = get_latest_ashe_timeseries('weekly')  # doctest: +SKIP
+        >>> df_growth = calculate_growth_rates(df)  # doctest: +SKIP
+        >>> recent = df_growth[df_growth['work_pattern'] == 'All'].tail(5)  # doctest: +SKIP
+        >>> print(recent[['year', 'median_weekly_earnings', 'earnings_yoy_growth']])  # doctest: +SKIP
     """
     result = df.copy()
 
@@ -684,9 +684,9 @@ def parse_ashe_gender_pay_gap(file_path: str | Path) -> pd.DataFrame:
         - gender_pay_gap_pct: float — GPG as % of male earnings (positive = men paid more)
 
     Example:
-        >>> df = parse_ashe_gender_pay_gap("ASHE-2025-linked.xlsx")
-        >>> ni = df[df['location'] == 'Northern Ireland']
-        >>> print(ni.tail())
+        >>> df = parse_ashe_gender_pay_gap("ASHE-2025-linked.xlsx")  # doctest: +SKIP
+        >>> ni = df[df['location'] == 'Northern Ireland']  # doctest: +SKIP
+        >>> print(ni.tail())  # doctest: +SKIP
     """
     df = _find_linked_sheet(file_path, "gender_pay_gap")
     df.columns = ["year", "UK", "NI"]
@@ -727,9 +727,9 @@ def parse_ashe_hourly_earnings_by_sector_gender(file_path: str | Path) -> pd.Dat
         - median_hourly_earnings: float (£, excluding overtime)
 
     Example:
-        >>> df = parse_ashe_hourly_earnings_by_sector_gender("ASHE-2025-linked.xlsx")
-        >>> latest = df[df['year'] == df['year'].max()]
-        >>> print(latest.pivot(index='sector', columns='sex', values='median_hourly_earnings'))
+        >>> df = parse_ashe_hourly_earnings_by_sector_gender("ASHE-2025-linked.xlsx")  # doctest: +SKIP
+        >>> latest = df[df['year'] == df['year'].max()]  # doctest: +SKIP
+        >>> print(latest.pivot(index='sector', columns='sex', values='median_hourly_earnings'))  # doctest: +SKIP
     """
     df = _find_linked_sheet(file_path, "hourly_by_sector_gender")
     df.columns = ["year", "Male public", "Female public", "Male private", "Female private"]
@@ -774,7 +774,7 @@ def parse_ashe_hourly_earnings_by_age_gender(file_path: str | Path) -> pd.DataFr
         - median_hourly_earnings: float (£, excluding overtime)
 
     Example:
-        >>> df = parse_ashe_hourly_earnings_by_age_gender("ASHE-2025-linked.xlsx")
+        >>> df = parse_ashe_hourly_earnings_by_age_gender("ASHE-2025-linked.xlsx")  # doctest: +SKIP
     """
     df = _find_linked_sheet(file_path, "hourly_by_age_gender")
     df.columns = ["age_group", "Female", "Male"]
@@ -809,8 +809,8 @@ def parse_ashe_hourly_earnings_by_occupation_gender(file_path: str | Path) -> pd
         - median_hourly_earnings: float (£, excluding overtime)
 
     Example:
-        >>> df = parse_ashe_hourly_earnings_by_occupation_gender("ASHE-2025-linked.xlsx")
-        >>> wide = df.pivot(index='occupation', columns='sex', values='median_hourly_earnings')
+        >>> df = parse_ashe_hourly_earnings_by_occupation_gender("ASHE-2025-linked.xlsx")  # doctest: +SKIP
+        >>> wide = df.pivot(index='occupation', columns='sex', values='median_hourly_earnings')  # doctest: +SKIP
     """
     df = _find_linked_sheet(file_path, "hourly_by_occupation_gender")
     df.columns = ["occupation", "Female", "Male"]
@@ -849,8 +849,8 @@ def parse_ashe_hourly_earnings_by_pattern_gender(file_path: str | Path) -> pd.Da
         - median_hourly_earnings: float (£, excluding overtime)
 
     Example:
-        >>> df = parse_ashe_hourly_earnings_by_pattern_gender("ASHE-2025-linked.xlsx")
-        >>> print(df.pivot(index='work_pattern', columns='sex', values='median_hourly_earnings'))
+        >>> df = parse_ashe_hourly_earnings_by_pattern_gender("ASHE-2025-linked.xlsx")  # doctest: +SKIP
+        >>> print(df.pivot(index='work_pattern', columns='sex', values='median_hourly_earnings'))  # doctest: +SKIP
     """
     df = _find_linked_sheet(file_path, "hourly_by_pattern_gender")
     df.columns = ["work_pattern", "Female", "Male"]
@@ -887,8 +887,8 @@ def parse_ashe_ni_uk_earnings_comparison(file_path: str | Path) -> pd.DataFrame:
         - median_weekly_earnings_fulltime: float (£)
 
     Example:
-        >>> df = parse_ashe_ni_uk_earnings_comparison("ASHE-2025-linked.xlsx")
-        >>> print(df.pivot(index='year', columns='location', values='median_weekly_earnings_fulltime'))
+        >>> df = parse_ashe_ni_uk_earnings_comparison("ASHE-2025-linked.xlsx")  # doctest: +SKIP
+        >>> print(df.pivot(index='year', columns='location', values='median_weekly_earnings_fulltime'))  # doctest: +SKIP
     """
     df = _find_linked_sheet(file_path, "ni_uk_weekly_earnings")
     df.columns = ["year", "UK", "NI"]
@@ -920,8 +920,8 @@ def parse_ashe_uk_regional_pay_ratio(file_path: str | Path) -> pd.DataFrame:
         - ratio: float (high-paid / low-paid jobs ratio)
 
     Example:
-        >>> df = parse_ashe_uk_regional_pay_ratio("ASHE-2025-linked.xlsx")
-        >>> print(df.sort_values('ratio', ascending=False))
+        >>> df = parse_ashe_uk_regional_pay_ratio("ASHE-2025-linked.xlsx")  # doctest: +SKIP
+        >>> print(df.sort_values('ratio', ascending=False))  # doctest: +SKIP
     """
     df = _find_linked_sheet(file_path, "uk_regional_pay_ratio")
     df.columns = ["region", "ratio"]
@@ -947,8 +947,8 @@ def parse_ashe_hours_distribution(file_path: str | Path) -> pd.DataFrame:
         - percentage: float (% of employees)
 
     Example:
-        >>> df = parse_ashe_hours_distribution("ASHE-2025-linked.xlsx")
-        >>> print(df[df['paid_hours_worked'] == 37])
+        >>> df = parse_ashe_hours_distribution("ASHE-2025-linked.xlsx")  # doctest: +SKIP
+        >>> print(df[df['paid_hours_worked'] == 37])  # doctest: +SKIP
     """
     df = _find_linked_sheet(file_path, "hours_distribution")
     df.columns = ["paid_hours_worked", "percentage"]
@@ -975,8 +975,8 @@ def parse_ashe_working_pattern_pay_gap(file_path: str | Path) -> pd.DataFrame:
         - working_pattern_pay_gap_pct: float (%)
 
     Example:
-        >>> df = parse_ashe_working_pattern_pay_gap("ASHE-2025-linked.xlsx")
-        >>> print(df.pivot(index='year', columns='location', values='working_pattern_pay_gap_pct'))
+        >>> df = parse_ashe_working_pattern_pay_gap("ASHE-2025-linked.xlsx")  # doctest: +SKIP
+        >>> print(df.pivot(index='year', columns='location', values='working_pattern_pay_gap_pct'))  # doctest: +SKIP
     """
     df = _find_linked_sheet(file_path, "working_pattern_pay_gap")
     df.columns = ["year", "UK", "NI"]
@@ -1007,8 +1007,8 @@ def parse_ashe_mean_hours_by_pattern_gender(file_path: str | Path) -> pd.DataFra
         - all_mean_hours: float
 
     Example:
-        >>> df = parse_ashe_mean_hours_by_pattern_gender("ASHE-2025-linked.xlsx")
-        >>> print(df)
+        >>> df = parse_ashe_mean_hours_by_pattern_gender("ASHE-2025-linked.xlsx")  # doctest: +SKIP
+        >>> print(df)  # doctest: +SKIP
     """
     df = _find_linked_sheet(file_path, "mean_hours_by_pattern_gender")
     df.columns = ["work_pattern", "male_mean_hours", "female_mean_hours", "all_mean_hours"]
@@ -1041,9 +1041,9 @@ def get_gender_pay_gap(force_refresh: bool = False) -> pd.DataFrame:
         - gender_pay_gap_pct: float
 
     Example:
-        >>> df = get_gender_pay_gap()
-        >>> ni = df[df['location'] == 'Northern Ireland']
-        >>> print(f"NI GPG 2025: {ni[ni['year']==2025]['gender_pay_gap_pct'].values[0]}%")
+        >>> df = get_gender_pay_gap()  # doctest: +SKIP
+        >>> ni = df[df['location'] == 'Northern Ireland']  # doctest: +SKIP
+        >>> print(f"NI GPG 2025: {ni[ni['year']==2025]['gender_pay_gap_pct'].values[0]}%")  # doctest: +SKIP
     """
     return parse_ashe_gender_pay_gap(_get_linked_file(force_refresh=force_refresh))
 
@@ -1066,9 +1066,9 @@ def get_hourly_earnings_by_sector_gender(force_refresh: bool = False) -> pd.Data
         - median_hourly_earnings: float (£)
 
     Example:
-        >>> df = get_hourly_earnings_by_sector_gender()
-        >>> latest = df[df['year'] == df['year'].max()]
-        >>> print(latest.pivot(index='sector', columns='sex', values='median_hourly_earnings'))
+        >>> df = get_hourly_earnings_by_sector_gender()  # doctest: +SKIP
+        >>> latest = df[df['year'] == df['year'].max()]  # doctest: +SKIP
+        >>> print(latest.pivot(index='sector', columns='sex', values='median_hourly_earnings'))  # doctest: +SKIP
     """
     return parse_ashe_hourly_earnings_by_sector_gender(_get_linked_file(force_refresh=force_refresh))
 
@@ -1090,10 +1090,10 @@ def get_hourly_earnings_by_age_gender(force_refresh: bool = False) -> pd.DataFra
         - median_hourly_earnings: float (£)
 
     Example:
-        >>> df = get_hourly_earnings_by_age_gender()
-        >>> wide = df.pivot(index='age_group', columns='sex', values='median_hourly_earnings')
-        >>> wide['gpg_pct'] = (wide['Male'] - wide['Female']) / wide['Male'] * 100
-        >>> print(wide)
+        >>> df = get_hourly_earnings_by_age_gender()  # doctest: +SKIP
+        >>> wide = df.pivot(index='age_group', columns='sex', values='median_hourly_earnings')  # doctest: +SKIP
+        >>> wide['gpg_pct'] = (wide['Male'] - wide['Female']) / wide['Male'] * 100  # doctest: +SKIP
+        >>> print(wide)  # doctest: +SKIP
     """
     return parse_ashe_hourly_earnings_by_age_gender(_get_linked_file(force_refresh=force_refresh))
 
@@ -1115,10 +1115,10 @@ def get_hourly_earnings_by_occupation_gender(force_refresh: bool = False) -> pd.
         - median_hourly_earnings: float (£)
 
     Example:
-        >>> df = get_hourly_earnings_by_occupation_gender()
-        >>> wide = df.pivot(index='occupation', columns='sex', values='median_hourly_earnings')
-        >>> wide['gpg_pct'] = (wide['Male'] - wide['Female']) / wide['Male'] * 100
-        >>> print(wide.sort_values('gpg_pct', ascending=False))
+        >>> df = get_hourly_earnings_by_occupation_gender()  # doctest: +SKIP
+        >>> wide = df.pivot(index='occupation', columns='sex', values='median_hourly_earnings')  # doctest: +SKIP
+        >>> wide['gpg_pct'] = (wide['Male'] - wide['Female']) / wide['Male'] * 100  # doctest: +SKIP
+        >>> print(wide.sort_values('gpg_pct', ascending=False))  # doctest: +SKIP
     """
     return parse_ashe_hourly_earnings_by_occupation_gender(_get_linked_file(force_refresh=force_refresh))
 
@@ -1140,8 +1140,8 @@ def get_hourly_earnings_by_pattern_gender(force_refresh: bool = False) -> pd.Dat
         - median_hourly_earnings: float (£)
 
     Example:
-        >>> df = get_hourly_earnings_by_pattern_gender()
-        >>> print(df.pivot(index='work_pattern', columns='sex', values='median_hourly_earnings'))
+        >>> df = get_hourly_earnings_by_pattern_gender()  # doctest: +SKIP
+        >>> print(df.pivot(index='work_pattern', columns='sex', values='median_hourly_earnings'))  # doctest: +SKIP
     """
     return parse_ashe_hourly_earnings_by_pattern_gender(_get_linked_file(force_refresh=force_refresh))
 
@@ -1156,8 +1156,8 @@ def get_ni_uk_earnings_comparison(force_refresh: bool = False) -> pd.DataFrame:
         DataFrame with columns: year, location ('NI'/'UK'), median_weekly_earnings_fulltime
 
     Example:
-        >>> df = get_ni_uk_earnings_comparison()
-        >>> print(df.pivot(index='year', columns='location', values='median_weekly_earnings_fulltime'))
+        >>> df = get_ni_uk_earnings_comparison()  # doctest: +SKIP
+        >>> print(df.pivot(index='year', columns='location', values='median_weekly_earnings_fulltime'))  # doctest: +SKIP
     """
     return parse_ashe_ni_uk_earnings_comparison(_get_linked_file(force_refresh=force_refresh))
 
@@ -1172,8 +1172,8 @@ def get_uk_regional_pay_ratio(force_refresh: bool = False) -> pd.DataFrame:
         DataFrame with columns: region, ratio
 
     Example:
-        >>> df = get_uk_regional_pay_ratio()
-        >>> ni = df[df['region'] == 'Northern Ireland']
+        >>> df = get_uk_regional_pay_ratio()  # doctest: +SKIP
+        >>> ni = df[df['region'] == 'Northern Ireland']  # doctest: +SKIP
     """
     return parse_ashe_uk_regional_pay_ratio(_get_linked_file(force_refresh=force_refresh))
 
@@ -1188,8 +1188,8 @@ def get_hours_distribution(force_refresh: bool = False) -> pd.DataFrame:
         DataFrame with columns: paid_hours_worked, percentage
 
     Example:
-        >>> df = get_hours_distribution()
-        >>> print(df[df['paid_hours_worked'].between(35, 40)])
+        >>> df = get_hours_distribution()  # doctest: +SKIP
+        >>> print(df[df['paid_hours_worked'].between(35, 40)])  # doctest: +SKIP
     """
     return parse_ashe_hours_distribution(_get_linked_file(force_refresh=force_refresh))
 
@@ -1204,8 +1204,8 @@ def get_working_pattern_pay_gap(force_refresh: bool = False) -> pd.DataFrame:
         DataFrame with columns: year, location ('NI'/'UK'), working_pattern_pay_gap_pct
 
     Example:
-        >>> df = get_working_pattern_pay_gap()
-        >>> print(df.pivot(index='year', columns='location', values='working_pattern_pay_gap_pct'))
+        >>> df = get_working_pattern_pay_gap()  # doctest: +SKIP
+        >>> print(df.pivot(index='year', columns='location', values='working_pattern_pay_gap_pct'))  # doctest: +SKIP
     """
     return parse_ashe_working_pattern_pay_gap(_get_linked_file(force_refresh=force_refresh))
 
@@ -1220,8 +1220,8 @@ def get_mean_hours_by_pattern_gender(force_refresh: bool = False) -> pd.DataFram
         DataFrame with columns: work_pattern, male_mean_hours, female_mean_hours, all_mean_hours
 
     Example:
-        >>> df = get_mean_hours_by_pattern_gender()
-        >>> print(df)
+        >>> df = get_mean_hours_by_pattern_gender()  # doctest: +SKIP
+        >>> print(df)  # doctest: +SKIP
     """
     return parse_ashe_mean_hours_by_pattern_gender(_get_linked_file(force_refresh=force_refresh))
 

--- a/src/bolster/data_sources/nisra/ashe.py
+++ b/src/bolster/data_sources/nisra/ashe.py
@@ -163,7 +163,11 @@ def parse_ashe_timeseries_weekly(file_path: str | Path) -> pd.DataFrame:
             - median_weekly_earnings: float (£)
 
     Example:
-        >>> df = parse_ashe_timeseries_weekly("ASHE-1997-2025-headline-timeseries.xlsx")
+        >>> _, year = get_latest_ashe_publication_url()
+        >>> path = download_file(get_ashe_file_url(year, 'timeseries'), cache_ttl_hours=90*24)
+        >>> df = parse_ashe_timeseries_weekly(path)
+        >>> sorted(df.columns.tolist())
+        ['median_weekly_earnings', 'work_pattern', 'year']
     """
     logger.info(f"Parsing ASHE weekly earnings from: {file_path}")
 
@@ -199,7 +203,11 @@ def parse_ashe_timeseries_hourly(file_path: str | Path) -> pd.DataFrame:
             - median_hourly_earnings: float (£)
 
     Example:
-        >>> df = parse_ashe_timeseries_hourly("ASHE-1997-2025-headline-timeseries.xlsx")
+        >>> _, year = get_latest_ashe_publication_url()
+        >>> path = download_file(get_ashe_file_url(year, 'timeseries'), cache_ttl_hours=90*24)
+        >>> df = parse_ashe_timeseries_hourly(path)
+        >>> sorted(df.columns.tolist())
+        ['median_hourly_earnings', 'work_pattern', 'year']
     """
     logger.info(f"Parsing ASHE hourly earnings from: {file_path}")
 
@@ -235,7 +243,11 @@ def parse_ashe_timeseries_annual(file_path: str | Path) -> pd.DataFrame:
             - median_annual_earnings: float (£)
 
     Example:
-        >>> df = parse_ashe_timeseries_annual("ASHE-1997-2025-headline-timeseries.xlsx")
+        >>> _, year = get_latest_ashe_publication_url()
+        >>> path = download_file(get_ashe_file_url(year, 'timeseries'), cache_ttl_hours=90*24)
+        >>> df = parse_ashe_timeseries_annual(path)
+        >>> sorted(df.columns.tolist())
+        ['median_annual_earnings', 'work_pattern', 'year']
     """
     logger.info(f"Parsing ASHE annual earnings from: {file_path}")
 
@@ -274,7 +286,11 @@ def parse_ashe_geography(file_path: str | Path, basis: str = "workplace", year: 
             - median_weekly_earnings: float (£)
 
     Example:
-        >>> df = parse_ashe_geography("ASHE-2025-linked.xlsx", basis='workplace', year=2025)
+        >>> _, year = get_latest_ashe_publication_url()
+        >>> path = download_file(get_ashe_file_url(year, 'linked'), cache_ttl_hours=90*24)
+        >>> df = parse_ashe_geography(path, basis='workplace', year=year)
+        >>> 'median_weekly_earnings' in df.columns
+        True
     """
     logger.info(f"Parsing ASHE geography ({basis}) from: {file_path}")
 
@@ -326,7 +342,11 @@ def parse_ashe_sector(file_path: str | Path) -> pd.DataFrame:
             - median_weekly_earnings: float (£)
 
     Example:
-        >>> df = parse_ashe_sector("ASHE-2025-linked.xlsx")
+        >>> _, year = get_latest_ashe_publication_url()
+        >>> path = download_file(get_ashe_file_url(year, 'linked'), cache_ttl_hours=90*24)
+        >>> df = parse_ashe_sector(path)
+        >>> 'location' in df.columns
+        True
     """
     logger.info(f"Parsing ASHE sector data from: {file_path}")
 
@@ -501,7 +521,7 @@ def calculate_growth_rates(df: pd.DataFrame, periods: int = 1) -> pd.DataFrame:
     Example:
         >>> df = get_latest_ashe_timeseries('weekly')
         >>> df_growth = calculate_growth_rates(df)
-        >>> 'yoy_growth' in df_growth.columns
+        >>> 'earnings_yoy_growth' in df_growth.columns
         True
     """
     result = df.copy()
@@ -685,8 +705,11 @@ def parse_ashe_gender_pay_gap(file_path: str | Path) -> pd.DataFrame:
         - gender_pay_gap_pct: float — GPG as % of male earnings (positive = men paid more)
 
     Example:
-        >>> df = parse_ashe_gender_pay_gap("ASHE-2025-linked.xlsx")
-        >>> ni = df[df['location'] == 'Northern Ireland']
+        >>> _, year = get_latest_ashe_publication_url()
+        >>> path = download_file(get_ashe_file_url(year, 'linked'), cache_ttl_hours=90*24)
+        >>> df = parse_ashe_gender_pay_gap(path)
+        >>> sorted(df.columns.tolist())
+        ['gender_pay_gap_pct', 'location', 'year']
     """
     df = _find_linked_sheet(file_path, "gender_pay_gap")
     df.columns = ["year", "UK", "NI"]
@@ -727,8 +750,11 @@ def parse_ashe_hourly_earnings_by_sector_gender(file_path: str | Path) -> pd.Dat
         - median_hourly_earnings: float (£, excluding overtime)
 
     Example:
-        >>> df = parse_ashe_hourly_earnings_by_sector_gender("ASHE-2025-linked.xlsx")
-        >>> latest = df[df['year'] == df['year'].max()]
+        >>> _, year = get_latest_ashe_publication_url()
+        >>> path = download_file(get_ashe_file_url(year, 'linked'), cache_ttl_hours=90*24)
+        >>> df = parse_ashe_hourly_earnings_by_sector_gender(path)
+        >>> sorted(df.columns.tolist())
+        ['median_hourly_earnings', 'sector', 'sex', 'year']
     """
     df = _find_linked_sheet(file_path, "hourly_by_sector_gender")
     df.columns = ["year", "Male public", "Female public", "Male private", "Female private"]
@@ -773,7 +799,11 @@ def parse_ashe_hourly_earnings_by_age_gender(file_path: str | Path) -> pd.DataFr
         - median_hourly_earnings: float (£, excluding overtime)
 
     Example:
-        >>> df = parse_ashe_hourly_earnings_by_age_gender("ASHE-2025-linked.xlsx")
+        >>> _, year = get_latest_ashe_publication_url()
+        >>> path = download_file(get_ashe_file_url(year, 'linked'), cache_ttl_hours=90*24)
+        >>> df = parse_ashe_hourly_earnings_by_age_gender(path)
+        >>> sorted(df.columns.tolist())
+        ['age_group', 'median_hourly_earnings', 'sex']
     """
     df = _find_linked_sheet(file_path, "hourly_by_age_gender")
     df.columns = ["age_group", "Female", "Male"]
@@ -808,8 +838,11 @@ def parse_ashe_hourly_earnings_by_occupation_gender(file_path: str | Path) -> pd
         - median_hourly_earnings: float (£, excluding overtime)
 
     Example:
-        >>> df = parse_ashe_hourly_earnings_by_occupation_gender("ASHE-2025-linked.xlsx")
-        >>> wide = df.pivot(index='occupation', columns='sex', values='median_hourly_earnings')
+        >>> _, year = get_latest_ashe_publication_url()
+        >>> path = download_file(get_ashe_file_url(year, 'linked'), cache_ttl_hours=90*24)
+        >>> df = parse_ashe_hourly_earnings_by_occupation_gender(path)
+        >>> sorted(df.columns.tolist())
+        ['median_hourly_earnings', 'occupation', 'sex']
     """
     df = _find_linked_sheet(file_path, "hourly_by_occupation_gender")
     df.columns = ["occupation", "Female", "Male"]
@@ -848,7 +881,11 @@ def parse_ashe_hourly_earnings_by_pattern_gender(file_path: str | Path) -> pd.Da
         - median_hourly_earnings: float (£, excluding overtime)
 
     Example:
-        >>> df = parse_ashe_hourly_earnings_by_pattern_gender("ASHE-2025-linked.xlsx")
+        >>> _, year = get_latest_ashe_publication_url()
+        >>> path = download_file(get_ashe_file_url(year, 'linked'), cache_ttl_hours=90*24)
+        >>> df = parse_ashe_hourly_earnings_by_pattern_gender(path)
+        >>> sorted(df.columns.tolist())
+        ['median_hourly_earnings', 'sex', 'work_pattern']
     """
     df = _find_linked_sheet(file_path, "hourly_by_pattern_gender")
     df.columns = ["work_pattern", "Female", "Male"]
@@ -885,7 +922,11 @@ def parse_ashe_ni_uk_earnings_comparison(file_path: str | Path) -> pd.DataFrame:
         - median_weekly_earnings_fulltime: float (£)
 
     Example:
-        >>> df = parse_ashe_ni_uk_earnings_comparison("ASHE-2025-linked.xlsx")
+        >>> _, year = get_latest_ashe_publication_url()
+        >>> path = download_file(get_ashe_file_url(year, 'linked'), cache_ttl_hours=90*24)
+        >>> df = parse_ashe_ni_uk_earnings_comparison(path)
+        >>> sorted(df.columns.tolist())
+        ['location', 'median_weekly_earnings_fulltime', 'year']
     """
     df = _find_linked_sheet(file_path, "ni_uk_weekly_earnings")
     df.columns = ["year", "UK", "NI"]
@@ -917,7 +958,11 @@ def parse_ashe_uk_regional_pay_ratio(file_path: str | Path) -> pd.DataFrame:
         - ratio: float (high-paid / low-paid jobs ratio)
 
     Example:
-        >>> df = parse_ashe_uk_regional_pay_ratio("ASHE-2025-linked.xlsx")
+        >>> _, year = get_latest_ashe_publication_url()
+        >>> path = download_file(get_ashe_file_url(year, 'linked'), cache_ttl_hours=90*24)
+        >>> df = parse_ashe_uk_regional_pay_ratio(path)
+        >>> sorted(df.columns.tolist())
+        ['ratio', 'region']
     """
     df = _find_linked_sheet(file_path, "uk_regional_pay_ratio")
     df.columns = ["region", "ratio"]
@@ -943,7 +988,11 @@ def parse_ashe_hours_distribution(file_path: str | Path) -> pd.DataFrame:
         - percentage: float (% of employees)
 
     Example:
-        >>> df = parse_ashe_hours_distribution("ASHE-2025-linked.xlsx")
+        >>> _, year = get_latest_ashe_publication_url()
+        >>> path = download_file(get_ashe_file_url(year, 'linked'), cache_ttl_hours=90*24)
+        >>> df = parse_ashe_hours_distribution(path)
+        >>> sorted(df.columns.tolist())
+        ['paid_hours_worked', 'percentage']
     """
     df = _find_linked_sheet(file_path, "hours_distribution")
     df.columns = ["paid_hours_worked", "percentage"]
@@ -970,7 +1019,11 @@ def parse_ashe_working_pattern_pay_gap(file_path: str | Path) -> pd.DataFrame:
         - working_pattern_pay_gap_pct: float (%)
 
     Example:
-        >>> df = parse_ashe_working_pattern_pay_gap("ASHE-2025-linked.xlsx")
+        >>> _, year = get_latest_ashe_publication_url()
+        >>> path = download_file(get_ashe_file_url(year, 'linked'), cache_ttl_hours=90*24)
+        >>> df = parse_ashe_working_pattern_pay_gap(path)
+        >>> sorted(df.columns.tolist())
+        ['location', 'working_pattern_pay_gap_pct', 'year']
     """
     df = _find_linked_sheet(file_path, "working_pattern_pay_gap")
     df.columns = ["year", "UK", "NI"]
@@ -1001,7 +1054,11 @@ def parse_ashe_mean_hours_by_pattern_gender(file_path: str | Path) -> pd.DataFra
         - all_mean_hours: float
 
     Example:
-        >>> df = parse_ashe_mean_hours_by_pattern_gender("ASHE-2025-linked.xlsx")
+        >>> _, year = get_latest_ashe_publication_url()
+        >>> path = download_file(get_ashe_file_url(year, 'linked'), cache_ttl_hours=90*24)
+        >>> df = parse_ashe_mean_hours_by_pattern_gender(path)
+        >>> 'work_pattern' in df.columns
+        True
     """
     df = _find_linked_sheet(file_path, "mean_hours_by_pattern_gender")
     df.columns = ["work_pattern", "male_mean_hours", "female_mean_hours", "all_mean_hours"]

--- a/src/bolster/data_sources/nisra/ashe.py
+++ b/src/bolster/data_sources/nisra/ashe.py
@@ -30,13 +30,18 @@ Examples:
     >>> from bolster.data_sources.nisra import ashe
     >>> # Get latest weekly earnings timeseries
     >>> df = ashe.get_latest_ashe_timeseries(metric='weekly')
+    >>> sorted(df.columns.tolist())
+    ['median_weekly_earnings', 'work_pattern', 'year']
 
     >>> # Get geographic earnings by workplace
     >>> df_geo = ashe.get_latest_ashe_geography(basis='workplace')
+    >>> 'median_weekly_earnings' in df_geo.columns
+    True
 
     >>> # Get public vs private sector comparison
     >>> df_sector = ashe.get_latest_ashe_sector()
-    >>> print(df_sector[df_sector['year'] == 2025])
+    >>> 'location' in df_sector.columns
+    True
 
 Publication Details:
     - Frequency: Annual (October publication)
@@ -76,6 +81,8 @@ def get_latest_ashe_publication_url() -> tuple[str, int]:
 
     Example:
         >>> url, year = get_latest_ashe_publication_url()
+        >>> url.startswith('https://')
+        True
     """
     from bs4 import BeautifulSoup
 
@@ -121,6 +128,8 @@ def get_ashe_file_url(year: int, file_type: str = "timeseries") -> str:
 
     Example:
         >>> url = get_ashe_file_url(2025, 'timeseries')
+        >>> url.startswith('https://')
+        True
     """
     # ASHE is published in October
     month = 10
@@ -384,7 +393,8 @@ def get_latest_ashe_timeseries(metric: str = "weekly", force_refresh: bool = Fal
 
     Example:
         >>> df = get_latest_ashe_timeseries(metric='weekly')
-        >>> latest = df[df['year'] == df['year'].max()]
+        >>> sorted(df.columns.tolist())
+        ['median_weekly_earnings', 'work_pattern', 'year']
     """
     _, year = get_latest_ashe_publication_url()
     file_url = get_ashe_file_url(year, file_type="timeseries")
@@ -416,6 +426,8 @@ def get_latest_ashe_geography(basis: str = "workplace", force_refresh: bool = Fa
 
     Example:
         >>> df = get_latest_ashe_geography(basis='workplace')
+        >>> 'median_weekly_earnings' in df.columns
+        True
     """
     _, year = get_latest_ashe_publication_url()
     file_url = get_ashe_file_url(year, file_type="linked")
@@ -440,8 +452,8 @@ def get_latest_ashe_sector(force_refresh: bool = False) -> pd.DataFrame:
 
     Example:
         >>> df = get_latest_ashe_sector()
-        >>> latest = df[df['year'] == df['year'].max()]
-        >>> ni_latest = latest[latest['location'] == 'Northern Ireland']
+        >>> 'location' in df.columns
+        True
     """
     _, year = get_latest_ashe_publication_url()
     file_url = get_ashe_file_url(year, file_type="linked")
@@ -470,6 +482,8 @@ def get_earnings_by_year(df: pd.DataFrame, year: int) -> pd.DataFrame:
     Example:
         >>> df = get_latest_ashe_timeseries('weekly')
         >>> df_2025 = get_earnings_by_year(df, 2025)
+        >>> 'median_weekly_earnings' in df_2025.columns
+        True
     """
     return df[df["year"] == year].reset_index(drop=True)
 
@@ -487,7 +501,8 @@ def calculate_growth_rates(df: pd.DataFrame, periods: int = 1) -> pd.DataFrame:
     Example:
         >>> df = get_latest_ashe_timeseries('weekly')
         >>> df_growth = calculate_growth_rates(df)
-        >>> recent = df_growth[df_growth['work_pattern'] == 'All'].tail(5)
+        >>> 'yoy_growth' in df_growth.columns
+        True
     """
     result = df.copy()
 
@@ -1020,7 +1035,8 @@ def get_gender_pay_gap(force_refresh: bool = False) -> pd.DataFrame:
 
     Example:
         >>> df = get_gender_pay_gap()
-        >>> ni = df[df['location'] == 'Northern Ireland']
+        >>> 'gender_pay_gap_pct' in df.columns
+        True
     """
     return parse_ashe_gender_pay_gap(_get_linked_file(force_refresh=force_refresh))
 
@@ -1044,7 +1060,8 @@ def get_hourly_earnings_by_sector_gender(force_refresh: bool = False) -> pd.Data
 
     Example:
         >>> df = get_hourly_earnings_by_sector_gender()
-        >>> latest = df[df['year'] == df['year'].max()]
+        >>> 'median_hourly_earnings' in df.columns
+        True
     """
     return parse_ashe_hourly_earnings_by_sector_gender(_get_linked_file(force_refresh=force_refresh))
 
@@ -1067,8 +1084,8 @@ def get_hourly_earnings_by_age_gender(force_refresh: bool = False) -> pd.DataFra
 
     Example:
         >>> df = get_hourly_earnings_by_age_gender()
-        >>> wide = df.pivot(index='age_group', columns='sex', values='median_hourly_earnings')
-        >>> wide['gpg_pct'] = (wide['Male'] - wide['Female']) / wide['Male'] * 100
+        >>> 'median_hourly_earnings' in df.columns
+        True
     """
     return parse_ashe_hourly_earnings_by_age_gender(_get_linked_file(force_refresh=force_refresh))
 
@@ -1091,8 +1108,8 @@ def get_hourly_earnings_by_occupation_gender(force_refresh: bool = False) -> pd.
 
     Example:
         >>> df = get_hourly_earnings_by_occupation_gender()
-        >>> wide = df.pivot(index='occupation', columns='sex', values='median_hourly_earnings')
-        >>> wide['gpg_pct'] = (wide['Male'] - wide['Female']) / wide['Male'] * 100
+        >>> 'median_hourly_earnings' in df.columns
+        True
     """
     return parse_ashe_hourly_earnings_by_occupation_gender(_get_linked_file(force_refresh=force_refresh))
 
@@ -1115,6 +1132,8 @@ def get_hourly_earnings_by_pattern_gender(force_refresh: bool = False) -> pd.Dat
 
     Example:
         >>> df = get_hourly_earnings_by_pattern_gender()
+        >>> 'median_hourly_earnings' in df.columns
+        True
     """
     return parse_ashe_hourly_earnings_by_pattern_gender(_get_linked_file(force_refresh=force_refresh))
 
@@ -1130,6 +1149,8 @@ def get_ni_uk_earnings_comparison(force_refresh: bool = False) -> pd.DataFrame:
 
     Example:
         >>> df = get_ni_uk_earnings_comparison()
+        >>> 'median_weekly_earnings_fulltime' in df.columns
+        True
     """
     return parse_ashe_ni_uk_earnings_comparison(_get_linked_file(force_refresh=force_refresh))
 
@@ -1145,7 +1166,8 @@ def get_uk_regional_pay_ratio(force_refresh: bool = False) -> pd.DataFrame:
 
     Example:
         >>> df = get_uk_regional_pay_ratio()
-        >>> ni = df[df['region'] == 'Northern Ireland']
+        >>> 'ratio' in df.columns
+        True
     """
     return parse_ashe_uk_regional_pay_ratio(_get_linked_file(force_refresh=force_refresh))
 
@@ -1161,6 +1183,8 @@ def get_hours_distribution(force_refresh: bool = False) -> pd.DataFrame:
 
     Example:
         >>> df = get_hours_distribution()
+        >>> 'percentage' in df.columns
+        True
     """
     return parse_ashe_hours_distribution(_get_linked_file(force_refresh=force_refresh))
 
@@ -1176,6 +1200,8 @@ def get_working_pattern_pay_gap(force_refresh: bool = False) -> pd.DataFrame:
 
     Example:
         >>> df = get_working_pattern_pay_gap()
+        >>> 'working_pattern_pay_gap_pct' in df.columns
+        True
     """
     return parse_ashe_working_pattern_pay_gap(_get_linked_file(force_refresh=force_refresh))
 
@@ -1191,6 +1217,8 @@ def get_mean_hours_by_pattern_gender(force_refresh: bool = False) -> pd.DataFram
 
     Example:
         >>> df = get_mean_hours_by_pattern_gender()
+        >>> 'male_mean_hours' in df.columns
+        True
     """
     return parse_ashe_mean_hours_by_pattern_gender(_get_linked_file(force_refresh=force_refresh))
 

--- a/src/bolster/data_sources/nisra/births.py
+++ b/src/bolster/data_sources/nisra/births.py
@@ -26,13 +26,12 @@ Update Frequency: Monthly (published 12th of following month at 9:30 AM)
 Geographic Coverage: Northern Ireland (based on mother's residence)
 
 Example:
-    >>> from bolster.data_sources.nisra import births  # doctest: +SKIP
+    >>> from bolster.data_sources.nisra import births
     >>> # Get latest births by registration date
-    >>> df = births.get_latest_births(event_type='registration')  # doctest: +SKIP
-    >>> print(df.head())  # doctest: +SKIP
+    >>> df = births.get_latest_births(event_type='registration')
 
     >>> # Get latest births by occurrence date
-    >>> df = births.get_latest_births(event_type='occurrence')  # doctest: +SKIP
+    >>> df = births.get_latest_births(event_type='occurrence')
 """
 
 import logging
@@ -344,13 +343,10 @@ def get_latest_births(
 
     Example:
         >>> # Get births by registration date
-        >>> df = get_latest_births(event_type='registration')  # doctest: +SKIP
-        >>> print(df[df['sex'] == 'Male'].head())  # doctest: +SKIP
+        >>> df = get_latest_births(event_type='registration')
 
         >>> # Get both types
-        >>> data = get_latest_births(event_type='both')  # doctest: +SKIP
-        >>> print(data['registration'].head())  # doctest: +SKIP
-        >>> print(data['occurrence'].head())  # doctest: +SKIP
+        >>> data = get_latest_births(event_type='both')
     """
     # Discover latest publication
     excel_url = get_latest_births_publication_url()

--- a/src/bolster/data_sources/nisra/births.py
+++ b/src/bolster/data_sources/nisra/births.py
@@ -29,9 +29,15 @@ Example:
     >>> from bolster.data_sources.nisra import births
     >>> # Get latest births by registration date
     >>> df = births.get_latest_births(event_type='registration')
+    >>> sorted(df.columns.tolist())
+    ['births', 'month', 'sex']
+    >>> sorted(df['sex'].unique().tolist())
+    ['Female', 'Male', 'Persons']
 
     >>> # Get latest births by occurrence date
     >>> df = births.get_latest_births(event_type='occurrence')
+    >>> len(df) > 0
+    True
 """
 
 import logging
@@ -344,9 +350,13 @@ def get_latest_births(
     Example:
         >>> # Get births by registration date
         >>> df = get_latest_births(event_type='registration')
+        >>> sorted(df.columns.tolist())
+        ['births', 'month', 'sex']
 
         >>> # Get both types
         >>> data = get_latest_births(event_type='both')
+        >>> sorted(data.keys())
+        ['occurrence', 'registration']
     """
     # Discover latest publication
     excel_url = get_latest_births_publication_url()

--- a/src/bolster/data_sources/nisra/births.py
+++ b/src/bolster/data_sources/nisra/births.py
@@ -26,13 +26,13 @@ Update Frequency: Monthly (published 12th of following month at 9:30 AM)
 Geographic Coverage: Northern Ireland (based on mother's residence)
 
 Example:
-    >>> from bolster.data_sources.nisra import births
+    >>> from bolster.data_sources.nisra import births  # doctest: +SKIP
     >>> # Get latest births by registration date
-    >>> df = births.get_latest_births(event_type='registration')
-    >>> print(df.head())
+    >>> df = births.get_latest_births(event_type='registration')  # doctest: +SKIP
+    >>> print(df.head())  # doctest: +SKIP
 
     >>> # Get latest births by occurrence date
-    >>> df = births.get_latest_births(event_type='occurrence')
+    >>> df = births.get_latest_births(event_type='occurrence')  # doctest: +SKIP
 """
 
 import logging
@@ -344,13 +344,13 @@ def get_latest_births(
 
     Example:
         >>> # Get births by registration date
-        >>> df = get_latest_births(event_type='registration')
-        >>> print(df[df['sex'] == 'Male'].head())
+        >>> df = get_latest_births(event_type='registration')  # doctest: +SKIP
+        >>> print(df[df['sex'] == 'Male'].head())  # doctest: +SKIP
 
         >>> # Get both types
-        >>> data = get_latest_births(event_type='both')
-        >>> print(data['registration'].head())
-        >>> print(data['occurrence'].head())
+        >>> data = get_latest_births(event_type='both')  # doctest: +SKIP
+        >>> print(data['registration'].head())  # doctest: +SKIP
+        >>> print(data['occurrence'].head())  # doctest: +SKIP
     """
     # Discover latest publication
     excel_url = get_latest_births_publication_url()

--- a/src/bolster/data_sources/nisra/cancer_waiting_times.py
+++ b/src/bolster/data_sources/nisra/cancer_waiting_times.py
@@ -38,13 +38,13 @@ Example:
     >>> from bolster.data_sources.nisra import cancer_waiting_times as cwt
     >>> # Get latest 31-day waiting times by HSC Trust
     >>> df = cwt.get_latest_31_day_by_trust()
+    >>> sorted(df.columns.tolist())
+    ['date', 'month', 'over_target', 'performance_rate', 'total', 'trust', 'within_target', 'year']
 
     >>> # Get 62-day waiting times by tumour site
     >>> df_tumour = cwt.get_latest_62_day_by_tumour()
-
-    >>> # Calculate performance rates
-    >>> summary = cwt.get_performance_summary()
-    >>> print(summary)
+    >>> 'tumour_site' in df_tumour.columns
+    True
 
 Publication Details:
     - Frequency: Quarterly (published ~3 months after quarter end)

--- a/src/bolster/data_sources/nisra/cancer_waiting_times.py
+++ b/src/bolster/data_sources/nisra/cancer_waiting_times.py
@@ -35,18 +35,16 @@ as part of their healthcare performance monitoring, with data updated four times
 to track progress against key cancer treatment targets.
 
 Example:
-    >>> from bolster.data_sources.nisra import cancer_waiting_times as cwt  # doctest: +SKIP
+    >>> from bolster.data_sources.nisra import cancer_waiting_times as cwt
     >>> # Get latest 31-day waiting times by HSC Trust
-    >>> df = cwt.get_latest_31_day_by_trust()  # doctest: +SKIP
-    >>> print(df.tail())  # doctest: +SKIP
+    >>> df = cwt.get_latest_31_day_by_trust()
 
     >>> # Get 62-day waiting times by tumour site
-    >>> df_tumour = cwt.get_latest_62_day_by_tumour()  # doctest: +SKIP
-    >>> print(df_tumour[df_tumour['tumour_site'] == 'Lung Cancer'].tail())  # doctest: +SKIP
+    >>> df_tumour = cwt.get_latest_62_day_by_tumour()
 
     >>> # Calculate performance rates
-    >>> summary = cwt.get_performance_summary()  # doctest: +SKIP
-    >>> print(summary)  # doctest: +SKIP
+    >>> summary = cwt.get_performance_summary()
+    >>> print(summary)
 
 Publication Details:
     - Frequency: Quarterly (published ~3 months after quarter end)

--- a/src/bolster/data_sources/nisra/cancer_waiting_times.py
+++ b/src/bolster/data_sources/nisra/cancer_waiting_times.py
@@ -35,18 +35,18 @@ as part of their healthcare performance monitoring, with data updated four times
 to track progress against key cancer treatment targets.
 
 Example:
-    >>> from bolster.data_sources.nisra import cancer_waiting_times as cwt
+    >>> from bolster.data_sources.nisra import cancer_waiting_times as cwt  # doctest: +SKIP
     >>> # Get latest 31-day waiting times by HSC Trust
-    >>> df = cwt.get_latest_31_day_by_trust()
-    >>> print(df.tail())
+    >>> df = cwt.get_latest_31_day_by_trust()  # doctest: +SKIP
+    >>> print(df.tail())  # doctest: +SKIP
 
     >>> # Get 62-day waiting times by tumour site
-    >>> df_tumour = cwt.get_latest_62_day_by_tumour()
-    >>> print(df_tumour[df_tumour['tumour_site'] == 'Lung Cancer'].tail())
+    >>> df_tumour = cwt.get_latest_62_day_by_tumour()  # doctest: +SKIP
+    >>> print(df_tumour[df_tumour['tumour_site'] == 'Lung Cancer'].tail())  # doctest: +SKIP
 
     >>> # Calculate performance rates
-    >>> summary = cwt.get_performance_summary()
-    >>> print(summary)
+    >>> summary = cwt.get_performance_summary()  # doctest: +SKIP
+    >>> print(summary)  # doctest: +SKIP
 
 Publication Details:
     - Frequency: Quarterly (published ~3 months after quarter end)

--- a/src/bolster/data_sources/nisra/cancer_waiting_times.py
+++ b/src/bolster/data_sources/nisra/cancer_waiting_times.py
@@ -286,8 +286,8 @@ def parse_14_day_breast(file_path: str | Path) -> pd.DataFrame:
         From May 2025, breast cancer services became regional. Historic data
         (pre-May 2025) is by individual Trust. Regional data shows NI-wide figures.
     """
-    xl = pd.ExcelFile(file_path)
-    sheet_names = xl.sheet_names
+    with pd.ExcelFile(file_path) as xl:
+        sheet_names = xl.sheet_names
 
     if SHEET_14_DAY_HISTORIC in sheet_names:
         # New split format (Q4 2024-25 onwards)

--- a/src/bolster/data_sources/nisra/composite_index.py
+++ b/src/bolster/data_sources/nisra/composite_index.py
@@ -161,7 +161,11 @@ def parse_nicei_indices(file_path: str | Path) -> pd.DataFrame:
             - agriculture: float
 
     Example:
-        >>> df = parse_nicei_indices('/path/to/nicei.xlsx')
+        >>> url, _, _ = get_latest_nicei_publication_url()
+        >>> path = download_file(url, cache_ttl_hours=90*24)
+        >>> df = parse_nicei_indices(path)
+        >>> 'nicei' in df.columns
+        True
     """
     logger.info(f"Parsing NICEI indices from: {file_path}")
 
@@ -218,7 +222,11 @@ def parse_nicei_contributions(file_path: str | Path) -> pd.DataFrame:
             - agriculture_contribution: float
 
     Example:
-        >>> df = parse_nicei_contributions('/path/to/nicei.xlsx')
+        >>> url, _, _ = get_latest_nicei_publication_url()
+        >>> path = download_file(url, cache_ttl_hours=90*24)
+        >>> df = parse_nicei_contributions(path)
+        >>> 'nicei' in df.columns
+        True
     """
     logger.info(f"Parsing NICEI sector contributions from: {file_path}")
 

--- a/src/bolster/data_sources/nisra/composite_index.py
+++ b/src/bolster/data_sources/nisra/composite_index.py
@@ -26,23 +26,19 @@ Data Coverage:
     - Base period: 2022=100
 
 Examples:
-    >>> from bolster.data_sources.nisra import composite_index  # doctest: +SKIP
+    >>> from bolster.data_sources.nisra import composite_index
     >>> # Get latest NICEI data
-    >>> nicei_df = composite_index.get_latest_nicei()  # doctest: +SKIP
-    >>> print(nicei_df.tail())  # doctest: +SKIP
+    >>> nicei_df = composite_index.get_latest_nicei()
 
     >>> # Get sector contributions
-    >>> contrib_df = composite_index.get_latest_nicei_contributions()  # doctest: +SKIP
-    >>> print(contrib_df.tail())  # doctest: +SKIP
+    >>> contrib_df = composite_index.get_latest_nicei_contributions()
 
     >>> # Filter for specific year
-    >>> nicei_2024 = composite_index.get_nicei_by_year(nicei_df, 2024)  # doctest: +SKIP
-    >>> print(f"Annual average 2024: {nicei_2024['nicei'].mean():.2f}")  # doctest: +SKIP
+    >>> nicei_2024 = composite_index.get_nicei_by_year(nicei_df, 2024)
 
     >>> # Analyze sectoral performance
-    >>> latest = nicei_df.iloc[-1]  # doctest: +SKIP
-    >>> print(f"Q{latest['quarter']} {latest['year']} NICEI: {latest['nicei']:.2f}")  # doctest: +SKIP
-    >>> print(f"Services: {latest['services']:.2f}, Construction: {latest['construction']:.2f}")  # doctest: +SKIP
+    >>> latest = nicei_df.iloc[-1]
+    >>> print(f"Services: {latest['services']:.2f}, Construction: {latest['construction']:.2f}")
 
 Publication Details:
     - Frequency: Quarterly (published ~3 months after quarter end)
@@ -83,8 +79,7 @@ def get_latest_nicei_publication_url() -> tuple[str, int, str]:
         NISRADataNotFoundError: If unable to find the latest publication
 
     Example:
-        >>> url, year, quarter = get_latest_nicei_publication_url()  # doctest: +SKIP
-        >>> print(f"Latest NICEI: Q{quarter} {year}")  # doctest: +SKIP
+        >>> url, year, quarter = get_latest_nicei_publication_url()
     """
     from bs4 import BeautifulSoup
 
@@ -167,8 +162,7 @@ def parse_nicei_indices(file_path: str | Path) -> pd.DataFrame:
             - agriculture: float
 
     Example:
-        >>> df = parse_nicei_indices('/path/to/nicei.xlsx')  # doctest: +SKIP
-        >>> print(df[df['year'] == 2024].mean())  # doctest: +SKIP
+        >>> df = parse_nicei_indices('/path/to/nicei.xlsx')
     """
     logger.info(f"Parsing NICEI indices from: {file_path}")
 
@@ -225,9 +219,8 @@ def parse_nicei_contributions(file_path: str | Path) -> pd.DataFrame:
             - agriculture_contribution: float
 
     Example:
-        >>> df = parse_nicei_contributions('/path/to/nicei.xlsx')  # doctest: +SKIP
+        >>> df = parse_nicei_contributions('/path/to/nicei.xlsx')
         >>> # Find quarter with largest services contribution
-        >>> print(df.loc[df['services_contribution'].idxmax()])  # doctest: +SKIP
     """
     logger.info(f"Parsing NICEI sector contributions from: {file_path}")
 
@@ -290,8 +283,7 @@ def get_latest_nicei(force_refresh: bool = False) -> pd.DataFrame:
         DataFrame with quarterly NICEI index values and sectoral breakdowns
 
     Example:
-        >>> df = get_latest_nicei()  # doctest: +SKIP
-        >>> print(f"Latest NICEI: {df.iloc[-1]['nicei']:.2f}")  # doctest: +SKIP
+        >>> df = get_latest_nicei()
     """
     excel_url, year, quarter = get_latest_nicei_publication_url()
 
@@ -314,10 +306,8 @@ def get_latest_nicei_contributions(force_refresh: bool = False) -> pd.DataFrame:
         DataFrame with quarterly sector contributions to NICEI change
 
     Example:
-        >>> df = get_latest_nicei_contributions()  # doctest: +SKIP
-        >>> latest = df.iloc[-1]  # doctest: +SKIP
-        >>> print(f"Q{latest['quarter']} {latest['year']} contributions:")  # doctest: +SKIP
-        >>> print(f"  Services: {latest['services_contribution']:.2f}")  # doctest: +SKIP
+        >>> df = get_latest_nicei_contributions()
+        >>> latest = df.iloc[-1]
     """
     excel_url, year, quarter = get_latest_nicei_publication_url()
 
@@ -338,9 +328,8 @@ def get_nicei_by_year(df: pd.DataFrame, year: int) -> pd.DataFrame:
         Filtered DataFrame containing only the specified year
 
     Example:
-        >>> df = get_latest_nicei()  # doctest: +SKIP
-        >>> df_2024 = get_nicei_by_year(df, 2024)  # doctest: +SKIP
-        >>> print(f"2024 average NICEI: {df_2024['nicei'].mean():.2f}")  # doctest: +SKIP
+        >>> df = get_latest_nicei()
+        >>> df_2024 = get_nicei_by_year(df, 2024)
     """
     return df[df["year"] == year].reset_index(drop=True)
 
@@ -357,9 +346,8 @@ def get_nicei_by_quarter(df: pd.DataFrame, year: int, quarter: int) -> pd.DataFr
         Filtered DataFrame containing only the specified quarter (usually 1 row)
 
     Example:
-        >>> df = get_latest_nicei()  # doctest: +SKIP
-        >>> q2_2024 = get_nicei_by_quarter(df, 2024, 2)  # doctest: +SKIP
-        >>> print(f"Q2 2024 NICEI: {q2_2024['nicei'].values[0]:.2f}")  # doctest: +SKIP
+        >>> df = get_latest_nicei()
+        >>> q2_2024 = get_nicei_by_quarter(df, 2024, 2)
     """
     return df[(df["year"] == year) & (df["quarter"] == quarter)].reset_index(drop=True)
 

--- a/src/bolster/data_sources/nisra/composite_index.py
+++ b/src/bolster/data_sources/nisra/composite_index.py
@@ -27,18 +27,15 @@ Data Coverage:
 
 Examples:
     >>> from bolster.data_sources.nisra import composite_index
-    >>> # Get latest NICEI data
     >>> nicei_df = composite_index.get_latest_nicei()
-
-    >>> # Get sector contributions
+    >>> 'nicei' in nicei_df.columns
+    True
     >>> contrib_df = composite_index.get_latest_nicei_contributions()
-
-    >>> # Filter for specific year
+    >>> 'services_contribution' in contrib_df.columns
+    True
     >>> nicei_2024 = composite_index.get_nicei_by_year(nicei_df, 2024)
-
-    >>> # Analyze sectoral performance
-    >>> latest = nicei_df.iloc[-1]
-    >>> print(f"Services: {latest['services']:.2f}, Construction: {latest['construction']:.2f}")
+    >>> len(nicei_2024) <= 4
+    True
 
 Publication Details:
     - Frequency: Quarterly (published ~3 months after quarter end)
@@ -80,6 +77,8 @@ def get_latest_nicei_publication_url() -> tuple[str, int, str]:
 
     Example:
         >>> url, year, quarter = get_latest_nicei_publication_url()
+        >>> url.startswith('https://')
+        True
     """
     from bs4 import BeautifulSoup
 
@@ -220,7 +219,6 @@ def parse_nicei_contributions(file_path: str | Path) -> pd.DataFrame:
 
     Example:
         >>> df = parse_nicei_contributions('/path/to/nicei.xlsx')
-        >>> # Find quarter with largest services contribution
     """
     logger.info(f"Parsing NICEI sector contributions from: {file_path}")
 
@@ -284,6 +282,8 @@ def get_latest_nicei(force_refresh: bool = False) -> pd.DataFrame:
 
     Example:
         >>> df = get_latest_nicei()
+        >>> 'nicei' in df.columns
+        True
     """
     excel_url, year, quarter = get_latest_nicei_publication_url()
 
@@ -307,7 +307,8 @@ def get_latest_nicei_contributions(force_refresh: bool = False) -> pd.DataFrame:
 
     Example:
         >>> df = get_latest_nicei_contributions()
-        >>> latest = df.iloc[-1]
+        >>> 'services_contribution' in df.columns
+        True
     """
     excel_url, year, quarter = get_latest_nicei_publication_url()
 
@@ -330,6 +331,8 @@ def get_nicei_by_year(df: pd.DataFrame, year: int) -> pd.DataFrame:
     Example:
         >>> df = get_latest_nicei()
         >>> df_2024 = get_nicei_by_year(df, 2024)
+        >>> len(df_2024) <= 4
+        True
     """
     return df[df["year"] == year].reset_index(drop=True)
 
@@ -348,6 +351,8 @@ def get_nicei_by_quarter(df: pd.DataFrame, year: int, quarter: int) -> pd.DataFr
     Example:
         >>> df = get_latest_nicei()
         >>> q2_2024 = get_nicei_by_quarter(df, 2024, 2)
+        >>> len(q2_2024) <= 1
+        True
     """
     return df[(df["year"] == year) & (df["quarter"] == quarter)].reset_index(drop=True)
 

--- a/src/bolster/data_sources/nisra/composite_index.py
+++ b/src/bolster/data_sources/nisra/composite_index.py
@@ -26,23 +26,23 @@ Data Coverage:
     - Base period: 2022=100
 
 Examples:
-    >>> from bolster.data_sources.nisra import composite_index
+    >>> from bolster.data_sources.nisra import composite_index  # doctest: +SKIP
     >>> # Get latest NICEI data
-    >>> nicei_df = composite_index.get_latest_nicei()
-    >>> print(nicei_df.tail())
+    >>> nicei_df = composite_index.get_latest_nicei()  # doctest: +SKIP
+    >>> print(nicei_df.tail())  # doctest: +SKIP
 
     >>> # Get sector contributions
-    >>> contrib_df = composite_index.get_latest_nicei_contributions()
-    >>> print(contrib_df.tail())
+    >>> contrib_df = composite_index.get_latest_nicei_contributions()  # doctest: +SKIP
+    >>> print(contrib_df.tail())  # doctest: +SKIP
 
     >>> # Filter for specific year
-    >>> nicei_2024 = composite_index.get_nicei_by_year(nicei_df, 2024)
-    >>> print(f"Annual average 2024: {nicei_2024['nicei'].mean():.2f}")
+    >>> nicei_2024 = composite_index.get_nicei_by_year(nicei_df, 2024)  # doctest: +SKIP
+    >>> print(f"Annual average 2024: {nicei_2024['nicei'].mean():.2f}")  # doctest: +SKIP
 
     >>> # Analyze sectoral performance
-    >>> latest = nicei_df.iloc[-1]
-    >>> print(f"Q{latest['quarter']} {latest['year']} NICEI: {latest['nicei']:.2f}")
-    >>> print(f"Services: {latest['services']:.2f}, Construction: {latest['construction']:.2f}")
+    >>> latest = nicei_df.iloc[-1]  # doctest: +SKIP
+    >>> print(f"Q{latest['quarter']} {latest['year']} NICEI: {latest['nicei']:.2f}")  # doctest: +SKIP
+    >>> print(f"Services: {latest['services']:.2f}, Construction: {latest['construction']:.2f}")  # doctest: +SKIP
 
 Publication Details:
     - Frequency: Quarterly (published ~3 months after quarter end)
@@ -83,8 +83,8 @@ def get_latest_nicei_publication_url() -> tuple[str, int, str]:
         NISRADataNotFoundError: If unable to find the latest publication
 
     Example:
-        >>> url, year, quarter = get_latest_nicei_publication_url()
-        >>> print(f"Latest NICEI: Q{quarter} {year}")
+        >>> url, year, quarter = get_latest_nicei_publication_url()  # doctest: +SKIP
+        >>> print(f"Latest NICEI: Q{quarter} {year}")  # doctest: +SKIP
     """
     from bs4 import BeautifulSoup
 
@@ -167,8 +167,8 @@ def parse_nicei_indices(file_path: str | Path) -> pd.DataFrame:
             - agriculture: float
 
     Example:
-        >>> df = parse_nicei_indices('/path/to/nicei.xlsx')
-        >>> print(df[df['year'] == 2024].mean())
+        >>> df = parse_nicei_indices('/path/to/nicei.xlsx')  # doctest: +SKIP
+        >>> print(df[df['year'] == 2024].mean())  # doctest: +SKIP
     """
     logger.info(f"Parsing NICEI indices from: {file_path}")
 
@@ -225,9 +225,9 @@ def parse_nicei_contributions(file_path: str | Path) -> pd.DataFrame:
             - agriculture_contribution: float
 
     Example:
-        >>> df = parse_nicei_contributions('/path/to/nicei.xlsx')
+        >>> df = parse_nicei_contributions('/path/to/nicei.xlsx')  # doctest: +SKIP
         >>> # Find quarter with largest services contribution
-        >>> print(df.loc[df['services_contribution'].idxmax()])
+        >>> print(df.loc[df['services_contribution'].idxmax()])  # doctest: +SKIP
     """
     logger.info(f"Parsing NICEI sector contributions from: {file_path}")
 
@@ -290,8 +290,8 @@ def get_latest_nicei(force_refresh: bool = False) -> pd.DataFrame:
         DataFrame with quarterly NICEI index values and sectoral breakdowns
 
     Example:
-        >>> df = get_latest_nicei()
-        >>> print(f"Latest NICEI: {df.iloc[-1]['nicei']:.2f}")
+        >>> df = get_latest_nicei()  # doctest: +SKIP
+        >>> print(f"Latest NICEI: {df.iloc[-1]['nicei']:.2f}")  # doctest: +SKIP
     """
     excel_url, year, quarter = get_latest_nicei_publication_url()
 
@@ -314,10 +314,10 @@ def get_latest_nicei_contributions(force_refresh: bool = False) -> pd.DataFrame:
         DataFrame with quarterly sector contributions to NICEI change
 
     Example:
-        >>> df = get_latest_nicei_contributions()
-        >>> latest = df.iloc[-1]
-        >>> print(f"Q{latest['quarter']} {latest['year']} contributions:")
-        >>> print(f"  Services: {latest['services_contribution']:.2f}")
+        >>> df = get_latest_nicei_contributions()  # doctest: +SKIP
+        >>> latest = df.iloc[-1]  # doctest: +SKIP
+        >>> print(f"Q{latest['quarter']} {latest['year']} contributions:")  # doctest: +SKIP
+        >>> print(f"  Services: {latest['services_contribution']:.2f}")  # doctest: +SKIP
     """
     excel_url, year, quarter = get_latest_nicei_publication_url()
 
@@ -338,9 +338,9 @@ def get_nicei_by_year(df: pd.DataFrame, year: int) -> pd.DataFrame:
         Filtered DataFrame containing only the specified year
 
     Example:
-        >>> df = get_latest_nicei()
-        >>> df_2024 = get_nicei_by_year(df, 2024)
-        >>> print(f"2024 average NICEI: {df_2024['nicei'].mean():.2f}")
+        >>> df = get_latest_nicei()  # doctest: +SKIP
+        >>> df_2024 = get_nicei_by_year(df, 2024)  # doctest: +SKIP
+        >>> print(f"2024 average NICEI: {df_2024['nicei'].mean():.2f}")  # doctest: +SKIP
     """
     return df[df["year"] == year].reset_index(drop=True)
 
@@ -357,9 +357,9 @@ def get_nicei_by_quarter(df: pd.DataFrame, year: int, quarter: int) -> pd.DataFr
         Filtered DataFrame containing only the specified quarter (usually 1 row)
 
     Example:
-        >>> df = get_latest_nicei()
-        >>> q2_2024 = get_nicei_by_quarter(df, 2024, 2)
-        >>> print(f"Q2 2024 NICEI: {q2_2024['nicei'].values[0]:.2f}")
+        >>> df = get_latest_nicei()  # doctest: +SKIP
+        >>> q2_2024 = get_nicei_by_quarter(df, 2024, 2)  # doctest: +SKIP
+        >>> print(f"Q2 2024 NICEI: {q2_2024['nicei'].values[0]:.2f}")  # doctest: +SKIP
     """
     return df[(df["year"] == year) & (df["quarter"] == quarter)].reset_index(drop=True)
 

--- a/src/bolster/data_sources/nisra/construction_output.py
+++ b/src/bolster/data_sources/nisra/construction_output.py
@@ -24,23 +24,20 @@ Data Coverage:
     - Base year: 2022 = 100 (chained volume measure)
 
 Examples:
-    >>> from bolster.data_sources.nisra import construction_output  # doctest: +SKIP
+    >>> from bolster.data_sources.nisra import construction_output
     >>> # Get latest construction output data
-    >>> df = construction_output.get_latest_construction_output()  # doctest: +SKIP
-    >>> print(df.head())  # doctest: +SKIP
+    >>> df = construction_output.get_latest_construction_output()
 
     >>> # Filter for specific year
-    >>> df_2024 = construction_output.get_construction_by_year(df, 2024)  # doctest: +SKIP
-    >>> print(f"Q4 2024 All Work: {df_2024[df_2024['quarter']=='Q4']['all_work_index'].values[0]}")  # doctest: +SKIP
+    >>> df_2024 = construction_output.get_construction_by_year(df, 2024)
 
     >>> # Get specific quarter
-    >>> q2_2025 = construction_output.get_construction_by_quarter(df, 'Q2', 2025)  # doctest: +SKIP
-    >>> print(f"Q2 2025: All Work={q2_2025['all_work_index'].values[0]:.1f}")  # doctest: +SKIP
+    >>> q2_2025 = construction_output.get_construction_by_quarter(df, 'Q2', 2025)
 
     >>> # Calculate growth rates
-    >>> df_growth = construction_output.calculate_growth_rates(df)  # doctest: +SKIP
-    >>> recent = df_growth.tail(4)  # doctest: +SKIP
-    >>> print(recent[['quarter', 'year', 'all_work_index', 'all_work_yoy_growth']])  # doctest: +SKIP
+    >>> df_growth = construction_output.calculate_growth_rates(df)
+    >>> recent = df_growth.tail(4)
+    >>> print(recent[['quarter', 'year', 'all_work_index', 'all_work_yoy_growth']])
 
 Publication Details:
     - Frequency: Quarterly
@@ -79,8 +76,7 @@ def get_latest_construction_publication_url() -> tuple[str, datetime]:
         NISRADataNotFoundError: If unable to find the latest publication
 
     Example:
-        >>> url, pub_date = get_latest_construction_publication_url()  # doctest: +SKIP
-        >>> print(f"Latest published: {pub_date.strftime('%Y-%m-%d')}")  # doctest: +SKIP
+        >>> url, pub_date = get_latest_construction_publication_url()
     """
     from bs4 import BeautifulSoup
 
@@ -154,8 +150,7 @@ def parse_construction_file(file_path: str | Path) -> pd.DataFrame:
             - repair_maintenance_index: float (repair and maintenance, SA)
 
     Example:
-        >>> df = parse_construction_file("construction-tables-q2-2025.xlsx")  # doctest: +SKIP
-        >>> print(df[df['year'] == 2025].tail())  # doctest: +SKIP
+        >>> df = parse_construction_file("construction-tables-q2-2025.xlsx")
     """
     logger.info(f"Parsing Construction Output file: {file_path}")
 
@@ -248,9 +243,7 @@ def get_latest_construction_output(force_refresh: bool = False) -> pd.DataFrame:
         DataFrame with quarterly Construction Output data
 
     Example:
-        >>> df = get_latest_construction_output()  # doctest: +SKIP
-        >>> print(f"Latest quarter: {df.iloc[-1]['quarter']} {df.iloc[-1]['year']}")  # doctest: +SKIP
-        >>> print(f"All Work Index: {df.iloc[-1]['all_work_index']:.1f}")  # doctest: +SKIP
+        >>> df = get_latest_construction_output()
     """
     excel_url, pub_date = get_latest_construction_publication_url()
 
@@ -276,9 +269,8 @@ def get_construction_by_year(df: pd.DataFrame, year: int) -> pd.DataFrame:
         DataFrame with only the specified year's data
 
     Example:
-        >>> df = get_latest_construction_output()  # doctest: +SKIP
-        >>> df_2024 = get_construction_by_year(df, 2024)  # doctest: +SKIP
-        >>> print(df_2024)  # doctest: +SKIP
+        >>> df = get_latest_construction_output()
+        >>> df_2024 = get_construction_by_year(df, 2024)
     """
     return df[df["year"] == year].reset_index(drop=True)
 
@@ -295,9 +287,8 @@ def get_construction_by_quarter(df: pd.DataFrame, quarter: str, year: int) -> pd
         DataFrame with single row for the specified quarter
 
     Example:
-        >>> df = get_latest_construction_output()  # doctest: +SKIP
-        >>> q2_2025 = get_construction_by_quarter(df, 'Q2', 2025)  # doctest: +SKIP
-        >>> print(f"Q2 2025 All Work: {q2_2025['all_work_index'].values[0]:.1f}")  # doctest: +SKIP
+        >>> df = get_latest_construction_output()
+        >>> q2_2025 = get_construction_by_quarter(df, 'Q2', 2025)
     """
     return df[(df["quarter"] == quarter) & (df["year"] == year)].reset_index(drop=True)
 
@@ -316,10 +307,9 @@ def calculate_growth_rates(df: pd.DataFrame, periods: int = 4) -> pd.DataFrame:
             - repair_maintenance_yoy_growth: R&M percentage change vs same quarter previous year
 
     Example:
-        >>> df = get_latest_construction_output()  # doctest: +SKIP
-        >>> df_growth = calculate_growth_rates(df)  # doctest: +SKIP
-        >>> recent = df_growth.tail(4)  # doctest: +SKIP
-        >>> print(recent[['quarter', 'year', 'all_work_index', 'all_work_yoy_growth']])  # doctest: +SKIP
+        >>> df = get_latest_construction_output()
+        >>> df_growth = calculate_growth_rates(df)
+        >>> recent = df_growth.tail(4)
     """
     result = df.copy()
 
@@ -350,9 +340,8 @@ def get_summary_statistics(df: pd.DataFrame, start_year: int | None = None, end_
             - quarters_count: Number of quarters included
 
     Example:
-        >>> df = get_latest_construction_output()  # doctest: +SKIP
-        >>> stats = get_summary_statistics(df, start_year=2020)  # doctest: +SKIP
-        >>> print(f"All Work mean since 2020: {stats['all_work_mean']:.1f}")  # doctest: +SKIP
+        >>> df = get_latest_construction_output()
+        >>> stats = get_summary_statistics(df, start_year=2020)
     """
     filtered = df.copy()
 

--- a/src/bolster/data_sources/nisra/construction_output.py
+++ b/src/bolster/data_sources/nisra/construction_output.py
@@ -24,23 +24,23 @@ Data Coverage:
     - Base year: 2022 = 100 (chained volume measure)
 
 Examples:
-    >>> from bolster.data_sources.nisra import construction_output
+    >>> from bolster.data_sources.nisra import construction_output  # doctest: +SKIP
     >>> # Get latest construction output data
-    >>> df = construction_output.get_latest_construction_output()
-    >>> print(df.head())
+    >>> df = construction_output.get_latest_construction_output()  # doctest: +SKIP
+    >>> print(df.head())  # doctest: +SKIP
 
     >>> # Filter for specific year
-    >>> df_2024 = construction_output.get_construction_by_year(df, 2024)
-    >>> print(f"Q4 2024 All Work: {df_2024[df_2024['quarter']=='Q4']['all_work_index'].values[0]}")
+    >>> df_2024 = construction_output.get_construction_by_year(df, 2024)  # doctest: +SKIP
+    >>> print(f"Q4 2024 All Work: {df_2024[df_2024['quarter']=='Q4']['all_work_index'].values[0]}")  # doctest: +SKIP
 
     >>> # Get specific quarter
-    >>> q2_2025 = construction_output.get_construction_by_quarter(df, 'Q2', 2025)
-    >>> print(f"Q2 2025: All Work={q2_2025['all_work_index'].values[0]:.1f}")
+    >>> q2_2025 = construction_output.get_construction_by_quarter(df, 'Q2', 2025)  # doctest: +SKIP
+    >>> print(f"Q2 2025: All Work={q2_2025['all_work_index'].values[0]:.1f}")  # doctest: +SKIP
 
     >>> # Calculate growth rates
-    >>> df_growth = construction_output.calculate_growth_rates(df)
-    >>> recent = df_growth.tail(4)
-    >>> print(recent[['quarter', 'year', 'all_work_index', 'all_work_yoy_growth']])
+    >>> df_growth = construction_output.calculate_growth_rates(df)  # doctest: +SKIP
+    >>> recent = df_growth.tail(4)  # doctest: +SKIP
+    >>> print(recent[['quarter', 'year', 'all_work_index', 'all_work_yoy_growth']])  # doctest: +SKIP
 
 Publication Details:
     - Frequency: Quarterly
@@ -79,8 +79,8 @@ def get_latest_construction_publication_url() -> tuple[str, datetime]:
         NISRADataNotFoundError: If unable to find the latest publication
 
     Example:
-        >>> url, pub_date = get_latest_construction_publication_url()
-        >>> print(f"Latest published: {pub_date.strftime('%Y-%m-%d')}")
+        >>> url, pub_date = get_latest_construction_publication_url()  # doctest: +SKIP
+        >>> print(f"Latest published: {pub_date.strftime('%Y-%m-%d')}")  # doctest: +SKIP
     """
     from bs4 import BeautifulSoup
 
@@ -154,8 +154,8 @@ def parse_construction_file(file_path: str | Path) -> pd.DataFrame:
             - repair_maintenance_index: float (repair and maintenance, SA)
 
     Example:
-        >>> df = parse_construction_file("construction-tables-q2-2025.xlsx")
-        >>> print(df[df['year'] == 2025].tail())
+        >>> df = parse_construction_file("construction-tables-q2-2025.xlsx")  # doctest: +SKIP
+        >>> print(df[df['year'] == 2025].tail())  # doctest: +SKIP
     """
     logger.info(f"Parsing Construction Output file: {file_path}")
 
@@ -248,9 +248,9 @@ def get_latest_construction_output(force_refresh: bool = False) -> pd.DataFrame:
         DataFrame with quarterly Construction Output data
 
     Example:
-        >>> df = get_latest_construction_output()
-        >>> print(f"Latest quarter: {df.iloc[-1]['quarter']} {df.iloc[-1]['year']}")
-        >>> print(f"All Work Index: {df.iloc[-1]['all_work_index']:.1f}")
+        >>> df = get_latest_construction_output()  # doctest: +SKIP
+        >>> print(f"Latest quarter: {df.iloc[-1]['quarter']} {df.iloc[-1]['year']}")  # doctest: +SKIP
+        >>> print(f"All Work Index: {df.iloc[-1]['all_work_index']:.1f}")  # doctest: +SKIP
     """
     excel_url, pub_date = get_latest_construction_publication_url()
 
@@ -276,9 +276,9 @@ def get_construction_by_year(df: pd.DataFrame, year: int) -> pd.DataFrame:
         DataFrame with only the specified year's data
 
     Example:
-        >>> df = get_latest_construction_output()
-        >>> df_2024 = get_construction_by_year(df, 2024)
-        >>> print(df_2024)
+        >>> df = get_latest_construction_output()  # doctest: +SKIP
+        >>> df_2024 = get_construction_by_year(df, 2024)  # doctest: +SKIP
+        >>> print(df_2024)  # doctest: +SKIP
     """
     return df[df["year"] == year].reset_index(drop=True)
 
@@ -295,9 +295,9 @@ def get_construction_by_quarter(df: pd.DataFrame, quarter: str, year: int) -> pd
         DataFrame with single row for the specified quarter
 
     Example:
-        >>> df = get_latest_construction_output()
-        >>> q2_2025 = get_construction_by_quarter(df, 'Q2', 2025)
-        >>> print(f"Q2 2025 All Work: {q2_2025['all_work_index'].values[0]:.1f}")
+        >>> df = get_latest_construction_output()  # doctest: +SKIP
+        >>> q2_2025 = get_construction_by_quarter(df, 'Q2', 2025)  # doctest: +SKIP
+        >>> print(f"Q2 2025 All Work: {q2_2025['all_work_index'].values[0]:.1f}")  # doctest: +SKIP
     """
     return df[(df["quarter"] == quarter) & (df["year"] == year)].reset_index(drop=True)
 
@@ -316,10 +316,10 @@ def calculate_growth_rates(df: pd.DataFrame, periods: int = 4) -> pd.DataFrame:
             - repair_maintenance_yoy_growth: R&M percentage change vs same quarter previous year
 
     Example:
-        >>> df = get_latest_construction_output()
-        >>> df_growth = calculate_growth_rates(df)
-        >>> recent = df_growth.tail(4)
-        >>> print(recent[['quarter', 'year', 'all_work_index', 'all_work_yoy_growth']])
+        >>> df = get_latest_construction_output()  # doctest: +SKIP
+        >>> df_growth = calculate_growth_rates(df)  # doctest: +SKIP
+        >>> recent = df_growth.tail(4)  # doctest: +SKIP
+        >>> print(recent[['quarter', 'year', 'all_work_index', 'all_work_yoy_growth']])  # doctest: +SKIP
     """
     result = df.copy()
 
@@ -350,9 +350,9 @@ def get_summary_statistics(df: pd.DataFrame, start_year: int | None = None, end_
             - quarters_count: Number of quarters included
 
     Example:
-        >>> df = get_latest_construction_output()
-        >>> stats = get_summary_statistics(df, start_year=2020)
-        >>> print(f"All Work mean since 2020: {stats['all_work_mean']:.1f}")
+        >>> df = get_latest_construction_output()  # doctest: +SKIP
+        >>> stats = get_summary_statistics(df, start_year=2020)  # doctest: +SKIP
+        >>> print(f"All Work mean since 2020: {stats['all_work_mean']:.1f}")  # doctest: +SKIP
     """
     filtered = df.copy()
 

--- a/src/bolster/data_sources/nisra/construction_output.py
+++ b/src/bolster/data_sources/nisra/construction_output.py
@@ -25,19 +25,15 @@ Data Coverage:
 
 Examples:
     >>> from bolster.data_sources.nisra import construction_output
-    >>> # Get latest construction output data
     >>> df = construction_output.get_latest_construction_output()
-
-    >>> # Filter for specific year
+    >>> 'all_work_index' in df.columns
+    True
     >>> df_2024 = construction_output.get_construction_by_year(df, 2024)
-
-    >>> # Get specific quarter
-    >>> q2_2025 = construction_output.get_construction_by_quarter(df, 'Q2', 2025)
-
-    >>> # Calculate growth rates
+    >>> len(df_2024) <= 4
+    True
     >>> df_growth = construction_output.calculate_growth_rates(df)
-    >>> recent = df_growth.tail(4)
-    >>> print(recent[['quarter', 'year', 'all_work_index', 'all_work_yoy_growth']])
+    >>> 'all_work_yoy_growth' in df_growth.columns
+    True
 
 Publication Details:
     - Frequency: Quarterly
@@ -77,6 +73,8 @@ def get_latest_construction_publication_url() -> tuple[str, datetime]:
 
     Example:
         >>> url, pub_date = get_latest_construction_publication_url()
+        >>> url.startswith('https://')
+        True
     """
     from bs4 import BeautifulSoup
 
@@ -244,6 +242,8 @@ def get_latest_construction_output(force_refresh: bool = False) -> pd.DataFrame:
 
     Example:
         >>> df = get_latest_construction_output()
+        >>> 'all_work_index' in df.columns
+        True
     """
     excel_url, pub_date = get_latest_construction_publication_url()
 
@@ -271,6 +271,8 @@ def get_construction_by_year(df: pd.DataFrame, year: int) -> pd.DataFrame:
     Example:
         >>> df = get_latest_construction_output()
         >>> df_2024 = get_construction_by_year(df, 2024)
+        >>> len(df_2024) <= 4
+        True
     """
     return df[df["year"] == year].reset_index(drop=True)
 
@@ -289,6 +291,8 @@ def get_construction_by_quarter(df: pd.DataFrame, quarter: str, year: int) -> pd
     Example:
         >>> df = get_latest_construction_output()
         >>> q2_2025 = get_construction_by_quarter(df, 'Q2', 2025)
+        >>> len(q2_2025) <= 1
+        True
     """
     return df[(df["quarter"] == quarter) & (df["year"] == year)].reset_index(drop=True)
 
@@ -309,7 +313,8 @@ def calculate_growth_rates(df: pd.DataFrame, periods: int = 4) -> pd.DataFrame:
     Example:
         >>> df = get_latest_construction_output()
         >>> df_growth = calculate_growth_rates(df)
-        >>> recent = df_growth.tail(4)
+        >>> 'all_work_yoy_growth' in df_growth.columns
+        True
     """
     result = df.copy()
 
@@ -342,6 +347,8 @@ def get_summary_statistics(df: pd.DataFrame, start_year: int | None = None, end_
     Example:
         >>> df = get_latest_construction_output()
         >>> stats = get_summary_statistics(df, start_year=2020)
+        >>> 'all_work_mean' in stats
+        True
     """
     filtered = df.copy()
 

--- a/src/bolster/data_sources/nisra/construction_output.py
+++ b/src/bolster/data_sources/nisra/construction_output.py
@@ -148,7 +148,11 @@ def parse_construction_file(file_path: str | Path) -> pd.DataFrame:
             - repair_maintenance_index: float (repair and maintenance, SA)
 
     Example:
-        >>> df = parse_construction_file("construction-tables-q2-2025.xlsx")
+        >>> url, _ = get_latest_construction_publication_url()
+        >>> path = download_file(url, cache_ttl_hours=168)
+        >>> df = parse_construction_file(path)
+        >>> 'all_work_index' in df.columns
+        True
     """
     logger.info(f"Parsing Construction Output file: {file_path}")
 

--- a/src/bolster/data_sources/nisra/deaths.py
+++ b/src/bolster/data_sources/nisra/deaths.py
@@ -23,13 +23,12 @@ Update Frequency: Weekly (published Fridays for week ending previous Friday)
 Geographic Coverage: Northern Ireland
 
 Example:
-    >>> from bolster.data_sources.nisra import deaths  # doctest: +SKIP
+    >>> from bolster.data_sources.nisra import deaths
     >>> # Get latest demographics breakdown
-    >>> df = deaths.get_latest_deaths(dimension='demographics')  # doctest: +SKIP
-    >>> print(df.head())  # doctest: +SKIP
+    >>> df = deaths.get_latest_deaths(dimension='demographics')
 
     >>> # Get specific week
-    >>> df = deaths.parse_deaths_file('/path/to/file.xlsx', dimension='geography')  # doctest: +SKIP
+    >>> df = deaths.parse_deaths_file('/path/to/file.xlsx', dimension='geography')
 """
 
 import logging
@@ -542,9 +541,8 @@ def parse_deaths_file(
         DataFrame for single dimension, or dict of DataFrames for 'all'
 
     Example:
-        >>> df = parse_deaths_file('deaths.xlsx', dimension='totals')  # doctest: +SKIP
-        >>> data = parse_deaths_file('deaths.xlsx', dimension='all')  # doctest: +SKIP
-        >>> print(data['totals'].head())  # doctest: +SKIP
+        >>> df = parse_deaths_file('deaths.xlsx', dimension='totals')
+        >>> data = parse_deaths_file('deaths.xlsx', dimension='all')
     """
     if dimension == "all":
         return {
@@ -577,8 +575,7 @@ def get_latest_deaths(
         DataFrame or dict of DataFrames depending on dimension
 
     Example:
-        >>> df = get_latest_deaths(dimension='demographics')  # doctest: +SKIP
-        >>> print(f"Latest week: {df['week_ending'].max()}")  # doctest: +SKIP
+        >>> df = get_latest_deaths(dimension='demographics')
     """
     url = get_latest_weekly_deaths_url()
     file_path = download_file(url, cache_ttl_hours=7 * 24, force_refresh=force_refresh)
@@ -630,15 +627,14 @@ def get_historical_deaths(
 
     Example:
         >>> # Get totals only
-        >>> df = get_historical_deaths()  # doctest: +SKIP
-        >>> print(f"Data spans {df['year'].min()} to {df['year'].max()}")  # doctest: +SKIP
+        >>> df = get_historical_deaths()
 
         >>> # Get totals with age breakdowns
-        >>> data = get_historical_deaths(years=[2020, 2021], include_age_breakdowns=True)  # doctest: +SKIP
-        >>> totals = data['totals']  # doctest: +SKIP
-        >>> age_data = data['age_breakdowns']  # doctest: +SKIP
+        >>> data = get_historical_deaths(years=[2020, 2021], include_age_breakdowns=True)
+        >>> totals = data['totals']
+        >>> age_data = data['age_breakdowns']
         >>> # Analyze age distribution
-        >>> age_summary = age_data.groupby('age_range')['deaths'].sum()  # doctest: +SKIP
+        >>> age_summary = age_data.groupby('age_range')['deaths'].sum()
     """
     # Download the historical file
     links = scrape_download_links(HISTORICAL_DEATHS_URL, file_extension=".xlsx")
@@ -770,12 +766,11 @@ def get_combined_deaths(
 
     Example:
         >>> # Get past 5 years plus 2025 YTD
-        >>> df = get_combined_deaths()  # doctest: +SKIP
-        >>> print(f"Data from {df['week_ending'].min().date()} to {df['week_ending'].max().date()}")  # doctest: +SKIP
+        >>> df = get_combined_deaths()
 
         >>> # Create multi-year visualizations
-        >>> import plotly.express as px  # doctest: +SKIP
-        >>> fig = px.line(df, x='week_ending', y='total_deaths', color='year')  # doctest: +SKIP
+        >>> import plotly.express as px
+        >>> fig = px.line(df, x='week_ending', y='total_deaths', color='year')
     """
     current_year = datetime.now().year
 

--- a/src/bolster/data_sources/nisra/deaths.py
+++ b/src/bolster/data_sources/nisra/deaths.py
@@ -781,7 +781,6 @@ def get_combined_deaths(
         - data_source: 'historical' or 'current'
 
     Example:
-        >>> # Get past 5 years plus 2025 YTD
         >>> df = get_combined_deaths()
         >>> 'total_deaths' in df.columns
         True

--- a/src/bolster/data_sources/nisra/deaths.py
+++ b/src/bolster/data_sources/nisra/deaths.py
@@ -30,9 +30,6 @@ Example:
     ['age_range', 'deaths', 'sex', 'week_ending']
     >>> len(df) > 0
     True
-
-    >>> # Get specific week
-    >>> df = deaths.parse_deaths_file('/path/to/file.xlsx', dimension='geography')
 """
 
 import logging
@@ -545,8 +542,9 @@ def parse_deaths_file(
         DataFrame for single dimension, or dict of DataFrames for 'all'
 
     Example:
-        >>> df = parse_deaths_file('deaths.xlsx', dimension='totals')
-        >>> data = parse_deaths_file('deaths.xlsx', dimension='all')
+        >>> url = get_latest_weekly_deaths_url()
+        >>> path = download_file(url, cache_ttl_hours=24*7)
+        >>> data = parse_deaths_file(path, dimension='all')
         >>> sorted(data.keys())
         ['demographics', 'geography', 'place', 'totals']
     """
@@ -781,7 +779,7 @@ def get_combined_deaths(
         - data_source: 'historical' or 'current'
 
     Example:
-        >>> df = get_combined_deaths()
+        >>> df = get_combined_deaths(years=[2022, 2023, 2024])
         >>> 'total_deaths' in df.columns
         True
         >>> 'data_source' in df.columns

--- a/src/bolster/data_sources/nisra/deaths.py
+++ b/src/bolster/data_sources/nisra/deaths.py
@@ -26,6 +26,10 @@ Example:
     >>> from bolster.data_sources.nisra import deaths
     >>> # Get latest demographics breakdown
     >>> df = deaths.get_latest_deaths(dimension='demographics')
+    >>> sorted(df.columns.tolist())
+    ['age_range', 'deaths', 'sex', 'week_ending']
+    >>> len(df) > 0
+    True
 
     >>> # Get specific week
     >>> df = deaths.parse_deaths_file('/path/to/file.xlsx', dimension='geography')
@@ -543,6 +547,8 @@ def parse_deaths_file(
     Example:
         >>> df = parse_deaths_file('deaths.xlsx', dimension='totals')
         >>> data = parse_deaths_file('deaths.xlsx', dimension='all')
+        >>> sorted(data.keys())
+        ['demographics', 'geography', 'place', 'totals']
     """
     if dimension == "all":
         return {
@@ -576,6 +582,10 @@ def get_latest_deaths(
 
     Example:
         >>> df = get_latest_deaths(dimension='demographics')
+        >>> sorted(df.columns.tolist())
+        ['age_range', 'deaths', 'sex', 'week_ending']
+        >>> len(df) > 0
+        True
     """
     url = get_latest_weekly_deaths_url()
     file_path = download_file(url, cache_ttl_hours=7 * 24, force_refresh=force_refresh)
@@ -628,13 +638,19 @@ def get_historical_deaths(
     Example:
         >>> # Get totals only
         >>> df = get_historical_deaths()
+        >>> 'total_deaths' in df.columns
+        True
 
         >>> # Get totals with age breakdowns
         >>> data = get_historical_deaths(years=[2020, 2021], include_age_breakdowns=True)
+        >>> sorted(data.keys())
+        ['age_breakdowns', 'totals']
         >>> totals = data['totals']
         >>> age_data = data['age_breakdowns']
         >>> # Analyze age distribution
         >>> age_summary = age_data.groupby('age_range')['deaths'].sum()
+        >>> len(age_summary) > 0
+        True
     """
     # Download the historical file
     links = scrape_download_links(HISTORICAL_DEATHS_URL, file_extension=".xlsx")
@@ -767,10 +783,10 @@ def get_combined_deaths(
     Example:
         >>> # Get past 5 years plus 2025 YTD
         >>> df = get_combined_deaths()
-
-        >>> # Create multi-year visualizations
-        >>> import plotly.express as px
-        >>> fig = px.line(df, x='week_ending', y='total_deaths', color='year')
+        >>> 'total_deaths' in df.columns
+        True
+        >>> 'data_source' in df.columns
+        True
     """
     current_year = datetime.now().year
 

--- a/src/bolster/data_sources/nisra/deaths.py
+++ b/src/bolster/data_sources/nisra/deaths.py
@@ -23,13 +23,13 @@ Update Frequency: Weekly (published Fridays for week ending previous Friday)
 Geographic Coverage: Northern Ireland
 
 Example:
-    >>> from bolster.data_sources.nisra import deaths
+    >>> from bolster.data_sources.nisra import deaths  # doctest: +SKIP
     >>> # Get latest demographics breakdown
-    >>> df = deaths.get_latest_deaths(dimension='demographics')
-    >>> print(df.head())
+    >>> df = deaths.get_latest_deaths(dimension='demographics')  # doctest: +SKIP
+    >>> print(df.head())  # doctest: +SKIP
 
     >>> # Get specific week
-    >>> df = deaths.parse_deaths_file('/path/to/file.xlsx', dimension='geography')
+    >>> df = deaths.parse_deaths_file('/path/to/file.xlsx', dimension='geography')  # doctest: +SKIP
 """
 
 import logging
@@ -542,9 +542,9 @@ def parse_deaths_file(
         DataFrame for single dimension, or dict of DataFrames for 'all'
 
     Example:
-        >>> df = parse_deaths_file('deaths.xlsx', dimension='totals')
-        >>> data = parse_deaths_file('deaths.xlsx', dimension='all')
-        >>> print(data['totals'].head())
+        >>> df = parse_deaths_file('deaths.xlsx', dimension='totals')  # doctest: +SKIP
+        >>> data = parse_deaths_file('deaths.xlsx', dimension='all')  # doctest: +SKIP
+        >>> print(data['totals'].head())  # doctest: +SKIP
     """
     if dimension == "all":
         return {
@@ -577,8 +577,8 @@ def get_latest_deaths(
         DataFrame or dict of DataFrames depending on dimension
 
     Example:
-        >>> df = get_latest_deaths(dimension='demographics')
-        >>> print(f"Latest week: {df['week_ending'].max()}")
+        >>> df = get_latest_deaths(dimension='demographics')  # doctest: +SKIP
+        >>> print(f"Latest week: {df['week_ending'].max()}")  # doctest: +SKIP
     """
     url = get_latest_weekly_deaths_url()
     file_path = download_file(url, cache_ttl_hours=7 * 24, force_refresh=force_refresh)
@@ -630,15 +630,15 @@ def get_historical_deaths(
 
     Example:
         >>> # Get totals only
-        >>> df = get_historical_deaths()
-        >>> print(f"Data spans {df['year'].min()} to {df['year'].max()}")
+        >>> df = get_historical_deaths()  # doctest: +SKIP
+        >>> print(f"Data spans {df['year'].min()} to {df['year'].max()}")  # doctest: +SKIP
 
         >>> # Get totals with age breakdowns
-        >>> data = get_historical_deaths(years=[2020, 2021], include_age_breakdowns=True)
-        >>> totals = data['totals']
-        >>> age_data = data['age_breakdowns']
+        >>> data = get_historical_deaths(years=[2020, 2021], include_age_breakdowns=True)  # doctest: +SKIP
+        >>> totals = data['totals']  # doctest: +SKIP
+        >>> age_data = data['age_breakdowns']  # doctest: +SKIP
         >>> # Analyze age distribution
-        >>> age_summary = age_data.groupby('age_range')['deaths'].sum()
+        >>> age_summary = age_data.groupby('age_range')['deaths'].sum()  # doctest: +SKIP
     """
     # Download the historical file
     links = scrape_download_links(HISTORICAL_DEATHS_URL, file_extension=".xlsx")
@@ -770,12 +770,12 @@ def get_combined_deaths(
 
     Example:
         >>> # Get past 5 years plus 2025 YTD
-        >>> df = get_combined_deaths()
-        >>> print(f"Data from {df['week_ending'].min().date()} to {df['week_ending'].max().date()}")
+        >>> df = get_combined_deaths()  # doctest: +SKIP
+        >>> print(f"Data from {df['week_ending'].min().date()} to {df['week_ending'].max().date()}")  # doctest: +SKIP
 
         >>> # Create multi-year visualizations
-        >>> import plotly.express as px
-        >>> fig = px.line(df, x='week_ending', y='total_deaths', color='year')
+        >>> import plotly.express as px  # doctest: +SKIP
+        >>> fig = px.line(df, x='week_ending', y='total_deaths', color='year')  # doctest: +SKIP
     """
     current_year = datetime.now().year
 

--- a/src/bolster/data_sources/nisra/economic_indicators.py
+++ b/src/bolster/data_sources/nisra/economic_indicators.py
@@ -215,7 +215,11 @@ def parse_ios_file(file_path: str | Path) -> pd.DataFrame:
             - uk_index: float (UK index value)
 
     Example:
-        >>> df = parse_ios_file("ios-q3-2025-tables.xlsx")
+        >>> url, _ = get_latest_ios_publication_url()
+        >>> path = download_file(url, cache_ttl_hours=168)
+        >>> df = parse_ios_file(path)
+        >>> 'ni_index' in df.columns
+        True
     """
     logger.info(f"Parsing Index of Services file: {file_path}")
 
@@ -262,7 +266,11 @@ def parse_iop_file(file_path: str | Path) -> pd.DataFrame:
             - uk_index: float (UK index value)
 
     Example:
-        >>> df = parse_iop_file("iop-q3-2025-tables.xlsx")
+        >>> url, _ = get_latest_iop_publication_url()
+        >>> path = download_file(url, cache_ttl_hours=168)
+        >>> df = parse_iop_file(path)
+        >>> 'ni_index' in df.columns
+        True
     """
     logger.info(f"Parsing Index of Production file: {file_path}")
 

--- a/src/bolster/data_sources/nisra/economic_indicators.py
+++ b/src/bolster/data_sources/nisra/economic_indicators.py
@@ -23,23 +23,23 @@ Data Coverage:
     - Both include NI and UK comparator data
 
 Example:
-    >>> from bolster.data_sources.nisra import economic_indicators
+    >>> from bolster.data_sources.nisra import economic_indicators  # doctest: +SKIP
     >>> # Get latest Index of Services data
-    >>> ios_df = economic_indicators.get_latest_index_of_services()
-    >>> print(ios_df.head())
+    >>> ios_df = economic_indicators.get_latest_index_of_services()  # doctest: +SKIP
+    >>> print(ios_df.head())  # doctest: +SKIP
 
     >>> # Get latest Index of Production data
-    >>> iop_df = economic_indicators.get_latest_index_of_production()
-    >>> print(iop_df.head())
+    >>> iop_df = economic_indicators.get_latest_index_of_production()  # doctest: +SKIP
+    >>> print(iop_df.head())  # doctest: +SKIP
 
     >>> # Filter for specific year
-    >>> ios_2024 = economic_indicators.get_ios_by_year(ios_df, 2024)
-    >>> print(f"NI Services Q4 2024: {ios_2024[ios_2024['quarter']=='Q4']['ni_index'].values[0]}")
+    >>> ios_2024 = economic_indicators.get_ios_by_year(ios_df, 2024)  # doctest: +SKIP
+    >>> print(f"NI Services Q4 2024: {ios_2024[ios_2024['quarter']=='Q4']['ni_index'].values[0]}")  # doctest: +SKIP
 
     >>> # Compare NI vs UK performance
-    >>> latest_q = ios_df.iloc[-1]
-    >>> print(f"Latest quarter: {latest_q['quarter']} {latest_q['year']}")
-    >>> print(f"NI: {latest_q['ni_index']}, UK: {latest_q['uk_index']}")
+    >>> latest_q = ios_df.iloc[-1]  # doctest: +SKIP
+    >>> print(f"Latest quarter: {latest_q['quarter']} {latest_q['year']}")  # doctest: +SKIP
+    >>> print(f"NI: {latest_q['ni_index']}, UK: {latest_q['uk_index']}")  # doctest: +SKIP
 
 Publication Details:
     - Frequency: Quarterly
@@ -77,9 +77,9 @@ def get_latest_ios_publication_url() -> tuple[str, datetime]:
         NISRADataNotFoundError: If unable to find the latest publication
 
     Example:
-        >>> url, pub_date = get_latest_ios_publication_url()
-        >>> print(f"Latest IOS published: {pub_date.strftime('%Y-%m-%d')}")
-        >>> print(f"Data URL: {url}")
+        >>> url, pub_date = get_latest_ios_publication_url()  # doctest: +SKIP
+        >>> print(f"Latest IOS published: {pub_date.strftime('%Y-%m-%d')}")  # doctest: +SKIP
+        >>> print(f"Data URL: {url}")  # doctest: +SKIP
     """
     from bs4 import BeautifulSoup
 
@@ -145,8 +145,8 @@ def get_latest_iop_publication_url() -> tuple[str, datetime]:
         NISRADataNotFoundError: If unable to find the latest publication
 
     Example:
-        >>> url, pub_date = get_latest_iop_publication_url()
-        >>> print(f"Latest IOP published: {pub_date.strftime('%Y-%m-%d')}")
+        >>> url, pub_date = get_latest_iop_publication_url()  # doctest: +SKIP
+        >>> print(f"Latest IOP published: {pub_date.strftime('%Y-%m-%d')}")  # doctest: +SKIP
     """
     from bs4 import BeautifulSoup
 
@@ -216,8 +216,8 @@ def parse_ios_file(file_path: str | Path) -> pd.DataFrame:
             - uk_index: float (UK index value)
 
     Example:
-        >>> df = parse_ios_file("ios-q3-2025-tables.xlsx")
-        >>> print(df[df['year'] == 2025].tail())
+        >>> df = parse_ios_file("ios-q3-2025-tables.xlsx")  # doctest: +SKIP
+        >>> print(df[df['year'] == 2025].tail())  # doctest: +SKIP
     """
     logger.info(f"Parsing Index of Services file: {file_path}")
 
@@ -264,8 +264,8 @@ def parse_iop_file(file_path: str | Path) -> pd.DataFrame:
             - uk_index: float (UK index value)
 
     Example:
-        >>> df = parse_iop_file("iop-q3-2025-tables.xlsx")
-        >>> print(df[df['year'] == 2025].tail())
+        >>> df = parse_iop_file("iop-q3-2025-tables.xlsx")  # doctest: +SKIP
+        >>> print(df[df['year'] == 2025].tail())  # doctest: +SKIP
     """
     logger.info(f"Parsing Index of Production file: {file_path}")
 
@@ -311,9 +311,9 @@ def get_latest_index_of_services(force_refresh: bool = False) -> pd.DataFrame:
         DataFrame with quarterly Index of Services data for NI and UK
 
     Example:
-        >>> df = get_latest_index_of_services()
-        >>> print(f"Latest quarter: {df.iloc[-1]['quarter']} {df.iloc[-1]['year']}")
-        >>> print(f"NI Index: {df.iloc[-1]['ni_index']}")
+        >>> df = get_latest_index_of_services()  # doctest: +SKIP
+        >>> print(f"Latest quarter: {df.iloc[-1]['quarter']} {df.iloc[-1]['year']}")  # doctest: +SKIP
+        >>> print(f"NI Index: {df.iloc[-1]['ni_index']}")  # doctest: +SKIP
     """
     excel_url, pub_date = get_latest_ios_publication_url()
 
@@ -336,9 +336,9 @@ def get_latest_index_of_production(force_refresh: bool = False) -> pd.DataFrame:
         DataFrame with quarterly Index of Production data for NI and UK
 
     Example:
-        >>> df = get_latest_index_of_production()
-        >>> print(f"Latest quarter: {df.iloc[-1]['quarter']} {df.iloc[-1]['year']}")
-        >>> print(f"NI Index: {df.iloc[-1]['ni_index']}")
+        >>> df = get_latest_index_of_production()  # doctest: +SKIP
+        >>> print(f"Latest quarter: {df.iloc[-1]['quarter']} {df.iloc[-1]['year']}")  # doctest: +SKIP
+        >>> print(f"NI Index: {df.iloc[-1]['ni_index']}")  # doctest: +SKIP
     """
     excel_url, pub_date = get_latest_iop_publication_url()
 
@@ -364,9 +364,9 @@ def get_ios_by_year(df: pd.DataFrame, year: int) -> pd.DataFrame:
         DataFrame with only the specified year's data
 
     Example:
-        >>> ios_df = get_latest_index_of_services()
-        >>> ios_2024 = get_ios_by_year(ios_df, 2024)
-        >>> print(ios_2024)
+        >>> ios_df = get_latest_index_of_services()  # doctest: +SKIP
+        >>> ios_2024 = get_ios_by_year(ios_df, 2024)  # doctest: +SKIP
+        >>> print(ios_2024)  # doctest: +SKIP
     """
     return df[df["year"] == year].reset_index(drop=True)
 
@@ -382,9 +382,9 @@ def get_iop_by_year(df: pd.DataFrame, year: int) -> pd.DataFrame:
         DataFrame with only the specified year's data
 
     Example:
-        >>> iop_df = get_latest_index_of_production()
-        >>> iop_2024 = get_iop_by_year(iop_df, 2024)
-        >>> print(iop_2024)
+        >>> iop_df = get_latest_index_of_production()  # doctest: +SKIP
+        >>> iop_2024 = get_iop_by_year(iop_df, 2024)  # doctest: +SKIP
+        >>> print(iop_2024)  # doctest: +SKIP
     """
     return df[df["year"] == year].reset_index(drop=True)
 
@@ -401,9 +401,9 @@ def get_ios_by_quarter(df: pd.DataFrame, quarter: str, year: int) -> pd.DataFram
         DataFrame with single row for the specified quarter
 
     Example:
-        >>> ios_df = get_latest_index_of_services()
-        >>> q3_2025 = get_ios_by_quarter(ios_df, 'Q3', 2025)
-        >>> print(f"Q3 2025 NI: {q3_2025['ni_index'].values[0]}")
+        >>> ios_df = get_latest_index_of_services()  # doctest: +SKIP
+        >>> q3_2025 = get_ios_by_quarter(ios_df, 'Q3', 2025)  # doctest: +SKIP
+        >>> print(f"Q3 2025 NI: {q3_2025['ni_index'].values[0]}")  # doctest: +SKIP
     """
     return df[(df["quarter"] == quarter) & (df["year"] == year)].reset_index(drop=True)
 
@@ -420,9 +420,9 @@ def get_iop_by_quarter(df: pd.DataFrame, quarter: str, year: int) -> pd.DataFram
         DataFrame with single row for the specified quarter
 
     Example:
-        >>> iop_df = get_latest_index_of_production()
-        >>> q3_2025 = get_iop_by_quarter(iop_df, 'Q3', 2025)
-        >>> print(f"Q3 2025 NI: {q3_2025['ni_index'].values[0]}")
+        >>> iop_df = get_latest_index_of_production()  # doctest: +SKIP
+        >>> q3_2025 = get_iop_by_quarter(iop_df, 'Q3', 2025)  # doctest: +SKIP
+        >>> print(f"Q3 2025 NI: {q3_2025['ni_index'].values[0]}")  # doctest: +SKIP
     """
     return df[(df["quarter"] == quarter) & (df["year"] == year)].reset_index(drop=True)
 
@@ -440,10 +440,10 @@ def calculate_ios_growth_rate(df: pd.DataFrame, periods: int = 4) -> pd.DataFram
             - uk_growth_rate: UK percentage change vs same quarter previous year
 
     Example:
-        >>> ios_df = get_latest_index_of_services()
-        >>> ios_growth = calculate_ios_growth_rate(ios_df)
-        >>> recent = ios_growth.tail(4)
-        >>> print(recent[['quarter', 'year', 'ni_index', 'ni_growth_rate']])
+        >>> ios_df = get_latest_index_of_services()  # doctest: +SKIP
+        >>> ios_growth = calculate_ios_growth_rate(ios_df)  # doctest: +SKIP
+        >>> recent = ios_growth.tail(4)  # doctest: +SKIP
+        >>> print(recent[['quarter', 'year', 'ni_index', 'ni_growth_rate']])  # doctest: +SKIP
     """
     result = df.copy()
 
@@ -467,10 +467,10 @@ def calculate_iop_growth_rate(df: pd.DataFrame, periods: int = 4) -> pd.DataFram
             - uk_growth_rate: UK percentage change vs same quarter previous year
 
     Example:
-        >>> iop_df = get_latest_index_of_production()
-        >>> iop_growth = calculate_iop_growth_rate(iop_df)
-        >>> recent = iop_growth.tail(4)
-        >>> print(recent[['quarter', 'year', 'ni_index', 'ni_growth_rate']])
+        >>> iop_df = get_latest_index_of_production()  # doctest: +SKIP
+        >>> iop_growth = calculate_iop_growth_rate(iop_df)  # doctest: +SKIP
+        >>> recent = iop_growth.tail(4)  # doctest: +SKIP
+        >>> print(recent[['quarter', 'year', 'ni_index', 'ni_growth_rate']])  # doctest: +SKIP
     """
     result = df.copy()
 
@@ -501,9 +501,9 @@ def get_ios_summary_statistics(df: pd.DataFrame, start_year: int | None = None, 
             - quarters_count: Number of quarters included
 
     Example:
-        >>> ios_df = get_latest_index_of_services()
-        >>> stats = get_ios_summary_statistics(ios_df, start_year=2020)
-        >>> print(f"NI mean index since 2020: {stats['ni_mean']:.1f}")
+        >>> ios_df = get_latest_index_of_services()  # doctest: +SKIP
+        >>> stats = get_ios_summary_statistics(ios_df, start_year=2020)  # doctest: +SKIP
+        >>> print(f"NI mean index since 2020: {stats['ni_mean']:.1f}")  # doctest: +SKIP
     """
     filtered = df.copy()
 
@@ -536,9 +536,9 @@ def get_iop_summary_statistics(df: pd.DataFrame, start_year: int | None = None, 
         Dictionary with summary statistics (same format as get_ios_summary_statistics)
 
     Example:
-        >>> iop_df = get_latest_index_of_production()
-        >>> stats = get_iop_summary_statistics(iop_df, start_year=2020)
-        >>> print(f"NI mean index since 2020: {stats['ni_mean']:.1f}")
+        >>> iop_df = get_latest_index_of_production()  # doctest: +SKIP
+        >>> stats = get_iop_summary_statistics(iop_df, start_year=2020)  # doctest: +SKIP
+        >>> print(f"NI mean index since 2020: {stats['ni_mean']:.1f}")  # doctest: +SKIP
     """
     filtered = df.copy()
 

--- a/src/bolster/data_sources/nisra/economic_indicators.py
+++ b/src/bolster/data_sources/nisra/economic_indicators.py
@@ -23,23 +23,19 @@ Data Coverage:
     - Both include NI and UK comparator data
 
 Example:
-    >>> from bolster.data_sources.nisra import economic_indicators  # doctest: +SKIP
+    >>> from bolster.data_sources.nisra import economic_indicators
     >>> # Get latest Index of Services data
-    >>> ios_df = economic_indicators.get_latest_index_of_services()  # doctest: +SKIP
-    >>> print(ios_df.head())  # doctest: +SKIP
+    >>> ios_df = economic_indicators.get_latest_index_of_services()
 
     >>> # Get latest Index of Production data
-    >>> iop_df = economic_indicators.get_latest_index_of_production()  # doctest: +SKIP
-    >>> print(iop_df.head())  # doctest: +SKIP
+    >>> iop_df = economic_indicators.get_latest_index_of_production()
 
     >>> # Filter for specific year
-    >>> ios_2024 = economic_indicators.get_ios_by_year(ios_df, 2024)  # doctest: +SKIP
-    >>> print(f"NI Services Q4 2024: {ios_2024[ios_2024['quarter']=='Q4']['ni_index'].values[0]}")  # doctest: +SKIP
+    >>> ios_2024 = economic_indicators.get_ios_by_year(ios_df, 2024)
 
     >>> # Compare NI vs UK performance
-    >>> latest_q = ios_df.iloc[-1]  # doctest: +SKIP
-    >>> print(f"Latest quarter: {latest_q['quarter']} {latest_q['year']}")  # doctest: +SKIP
-    >>> print(f"NI: {latest_q['ni_index']}, UK: {latest_q['uk_index']}")  # doctest: +SKIP
+    >>> latest_q = ios_df.iloc[-1]
+    >>> print(f"NI: {latest_q['ni_index']}, UK: {latest_q['uk_index']}")
 
 Publication Details:
     - Frequency: Quarterly
@@ -77,9 +73,7 @@ def get_latest_ios_publication_url() -> tuple[str, datetime]:
         NISRADataNotFoundError: If unable to find the latest publication
 
     Example:
-        >>> url, pub_date = get_latest_ios_publication_url()  # doctest: +SKIP
-        >>> print(f"Latest IOS published: {pub_date.strftime('%Y-%m-%d')}")  # doctest: +SKIP
-        >>> print(f"Data URL: {url}")  # doctest: +SKIP
+        >>> url, pub_date = get_latest_ios_publication_url()
     """
     from bs4 import BeautifulSoup
 
@@ -145,8 +139,7 @@ def get_latest_iop_publication_url() -> tuple[str, datetime]:
         NISRADataNotFoundError: If unable to find the latest publication
 
     Example:
-        >>> url, pub_date = get_latest_iop_publication_url()  # doctest: +SKIP
-        >>> print(f"Latest IOP published: {pub_date.strftime('%Y-%m-%d')}")  # doctest: +SKIP
+        >>> url, pub_date = get_latest_iop_publication_url()
     """
     from bs4 import BeautifulSoup
 
@@ -216,8 +209,7 @@ def parse_ios_file(file_path: str | Path) -> pd.DataFrame:
             - uk_index: float (UK index value)
 
     Example:
-        >>> df = parse_ios_file("ios-q3-2025-tables.xlsx")  # doctest: +SKIP
-        >>> print(df[df['year'] == 2025].tail())  # doctest: +SKIP
+        >>> df = parse_ios_file("ios-q3-2025-tables.xlsx")
     """
     logger.info(f"Parsing Index of Services file: {file_path}")
 
@@ -264,8 +256,7 @@ def parse_iop_file(file_path: str | Path) -> pd.DataFrame:
             - uk_index: float (UK index value)
 
     Example:
-        >>> df = parse_iop_file("iop-q3-2025-tables.xlsx")  # doctest: +SKIP
-        >>> print(df[df['year'] == 2025].tail())  # doctest: +SKIP
+        >>> df = parse_iop_file("iop-q3-2025-tables.xlsx")
     """
     logger.info(f"Parsing Index of Production file: {file_path}")
 
@@ -311,9 +302,7 @@ def get_latest_index_of_services(force_refresh: bool = False) -> pd.DataFrame:
         DataFrame with quarterly Index of Services data for NI and UK
 
     Example:
-        >>> df = get_latest_index_of_services()  # doctest: +SKIP
-        >>> print(f"Latest quarter: {df.iloc[-1]['quarter']} {df.iloc[-1]['year']}")  # doctest: +SKIP
-        >>> print(f"NI Index: {df.iloc[-1]['ni_index']}")  # doctest: +SKIP
+        >>> df = get_latest_index_of_services()
     """
     excel_url, pub_date = get_latest_ios_publication_url()
 
@@ -336,9 +325,7 @@ def get_latest_index_of_production(force_refresh: bool = False) -> pd.DataFrame:
         DataFrame with quarterly Index of Production data for NI and UK
 
     Example:
-        >>> df = get_latest_index_of_production()  # doctest: +SKIP
-        >>> print(f"Latest quarter: {df.iloc[-1]['quarter']} {df.iloc[-1]['year']}")  # doctest: +SKIP
-        >>> print(f"NI Index: {df.iloc[-1]['ni_index']}")  # doctest: +SKIP
+        >>> df = get_latest_index_of_production()
     """
     excel_url, pub_date = get_latest_iop_publication_url()
 
@@ -364,9 +351,8 @@ def get_ios_by_year(df: pd.DataFrame, year: int) -> pd.DataFrame:
         DataFrame with only the specified year's data
 
     Example:
-        >>> ios_df = get_latest_index_of_services()  # doctest: +SKIP
-        >>> ios_2024 = get_ios_by_year(ios_df, 2024)  # doctest: +SKIP
-        >>> print(ios_2024)  # doctest: +SKIP
+        >>> ios_df = get_latest_index_of_services()
+        >>> ios_2024 = get_ios_by_year(ios_df, 2024)
     """
     return df[df["year"] == year].reset_index(drop=True)
 
@@ -382,9 +368,8 @@ def get_iop_by_year(df: pd.DataFrame, year: int) -> pd.DataFrame:
         DataFrame with only the specified year's data
 
     Example:
-        >>> iop_df = get_latest_index_of_production()  # doctest: +SKIP
-        >>> iop_2024 = get_iop_by_year(iop_df, 2024)  # doctest: +SKIP
-        >>> print(iop_2024)  # doctest: +SKIP
+        >>> iop_df = get_latest_index_of_production()
+        >>> iop_2024 = get_iop_by_year(iop_df, 2024)
     """
     return df[df["year"] == year].reset_index(drop=True)
 
@@ -401,9 +386,8 @@ def get_ios_by_quarter(df: pd.DataFrame, quarter: str, year: int) -> pd.DataFram
         DataFrame with single row for the specified quarter
 
     Example:
-        >>> ios_df = get_latest_index_of_services()  # doctest: +SKIP
-        >>> q3_2025 = get_ios_by_quarter(ios_df, 'Q3', 2025)  # doctest: +SKIP
-        >>> print(f"Q3 2025 NI: {q3_2025['ni_index'].values[0]}")  # doctest: +SKIP
+        >>> ios_df = get_latest_index_of_services()
+        >>> q3_2025 = get_ios_by_quarter(ios_df, 'Q3', 2025)
     """
     return df[(df["quarter"] == quarter) & (df["year"] == year)].reset_index(drop=True)
 
@@ -420,9 +404,8 @@ def get_iop_by_quarter(df: pd.DataFrame, quarter: str, year: int) -> pd.DataFram
         DataFrame with single row for the specified quarter
 
     Example:
-        >>> iop_df = get_latest_index_of_production()  # doctest: +SKIP
-        >>> q3_2025 = get_iop_by_quarter(iop_df, 'Q3', 2025)  # doctest: +SKIP
-        >>> print(f"Q3 2025 NI: {q3_2025['ni_index'].values[0]}")  # doctest: +SKIP
+        >>> iop_df = get_latest_index_of_production()
+        >>> q3_2025 = get_iop_by_quarter(iop_df, 'Q3', 2025)
     """
     return df[(df["quarter"] == quarter) & (df["year"] == year)].reset_index(drop=True)
 
@@ -440,10 +423,9 @@ def calculate_ios_growth_rate(df: pd.DataFrame, periods: int = 4) -> pd.DataFram
             - uk_growth_rate: UK percentage change vs same quarter previous year
 
     Example:
-        >>> ios_df = get_latest_index_of_services()  # doctest: +SKIP
-        >>> ios_growth = calculate_ios_growth_rate(ios_df)  # doctest: +SKIP
-        >>> recent = ios_growth.tail(4)  # doctest: +SKIP
-        >>> print(recent[['quarter', 'year', 'ni_index', 'ni_growth_rate']])  # doctest: +SKIP
+        >>> ios_df = get_latest_index_of_services()
+        >>> ios_growth = calculate_ios_growth_rate(ios_df)
+        >>> recent = ios_growth.tail(4)
     """
     result = df.copy()
 
@@ -467,10 +449,9 @@ def calculate_iop_growth_rate(df: pd.DataFrame, periods: int = 4) -> pd.DataFram
             - uk_growth_rate: UK percentage change vs same quarter previous year
 
     Example:
-        >>> iop_df = get_latest_index_of_production()  # doctest: +SKIP
-        >>> iop_growth = calculate_iop_growth_rate(iop_df)  # doctest: +SKIP
-        >>> recent = iop_growth.tail(4)  # doctest: +SKIP
-        >>> print(recent[['quarter', 'year', 'ni_index', 'ni_growth_rate']])  # doctest: +SKIP
+        >>> iop_df = get_latest_index_of_production()
+        >>> iop_growth = calculate_iop_growth_rate(iop_df)
+        >>> recent = iop_growth.tail(4)
     """
     result = df.copy()
 
@@ -501,9 +482,8 @@ def get_ios_summary_statistics(df: pd.DataFrame, start_year: int | None = None, 
             - quarters_count: Number of quarters included
 
     Example:
-        >>> ios_df = get_latest_index_of_services()  # doctest: +SKIP
-        >>> stats = get_ios_summary_statistics(ios_df, start_year=2020)  # doctest: +SKIP
-        >>> print(f"NI mean index since 2020: {stats['ni_mean']:.1f}")  # doctest: +SKIP
+        >>> ios_df = get_latest_index_of_services()
+        >>> stats = get_ios_summary_statistics(ios_df, start_year=2020)
     """
     filtered = df.copy()
 
@@ -536,9 +516,8 @@ def get_iop_summary_statistics(df: pd.DataFrame, start_year: int | None = None, 
         Dictionary with summary statistics (same format as get_ios_summary_statistics)
 
     Example:
-        >>> iop_df = get_latest_index_of_production()  # doctest: +SKIP
-        >>> stats = get_iop_summary_statistics(iop_df, start_year=2020)  # doctest: +SKIP
-        >>> print(f"NI mean index since 2020: {stats['ni_mean']:.1f}")  # doctest: +SKIP
+        >>> iop_df = get_latest_index_of_production()
+        >>> stats = get_iop_summary_statistics(iop_df, start_year=2020)
     """
     filtered = df.copy()
 

--- a/src/bolster/data_sources/nisra/economic_indicators.py
+++ b/src/bolster/data_sources/nisra/economic_indicators.py
@@ -26,16 +26,18 @@ Example:
     >>> from bolster.data_sources.nisra import economic_indicators
     >>> # Get latest Index of Services data
     >>> ios_df = economic_indicators.get_latest_index_of_services()
+    >>> sorted(ios_df.columns.tolist())
+    ['date', 'ni_index', 'quarter', 'uk_index', 'year']
 
     >>> # Get latest Index of Production data
     >>> iop_df = economic_indicators.get_latest_index_of_production()
+    >>> 'ni_index' in iop_df.columns
+    True
 
     >>> # Filter for specific year
     >>> ios_2024 = economic_indicators.get_ios_by_year(ios_df, 2024)
-
-    >>> # Compare NI vs UK performance
-    >>> latest_q = ios_df.iloc[-1]
-    >>> print(f"NI: {latest_q['ni_index']}, UK: {latest_q['uk_index']}")
+    >>> len(ios_2024) <= 4
+    True
 
 Publication Details:
     - Frequency: Quarterly
@@ -74,6 +76,8 @@ def get_latest_ios_publication_url() -> tuple[str, datetime]:
 
     Example:
         >>> url, pub_date = get_latest_ios_publication_url()
+        >>> url.startswith('https://')
+        True
     """
     from bs4 import BeautifulSoup
 
@@ -140,6 +144,8 @@ def get_latest_iop_publication_url() -> tuple[str, datetime]:
 
     Example:
         >>> url, pub_date = get_latest_iop_publication_url()
+        >>> url.startswith('https://')
+        True
     """
     from bs4 import BeautifulSoup
 
@@ -303,6 +309,8 @@ def get_latest_index_of_services(force_refresh: bool = False) -> pd.DataFrame:
 
     Example:
         >>> df = get_latest_index_of_services()
+        >>> sorted(df.columns.tolist())
+        ['date', 'ni_index', 'quarter', 'uk_index', 'year']
     """
     excel_url, pub_date = get_latest_ios_publication_url()
 
@@ -326,6 +334,8 @@ def get_latest_index_of_production(force_refresh: bool = False) -> pd.DataFrame:
 
     Example:
         >>> df = get_latest_index_of_production()
+        >>> sorted(df.columns.tolist())
+        ['date', 'ni_index', 'quarter', 'uk_index', 'year']
     """
     excel_url, pub_date = get_latest_iop_publication_url()
 
@@ -353,6 +363,8 @@ def get_ios_by_year(df: pd.DataFrame, year: int) -> pd.DataFrame:
     Example:
         >>> ios_df = get_latest_index_of_services()
         >>> ios_2024 = get_ios_by_year(ios_df, 2024)
+        >>> len(ios_2024) <= 4
+        True
     """
     return df[df["year"] == year].reset_index(drop=True)
 
@@ -370,6 +382,8 @@ def get_iop_by_year(df: pd.DataFrame, year: int) -> pd.DataFrame:
     Example:
         >>> iop_df = get_latest_index_of_production()
         >>> iop_2024 = get_iop_by_year(iop_df, 2024)
+        >>> len(iop_2024) <= 4
+        True
     """
     return df[df["year"] == year].reset_index(drop=True)
 
@@ -388,6 +402,8 @@ def get_ios_by_quarter(df: pd.DataFrame, quarter: str, year: int) -> pd.DataFram
     Example:
         >>> ios_df = get_latest_index_of_services()
         >>> q3_2025 = get_ios_by_quarter(ios_df, 'Q3', 2025)
+        >>> 'ni_index' in q3_2025.columns
+        True
     """
     return df[(df["quarter"] == quarter) & (df["year"] == year)].reset_index(drop=True)
 
@@ -406,6 +422,8 @@ def get_iop_by_quarter(df: pd.DataFrame, quarter: str, year: int) -> pd.DataFram
     Example:
         >>> iop_df = get_latest_index_of_production()
         >>> q3_2025 = get_iop_by_quarter(iop_df, 'Q3', 2025)
+        >>> 'ni_index' in q3_2025.columns
+        True
     """
     return df[(df["quarter"] == quarter) & (df["year"] == year)].reset_index(drop=True)
 
@@ -425,7 +443,8 @@ def calculate_ios_growth_rate(df: pd.DataFrame, periods: int = 4) -> pd.DataFram
     Example:
         >>> ios_df = get_latest_index_of_services()
         >>> ios_growth = calculate_ios_growth_rate(ios_df)
-        >>> recent = ios_growth.tail(4)
+        >>> 'ni_growth_rate' in ios_growth.columns
+        True
     """
     result = df.copy()
 
@@ -451,7 +470,8 @@ def calculate_iop_growth_rate(df: pd.DataFrame, periods: int = 4) -> pd.DataFram
     Example:
         >>> iop_df = get_latest_index_of_production()
         >>> iop_growth = calculate_iop_growth_rate(iop_df)
-        >>> recent = iop_growth.tail(4)
+        >>> 'ni_growth_rate' in iop_growth.columns
+        True
     """
     result = df.copy()
 
@@ -484,6 +504,8 @@ def get_ios_summary_statistics(df: pd.DataFrame, start_year: int | None = None, 
     Example:
         >>> ios_df = get_latest_index_of_services()
         >>> stats = get_ios_summary_statistics(ios_df, start_year=2020)
+        >>> 'ni_mean' in stats
+        True
     """
     filtered = df.copy()
 
@@ -518,6 +540,8 @@ def get_iop_summary_statistics(df: pd.DataFrame, start_year: int | None = None, 
     Example:
         >>> iop_df = get_latest_index_of_production()
         >>> stats = get_iop_summary_statistics(iop_df, start_year=2020)
+        >>> 'ni_mean' in stats
+        True
     """
     filtered = df.copy()
 

--- a/src/bolster/data_sources/nisra/emergency_care_waiting_times.py
+++ b/src/bolster/data_sources/nisra/emergency_care_waiting_times.py
@@ -21,14 +21,14 @@ Update Frequency:
     Quarterly, approximately 3 months after the end of each quarter.
 
 Example:
-    >>> from bolster.data_sources.nisra import emergency_care_waiting_times as ecwt
-    >>> df = ecwt.get_latest_data()
-    >>> print(df.tail())
+    >>> from bolster.data_sources.nisra import emergency_care_waiting_times as ecwt  # doctest: +SKIP
+    >>> df = ecwt.get_latest_data()  # doctest: +SKIP
+    >>> print(df.tail())  # doctest: +SKIP
 
     >>> # Type 1 A&E performance only
-    >>> type1 = df[df['attendance_type'] == 'Type 1']
-    >>> by_trust = type1.groupby('trust')['pct_within_4hrs'].mean()
-    >>> print(by_trust)
+    >>> type1 = df[df['attendance_type'] == 'Type 1']  # doctest: +SKIP
+    >>> by_trust = type1.groupby('trust')['pct_within_4hrs'].mean()  # doctest: +SKIP
+    >>> print(by_trust)  # doctest: +SKIP
 
 Publication Details:
     - Frequency: Quarterly (published ~3 months after quarter end)

--- a/src/bolster/data_sources/nisra/emergency_care_waiting_times.py
+++ b/src/bolster/data_sources/nisra/emergency_care_waiting_times.py
@@ -23,11 +23,8 @@ Update Frequency:
 Example:
     >>> from bolster.data_sources.nisra import emergency_care_waiting_times as ecwt
     >>> df = ecwt.get_latest_data()
-
-    >>> # Type 1 A&E performance only
-    >>> type1 = df[df['attendance_type'] == 'Type 1']
-    >>> by_trust = type1.groupby('trust')['pct_within_4hrs'].mean()
-    >>> print(by_trust)
+    >>> 'pct_within_4hrs' in df.columns
+    True
 
 Publication Details:
     - Frequency: Quarterly (published ~3 months after quarter end)

--- a/src/bolster/data_sources/nisra/emergency_care_waiting_times.py
+++ b/src/bolster/data_sources/nisra/emergency_care_waiting_times.py
@@ -21,14 +21,13 @@ Update Frequency:
     Quarterly, approximately 3 months after the end of each quarter.
 
 Example:
-    >>> from bolster.data_sources.nisra import emergency_care_waiting_times as ecwt  # doctest: +SKIP
-    >>> df = ecwt.get_latest_data()  # doctest: +SKIP
-    >>> print(df.tail())  # doctest: +SKIP
+    >>> from bolster.data_sources.nisra import emergency_care_waiting_times as ecwt
+    >>> df = ecwt.get_latest_data()
 
     >>> # Type 1 A&E performance only
-    >>> type1 = df[df['attendance_type'] == 'Type 1']  # doctest: +SKIP
-    >>> by_trust = type1.groupby('trust')['pct_within_4hrs'].mean()  # doctest: +SKIP
-    >>> print(by_trust)  # doctest: +SKIP
+    >>> type1 = df[df['attendance_type'] == 'Type 1']
+    >>> by_trust = type1.groupby('trust')['pct_within_4hrs'].mean()
+    >>> print(by_trust)
 
 Publication Details:
     - Frequency: Quarterly (published ~3 months after quarter end)

--- a/src/bolster/data_sources/nisra/index_of_production.py
+++ b/src/bolster/data_sources/nisra/index_of_production.py
@@ -19,13 +19,11 @@ Geographic Coverage: Northern Ireland and UK comparison
 Base Year: 2020=100
 
 Example:
-    >>> from bolster.data_sources.nisra import index_of_production as iop  # doctest: +SKIP
-    >>> df = iop.get_latest_iop()  # doctest: +SKIP
-    >>> print(df.tail())  # doctest: +SKIP
+    >>> from bolster.data_sources.nisra import index_of_production as iop
+    >>> df = iop.get_latest_iop()
 
     >>> # NI vs UK production gap in latest quarter
-    >>> latest = df.iloc[-1]  # doctest: +SKIP
-    >>> print(f"Q{latest['quarter']} {latest['year']}: NI={latest['ni_index']:.1f}, UK={latest['uk_index']:.1f}")  # doctest: +SKIP
+    >>> latest = df.iloc[-1]
 """
 
 import logging
@@ -183,12 +181,10 @@ def get_latest_iop(force_refresh: bool = False) -> pd.DataFrame:
         NISRAValidationError: If file structure is unexpected
 
     Example:
-        >>> df = get_latest_iop()  # doctest: +SKIP
-        >>> print(df.tail(4))  # doctest: +SKIP
+        >>> df = get_latest_iop()
         >>> # NI outperforming UK?
-        >>> latest = df.iloc[-1]  # doctest: +SKIP
-        >>> gap = latest['ni_index'] - latest['uk_index']  # doctest: +SKIP
-        >>> print(f"NI vs UK gap: {gap:+.1f} points")  # doctest: +SKIP
+        >>> latest = df.iloc[-1]
+        >>> gap = latest['ni_index'] - latest['uk_index']
     """
     excel_url, year, quarter = get_latest_iop_publication_url()
     logger.info(f"Downloading IOP Q{quarter} {year} from: {excel_url}")
@@ -236,9 +232,8 @@ def get_iop_by_year(df: pd.DataFrame, year: int) -> pd.DataFrame:
         Filtered DataFrame (up to 4 quarters)
 
     Example:
-        >>> df = get_latest_iop()  # doctest: +SKIP
-        >>> df_2024 = get_iop_by_year(df, 2024)  # doctest: +SKIP
-        >>> print(df_2024[['quarter_label', 'ni_index', 'uk_index']])  # doctest: +SKIP
+        >>> df = get_latest_iop()
+        >>> df_2024 = get_iop_by_year(df, 2024)
     """
     return df[df["year"] == year].reset_index(drop=True)
 
@@ -257,9 +252,8 @@ def get_iop_growth(df: pd.DataFrame) -> pd.DataFrame:
             - uk_yoy: UK year-on-year % change
 
     Example:
-        >>> df = get_latest_iop()  # doctest: +SKIP
-        >>> growth = get_iop_growth(df)  # doctest: +SKIP
-        >>> print(growth[['quarter_label', 'ni_yoy', 'uk_yoy']].tail(8))  # doctest: +SKIP
+        >>> df = get_latest_iop()
+        >>> growth = get_iop_growth(df)
     """
     result = df.copy()
     result["ni_qoq"] = result["ni_index"].pct_change(1).mul(100).round(2)

--- a/src/bolster/data_sources/nisra/index_of_production.py
+++ b/src/bolster/data_sources/nisra/index_of_production.py
@@ -19,13 +19,13 @@ Geographic Coverage: Northern Ireland and UK comparison
 Base Year: 2020=100
 
 Example:
-    >>> from bolster.data_sources.nisra import index_of_production as iop
-    >>> df = iop.get_latest_iop()
-    >>> print(df.tail())
+    >>> from bolster.data_sources.nisra import index_of_production as iop  # doctest: +SKIP
+    >>> df = iop.get_latest_iop()  # doctest: +SKIP
+    >>> print(df.tail())  # doctest: +SKIP
 
     >>> # NI vs UK production gap in latest quarter
-    >>> latest = df.iloc[-1]
-    >>> print(f"Q{latest['quarter']} {latest['year']}: NI={latest['ni_index']:.1f}, UK={latest['uk_index']:.1f}")
+    >>> latest = df.iloc[-1]  # doctest: +SKIP
+    >>> print(f"Q{latest['quarter']} {latest['year']}: NI={latest['ni_index']:.1f}, UK={latest['uk_index']:.1f}")  # doctest: +SKIP
 """
 
 import logging
@@ -183,12 +183,12 @@ def get_latest_iop(force_refresh: bool = False) -> pd.DataFrame:
         NISRAValidationError: If file structure is unexpected
 
     Example:
-        >>> df = get_latest_iop()
-        >>> print(df.tail(4))
+        >>> df = get_latest_iop()  # doctest: +SKIP
+        >>> print(df.tail(4))  # doctest: +SKIP
         >>> # NI outperforming UK?
-        >>> latest = df.iloc[-1]
-        >>> gap = latest['ni_index'] - latest['uk_index']
-        >>> print(f"NI vs UK gap: {gap:+.1f} points")
+        >>> latest = df.iloc[-1]  # doctest: +SKIP
+        >>> gap = latest['ni_index'] - latest['uk_index']  # doctest: +SKIP
+        >>> print(f"NI vs UK gap: {gap:+.1f} points")  # doctest: +SKIP
     """
     excel_url, year, quarter = get_latest_iop_publication_url()
     logger.info(f"Downloading IOP Q{quarter} {year} from: {excel_url}")
@@ -236,9 +236,9 @@ def get_iop_by_year(df: pd.DataFrame, year: int) -> pd.DataFrame:
         Filtered DataFrame (up to 4 quarters)
 
     Example:
-        >>> df = get_latest_iop()
-        >>> df_2024 = get_iop_by_year(df, 2024)
-        >>> print(df_2024[['quarter_label', 'ni_index', 'uk_index']])
+        >>> df = get_latest_iop()  # doctest: +SKIP
+        >>> df_2024 = get_iop_by_year(df, 2024)  # doctest: +SKIP
+        >>> print(df_2024[['quarter_label', 'ni_index', 'uk_index']])  # doctest: +SKIP
     """
     return df[df["year"] == year].reset_index(drop=True)
 
@@ -257,9 +257,9 @@ def get_iop_growth(df: pd.DataFrame) -> pd.DataFrame:
             - uk_yoy: UK year-on-year % change
 
     Example:
-        >>> df = get_latest_iop()
-        >>> growth = get_iop_growth(df)
-        >>> print(growth[['quarter_label', 'ni_yoy', 'uk_yoy']].tail(8))
+        >>> df = get_latest_iop()  # doctest: +SKIP
+        >>> growth = get_iop_growth(df)  # doctest: +SKIP
+        >>> print(growth[['quarter_label', 'ni_yoy', 'uk_yoy']].tail(8))  # doctest: +SKIP
     """
     result = df.copy()
     result["ni_qoq"] = result["ni_index"].pct_change(1).mul(100).round(2)

--- a/src/bolster/data_sources/nisra/index_of_production.py
+++ b/src/bolster/data_sources/nisra/index_of_production.py
@@ -21,9 +21,8 @@ Base Year: 2020=100
 Example:
     >>> from bolster.data_sources.nisra import index_of_production as iop
     >>> df = iop.get_latest_iop()
-
-    >>> # NI vs UK production gap in latest quarter
-    >>> latest = df.iloc[-1]
+    >>> 'ni_index' in df.columns
+    True
 """
 
 import logging
@@ -182,9 +181,8 @@ def get_latest_iop(force_refresh: bool = False) -> pd.DataFrame:
 
     Example:
         >>> df = get_latest_iop()
-        >>> # NI outperforming UK?
-        >>> latest = df.iloc[-1]
-        >>> gap = latest['ni_index'] - latest['uk_index']
+        >>> 'ni_index' in df.columns
+        True
     """
     excel_url, year, quarter = get_latest_iop_publication_url()
     logger.info(f"Downloading IOP Q{quarter} {year} from: {excel_url}")
@@ -234,6 +232,8 @@ def get_iop_by_year(df: pd.DataFrame, year: int) -> pd.DataFrame:
     Example:
         >>> df = get_latest_iop()
         >>> df_2024 = get_iop_by_year(df, 2024)
+        >>> len(df_2024) <= 4
+        True
     """
     return df[df["year"] == year].reset_index(drop=True)
 
@@ -254,6 +254,8 @@ def get_iop_growth(df: pd.DataFrame) -> pd.DataFrame:
     Example:
         >>> df = get_latest_iop()
         >>> growth = get_iop_growth(df)
+        >>> 'ni_yoy' in growth.columns
+        True
     """
     result = df.copy()
     result["ni_qoq"] = result["ni_index"].pct_change(1).mul(100).round(2)

--- a/src/bolster/data_sources/nisra/index_of_services.py
+++ b/src/bolster/data_sources/nisra/index_of_services.py
@@ -24,15 +24,13 @@ Geographic Coverage: Northern Ireland and UK comparison
 Base Year: 2020=100
 
 Example:
-    >>> from bolster.data_sources.nisra import index_of_services as ios  # doctest: +SKIP
-    >>> df = ios.get_latest_ios()  # doctest: +SKIP
-    >>> print(df.tail())  # doctest: +SKIP
+    >>> from bolster.data_sources.nisra import index_of_services as ios
+    >>> df = ios.get_latest_ios()
 
     >>> # Services sector growth
-    >>> from bolster.data_sources.nisra import index_of_services as ios  # doctest: +SKIP
-    >>> df = ios.get_latest_ios()  # doctest: +SKIP
-    >>> growth = ios.get_ios_growth(df)  # doctest: +SKIP
-    >>> print(growth[['quarter_label', 'ni_yoy']].tail(4))  # doctest: +SKIP
+    >>> from bolster.data_sources.nisra import index_of_services as ios
+    >>> df = ios.get_latest_ios()
+    >>> growth = ios.get_ios_growth(df)
 """
 
 import logging
@@ -182,11 +180,9 @@ def get_latest_ios(force_refresh: bool = False) -> pd.DataFrame:
         NISRAValidationError: If file structure is unexpected
 
     Example:
-        >>> df = get_latest_ios()  # doctest: +SKIP
-        >>> print(df.tail(4))  # doctest: +SKIP
+        >>> df = get_latest_ios()
         >>> # Services as driver of NI growth
-        >>> latest = df.iloc[-1]  # doctest: +SKIP
-        >>> print(f"NI Services {latest['quarter_label']}: {latest['ni_index']:.1f} (UK: {latest['uk_index']:.1f})")  # doctest: +SKIP
+        >>> latest = df.iloc[-1]
     """
     excel_url, year, quarter = get_latest_ios_publication_url()
     logger.info(f"Downloading IOS Q{quarter} {year} from: {excel_url}")
@@ -234,9 +230,8 @@ def get_ios_by_year(df: pd.DataFrame, year: int) -> pd.DataFrame:
         Filtered DataFrame (up to 4 quarters)
 
     Example:
-        >>> df = get_latest_ios()  # doctest: +SKIP
-        >>> df_2024 = get_ios_by_year(df, 2024)  # doctest: +SKIP
-        >>> print(df_2024[['quarter_label', 'ni_index', 'uk_index']])  # doctest: +SKIP
+        >>> df = get_latest_ios()
+        >>> df_2024 = get_ios_by_year(df, 2024)
     """
     return df[df["year"] == year].reset_index(drop=True)
 
@@ -255,9 +250,8 @@ def get_ios_growth(df: pd.DataFrame) -> pd.DataFrame:
             - uk_yoy: UK year-on-year % change
 
     Example:
-        >>> df = get_latest_ios()  # doctest: +SKIP
-        >>> growth = get_ios_growth(df)  # doctest: +SKIP
-        >>> print(growth[['quarter_label', 'ni_yoy', 'uk_yoy']].tail(8))  # doctest: +SKIP
+        >>> df = get_latest_ios()
+        >>> growth = get_ios_growth(df)
     """
     result = df.copy()
     result["ni_qoq"] = result["ni_index"].pct_change(1).mul(100).round(2)

--- a/src/bolster/data_sources/nisra/index_of_services.py
+++ b/src/bolster/data_sources/nisra/index_of_services.py
@@ -26,11 +26,11 @@ Base Year: 2020=100
 Example:
     >>> from bolster.data_sources.nisra import index_of_services as ios
     >>> df = ios.get_latest_ios()
-
-    >>> # Services sector growth
-    >>> from bolster.data_sources.nisra import index_of_services as ios
-    >>> df = ios.get_latest_ios()
+    >>> 'ni_index' in df.columns
+    True
     >>> growth = ios.get_ios_growth(df)
+    >>> 'ni_yoy' in growth.columns
+    True
 """
 
 import logging
@@ -181,8 +181,8 @@ def get_latest_ios(force_refresh: bool = False) -> pd.DataFrame:
 
     Example:
         >>> df = get_latest_ios()
-        >>> # Services as driver of NI growth
-        >>> latest = df.iloc[-1]
+        >>> 'ni_index' in df.columns
+        True
     """
     excel_url, year, quarter = get_latest_ios_publication_url()
     logger.info(f"Downloading IOS Q{quarter} {year} from: {excel_url}")
@@ -232,6 +232,8 @@ def get_ios_by_year(df: pd.DataFrame, year: int) -> pd.DataFrame:
     Example:
         >>> df = get_latest_ios()
         >>> df_2024 = get_ios_by_year(df, 2024)
+        >>> len(df_2024) <= 4
+        True
     """
     return df[df["year"] == year].reset_index(drop=True)
 
@@ -252,6 +254,8 @@ def get_ios_growth(df: pd.DataFrame) -> pd.DataFrame:
     Example:
         >>> df = get_latest_ios()
         >>> growth = get_ios_growth(df)
+        >>> 'ni_yoy' in growth.columns
+        True
     """
     result = df.copy()
     result["ni_qoq"] = result["ni_index"].pct_change(1).mul(100).round(2)

--- a/src/bolster/data_sources/nisra/index_of_services.py
+++ b/src/bolster/data_sources/nisra/index_of_services.py
@@ -24,15 +24,15 @@ Geographic Coverage: Northern Ireland and UK comparison
 Base Year: 2020=100
 
 Example:
-    >>> from bolster.data_sources.nisra import index_of_services as ios
-    >>> df = ios.get_latest_ios()
-    >>> print(df.tail())
+    >>> from bolster.data_sources.nisra import index_of_services as ios  # doctest: +SKIP
+    >>> df = ios.get_latest_ios()  # doctest: +SKIP
+    >>> print(df.tail())  # doctest: +SKIP
 
     >>> # Services sector growth
-    >>> from bolster.data_sources.nisra import index_of_services as ios
-    >>> df = ios.get_latest_ios()
-    >>> growth = ios.get_ios_growth(df)
-    >>> print(growth[['quarter_label', 'ni_yoy']].tail(4))
+    >>> from bolster.data_sources.nisra import index_of_services as ios  # doctest: +SKIP
+    >>> df = ios.get_latest_ios()  # doctest: +SKIP
+    >>> growth = ios.get_ios_growth(df)  # doctest: +SKIP
+    >>> print(growth[['quarter_label', 'ni_yoy']].tail(4))  # doctest: +SKIP
 """
 
 import logging
@@ -182,11 +182,11 @@ def get_latest_ios(force_refresh: bool = False) -> pd.DataFrame:
         NISRAValidationError: If file structure is unexpected
 
     Example:
-        >>> df = get_latest_ios()
-        >>> print(df.tail(4))
+        >>> df = get_latest_ios()  # doctest: +SKIP
+        >>> print(df.tail(4))  # doctest: +SKIP
         >>> # Services as driver of NI growth
-        >>> latest = df.iloc[-1]
-        >>> print(f"NI Services {latest['quarter_label']}: {latest['ni_index']:.1f} (UK: {latest['uk_index']:.1f})")
+        >>> latest = df.iloc[-1]  # doctest: +SKIP
+        >>> print(f"NI Services {latest['quarter_label']}: {latest['ni_index']:.1f} (UK: {latest['uk_index']:.1f})")  # doctest: +SKIP
     """
     excel_url, year, quarter = get_latest_ios_publication_url()
     logger.info(f"Downloading IOS Q{quarter} {year} from: {excel_url}")
@@ -234,9 +234,9 @@ def get_ios_by_year(df: pd.DataFrame, year: int) -> pd.DataFrame:
         Filtered DataFrame (up to 4 quarters)
 
     Example:
-        >>> df = get_latest_ios()
-        >>> df_2024 = get_ios_by_year(df, 2024)
-        >>> print(df_2024[['quarter_label', 'ni_index', 'uk_index']])
+        >>> df = get_latest_ios()  # doctest: +SKIP
+        >>> df_2024 = get_ios_by_year(df, 2024)  # doctest: +SKIP
+        >>> print(df_2024[['quarter_label', 'ni_index', 'uk_index']])  # doctest: +SKIP
     """
     return df[df["year"] == year].reset_index(drop=True)
 
@@ -255,9 +255,9 @@ def get_ios_growth(df: pd.DataFrame) -> pd.DataFrame:
             - uk_yoy: UK year-on-year % change
 
     Example:
-        >>> df = get_latest_ios()
-        >>> growth = get_ios_growth(df)
-        >>> print(growth[['quarter_label', 'ni_yoy', 'uk_yoy']].tail(8))
+        >>> df = get_latest_ios()  # doctest: +SKIP
+        >>> growth = get_ios_growth(df)  # doctest: +SKIP
+        >>> print(growth[['quarter_label', 'ni_yoy', 'uk_yoy']].tail(8))  # doctest: +SKIP
     """
     result = df.copy()
     result["ni_qoq"] = result["ni_index"].pct_change(1).mul(100).round(2)

--- a/src/bolster/data_sources/nisra/labour_market.py
+++ b/src/bolster/data_sources/nisra/labour_market.py
@@ -42,31 +42,31 @@ Architecture:
     - Uses standardized Excel parsing utilities from _base.py
 
 Usage:
-    >>> from bolster.data_sources.nisra import labour_market
+    >>> from bolster.data_sources.nisra import labour_market  # doctest: +SKIP
     >>> # Get latest quarterly employment data
-    >>> df = labour_market.get_latest_employment()
+    >>> df = labour_market.get_latest_employment()  # doctest: +SKIP
     >>> # Get economic inactivity data
-    >>> df = labour_market.get_latest_economic_inactivity()
+    >>> df = labour_market.get_latest_economic_inactivity()  # doctest: +SKIP
     >>> # Get all tables for a specific quarter
-    >>> data = labour_market.get_quarterly_data(year=2025, quarter="Jul-Sep")
+    >>> data = labour_market.get_quarterly_data(year=2025, quarter="Jul-Sep")  # doctest: +SKIP
     >>> # Get annual employment by Local Government District
-    >>> lgd_df = labour_market.get_latest_employment_by_lgd()
+    >>> lgd_df = labour_market.get_latest_employment_by_lgd()  # doctest: +SKIP
 
 Example:
-    >>> import pandas as pd
-    >>> from bolster.data_sources.nisra import labour_market
+    >>> import pandas as pd  # doctest: +SKIP
+    >>> from bolster.data_sources.nisra import labour_market  # doctest: +SKIP
     >>> # Get latest employment by age and sex
-    >>> emp_df = labour_market.get_latest_employment()
+    >>> emp_df = labour_market.get_latest_employment()  # doctest: +SKIP
     >>> # Filter for females aged 25-29
-    >>> young_females = emp_df[
-    ...     (emp_df['sex'] == 'Female') &
-    ...     (emp_df['age_group'] == '25 to 29')
-    ... ]
+    >>> young_females = emp_df[  # doctest: +SKIP
+    ...     (emp_df['sex'] == 'Female') &  # doctest: +SKIP
+    ...     (emp_df['age_group'] == '25 to 29')  # doctest: +SKIP
+    ... ]  # doctest: +SKIP
     >>> # Get employment by Local Government District
-    >>> lgd_df = labour_market.get_latest_employment_by_lgd()
+    >>> lgd_df = labour_market.get_latest_employment_by_lgd()  # doctest: +SKIP
     >>> # Compare Belfast and rural areas
-    >>> belfast = lgd_df[lgd_df['lgd'] == 'Belfast']
-    >>> print(f"Belfast employment rate: {belfast['employment_rate'].values[0]:.1f}%")
+    >>> belfast = lgd_df[lgd_df['lgd'] == 'Belfast']  # doctest: +SKIP
+    >>> print(f"Belfast employment rate: {belfast['employment_rate'].values[0]:.1f}%")  # doctest: +SKIP
 
 Author: Claude Code
 Date: 2025-12-21
@@ -108,9 +108,9 @@ def _quarter_to_month_names(quarter_str: str) -> tuple[str, str, str]:
         Tuple of (first_month, second_month, third_month)
 
     Examples:
-        >>> _quarter_to_month_names("Jul-Sep")
+        >>> _quarter_to_month_names("Jul-Sep")  # doctest: +SKIP
         ('July', 'August', 'September')
-        >>> _quarter_to_month_names("Jan-Mar")
+        >>> _quarter_to_month_names("Jan-Mar")  # doctest: +SKIP
         ('January', 'February', 'March')
     """
     quarter_map = {
@@ -198,8 +198,8 @@ def download_quarterly_lfs(year: int, quarter: str, force_refresh: bool = False,
         NISRADataNotFoundError: If the file cannot be downloaded
 
     Example:
-        >>> file_path = download_quarterly_lfs(2025, "Jul-Sep")
-        >>> print(f"Downloaded to: {file_path}")
+        >>> file_path = download_quarterly_lfs(2025, "Jul-Sep")  # doctest: +SKIP
+        >>> print(f"Downloaded to: {file_path}")  # doctest: +SKIP
     """
     # Build download URL
     url = _build_lfs_url(year, quarter)
@@ -232,8 +232,8 @@ def parse_employment_by_age_sex(file_path: str | Path) -> pd.DataFrame:
             - number: Absolute number employed (from Table 2.15b)
 
     Example:
-        >>> df = parse_employment_by_age_sex("lfs_2025_Q3.xlsx")
-        >>> print(df[df['sex'] == 'Female'].head())
+        >>> df = parse_employment_by_age_sex("lfs_2025_Q3.xlsx")  # doctest: +SKIP
+        >>> print(df[df['sex'] == 'Female'].head())  # doctest: +SKIP
     """
     wb = load_workbook(file_path, data_only=True)
 
@@ -381,10 +381,10 @@ def parse_economic_inactivity(file_path: str | Path) -> pd.DataFrame:
         allowing year-over-year comparisons for the same seasonal period.
 
     Example:
-        >>> df = parse_economic_inactivity("lfs_2025_Q3.xlsx")
+        >>> df = parse_economic_inactivity("lfs_2025_Q3.xlsx")  # doctest: +SKIP
         >>> # Get 2025 data
-        >>> df_2025 = df[df['time_period'].str.contains('2025')]
-        >>> print(df_2025)
+        >>> df_2025 = df[df['time_period'].str.contains('2025')]  # doctest: +SKIP
+        >>> print(df_2025)  # doctest: +SKIP
     """
     wb = load_workbook(file_path, data_only=True)
 
@@ -483,8 +483,8 @@ def get_latest_lfs_publication_url() -> tuple[str, str, str]:
         NISRADataNotFoundError: If no publication found
 
     Example:
-        >>> url, year, quarter = get_latest_lfs_publication_url()
-        >>> print(f"Latest data: {quarter} {year}")
+        >>> url, year, quarter = get_latest_lfs_publication_url()  # doctest: +SKIP
+        >>> print(f"Latest data: {quarter} {year}")  # doctest: +SKIP
     """
     from bs4 import BeautifulSoup
 
@@ -618,10 +618,10 @@ def get_latest_employment(force_refresh: bool = False) -> pd.DataFrame:
         DataFrame with employment statistics by age group and sex
 
     Example:
-        >>> df = get_latest_employment()
+        >>> df = get_latest_employment()  # doctest: +SKIP
         >>> # Analyze employment for 25-29 age group
-        >>> young_adults = df[df['age_group'] == '25 to 29']
-        >>> print(young_adults)
+        >>> young_adults = df[df['age_group'] == '25 to 29']  # doctest: +SKIP
+        >>> print(young_adults)  # doctest: +SKIP
     """
     # Discover latest publication from NISRA website
     excel_url, year, quarter = get_latest_lfs_publication_url()
@@ -649,8 +649,8 @@ def get_latest_economic_inactivity(force_refresh: bool = False) -> pd.DataFrame:
         DataFrame with economic inactivity statistics by sex
 
     Example:
-        >>> df = get_latest_economic_inactivity()
-        >>> print(df)
+        >>> df = get_latest_economic_inactivity()  # doctest: +SKIP
+        >>> print(df)  # doctest: +SKIP
     """
     # Discover latest publication from NISRA website
     excel_url, year, quarter = get_latest_lfs_publication_url()
@@ -683,9 +683,9 @@ def get_quarterly_data(
             - 'economic_inactivity': Economic inactivity data (Table 2.21)
 
     Example:
-        >>> data = get_quarterly_data(2025, "Jul-Sep")
-        >>> emp_df = data['employment']
-        >>> inact_df = data['economic_inactivity']
+        >>> data = get_quarterly_data(2025, "Jul-Sep")  # doctest: +SKIP
+        >>> emp_df = data['employment']  # doctest: +SKIP
+        >>> inact_df = data['economic_inactivity']  # doctest: +SKIP
     """
     if tables is None:
         tables = ["employment", "economic_inactivity"]
@@ -721,8 +721,8 @@ def get_latest_lgd_employment_url() -> tuple[str, int]:
         NISRADataNotFoundError: If unable to find the latest publication
 
     Example:
-        >>> url, year = get_latest_lgd_employment_url()
-        >>> print(f"Latest LGD tables: {year} at {url}")
+        >>> url, year = get_latest_lgd_employment_url()  # doctest: +SKIP
+        >>> print(f"Latest LGD tables: {year} at {url}")  # doctest: +SKIP
     """
     from datetime import datetime
 
@@ -793,9 +793,9 @@ def parse_employment_by_lgd(file_path: str | Path, year: int = None) -> pd.DataF
             - employment_rate: float (%)
 
     Example:
-        >>> df = parse_employment_by_lgd("lfs-lgd-2024.xlsx", year=2024)
-        >>> belfast = df[df['lgd'] == 'Belfast']
-        >>> print(f"Belfast employment rate: {belfast['employment_rate'].values[0]}%")
+        >>> df = parse_employment_by_lgd("lfs-lgd-2024.xlsx", year=2024)  # doctest: +SKIP
+        >>> belfast = df[df['lgd'] == 'Belfast']  # doctest: +SKIP
+        >>> print(f"Belfast employment rate: {belfast['employment_rate'].values[0]}%")  # doctest: +SKIP
     """
     logger.info(f"Parsing LFS LGD employment from: {file_path}")
 
@@ -874,10 +874,10 @@ def get_latest_employment_by_lgd(force_refresh: bool = False) -> pd.DataFrame:
         DataFrame with employment statistics for all 11 NI Local Government Districts
 
     Example:
-        >>> df = get_latest_employment_by_lgd()
+        >>> df = get_latest_employment_by_lgd()  # doctest: +SKIP
         >>> # Compare Belfast to other LGDs
-        >>> df_sorted = df.sort_values('employment_rate', ascending=False)
-        >>> print(df_sorted[['lgd', 'in_employment', 'employment_rate']])
+        >>> df_sorted = df.sort_values('employment_rate', ascending=False)  # doctest: +SKIP
+        >>> print(df_sorted[['lgd', 'in_employment', 'employment_rate']])  # doctest: +SKIP
     """
     excel_url, year = get_latest_lgd_employment_url()
 

--- a/src/bolster/data_sources/nisra/labour_market.py
+++ b/src/bolster/data_sources/nisra/labour_market.py
@@ -227,7 +227,11 @@ def parse_employment_by_age_sex(file_path: str | Path) -> pd.DataFrame:
             - number: Absolute number employed (from Table 2.15b)
 
     Example:
-        >>> df = parse_employment_by_age_sex("lfs_2025_Q3.xlsx")
+        >>> url, year, quarter = get_latest_lfs_publication_url()
+        >>> path = download_file(url, cache_ttl_hours=90*24)
+        >>> df = parse_employment_by_age_sex(path)
+        >>> 'age_group' in df.columns
+        True
     """
     wb = load_workbook(file_path, data_only=True)
 
@@ -375,9 +379,11 @@ def parse_economic_inactivity(file_path: str | Path) -> pd.DataFrame:
         allowing year-over-year comparisons for the same seasonal period.
 
     Example:
-        >>> df = parse_economic_inactivity("lfs_2025_Q3.xlsx")
-        >>> # Get 2025 data
-        >>> df_2025 = df[df['time_period'].str.contains('2025')]
+        >>> url, year, quarter = get_latest_lfs_publication_url()
+        >>> path = download_file(url, cache_ttl_hours=90*24)
+        >>> df = parse_economic_inactivity(path)
+        >>> 'economic_inactivity_rate' in df.columns
+        True
     """
     wb = load_workbook(file_path, data_only=True)
 
@@ -794,8 +800,11 @@ def parse_employment_by_lgd(file_path: str | Path, year: int = None) -> pd.DataF
             - employment_rate: float (%)
 
     Example:
-        >>> df = parse_employment_by_lgd("lfs-lgd-2024.xlsx", year=2024)
-        >>> belfast = df[df['lgd'] == 'Belfast']
+        >>> url, year = get_latest_lgd_employment_url()
+        >>> path = download_file(url, cache_ttl_hours=180*24)
+        >>> df = parse_employment_by_lgd(path, year=year)
+        >>> 'employment_rate' in df.columns
+        True
     """
     logger.info(f"Parsing LFS LGD employment from: {file_path}")
 

--- a/src/bolster/data_sources/nisra/labour_market.py
+++ b/src/bolster/data_sources/nisra/labour_market.py
@@ -53,20 +53,14 @@ Usage:
     >>> lgd_df = labour_market.get_latest_employment_by_lgd()
 
 Example:
-    >>> import pandas as pd
     >>> from bolster.data_sources.nisra import labour_market
-    >>> # Get latest employment by age and sex
     >>> emp_df = labour_market.get_latest_employment()
-    >>> # Filter for females aged 25-29
-    >>> young_females = emp_df[
-    ...     (emp_df['sex'] == 'Female') &
-    ...     (emp_df['age_group'] == '25 to 29')
-    ... ]
-    >>> # Get employment by Local Government District
+    >>> 'age_group' in emp_df.columns
+    True
+
     >>> lgd_df = labour_market.get_latest_employment_by_lgd()
-    >>> # Compare Belfast and rural areas
-    >>> belfast = lgd_df[lgd_df['lgd'] == 'Belfast']
-    >>> print(f"Belfast employment rate: {belfast['employment_rate'].values[0]:.1f}%")
+    >>> 'employment_rate' in lgd_df.columns
+    True
 
 Author: Claude Code
 Date: 2025-12-21
@@ -199,6 +193,8 @@ def download_quarterly_lfs(year: int, quarter: str, force_refresh: bool = False,
 
     Example:
         >>> file_path = download_quarterly_lfs(2025, "Jul-Sep")
+        >>> file_path.exists()
+        True
     """
     # Build download URL
     url = _build_lfs_url(year, quarter)
@@ -481,6 +477,8 @@ def get_latest_lfs_publication_url() -> tuple[str, str, str]:
 
     Example:
         >>> url, year, quarter = get_latest_lfs_publication_url()
+        >>> url.startswith('https://')
+        True
     """
     from bs4 import BeautifulSoup
 
@@ -615,8 +613,11 @@ def get_latest_employment(force_refresh: bool = False) -> pd.DataFrame:
 
     Example:
         >>> df = get_latest_employment()
-        >>> # Analyze employment for 25-29 age group
+        >>> 'age_group' in df.columns
+        True
         >>> young_adults = df[df['age_group'] == '25 to 29']
+        >>> len(young_adults) >= 0
+        True
     """
     # Discover latest publication from NISRA website
     excel_url, year, quarter = get_latest_lfs_publication_url()
@@ -645,6 +646,8 @@ def get_latest_economic_inactivity(force_refresh: bool = False) -> pd.DataFrame:
 
     Example:
         >>> df = get_latest_economic_inactivity()
+        >>> 'sex' in df.columns
+        True
     """
     # Discover latest publication from NISRA website
     excel_url, year, quarter = get_latest_lfs_publication_url()
@@ -678,8 +681,11 @@ def get_quarterly_data(
 
     Example:
         >>> data = get_quarterly_data(2025, "Jul-Sep")
+        >>> sorted(data.keys())
+        ['economic_inactivity', 'employment']
         >>> emp_df = data['employment']
-        >>> inact_df = data['economic_inactivity']
+        >>> 'age_group' in emp_df.columns
+        True
     """
     if tables is None:
         tables = ["employment", "economic_inactivity"]
@@ -716,6 +722,8 @@ def get_latest_lgd_employment_url() -> tuple[str, int]:
 
     Example:
         >>> url, year = get_latest_lgd_employment_url()
+        >>> url.startswith('https://')
+        True
     """
     from datetime import datetime
 
@@ -867,8 +875,10 @@ def get_latest_employment_by_lgd(force_refresh: bool = False) -> pd.DataFrame:
 
     Example:
         >>> df = get_latest_employment_by_lgd()
-        >>> # Compare Belfast to other LGDs
-        >>> df_sorted = df.sort_values('employment_rate', ascending=False)
+        >>> 'employment_rate' in df.columns
+        True
+        >>> len(df) > 0
+        True
     """
     excel_url, year = get_latest_lgd_employment_url()
 

--- a/src/bolster/data_sources/nisra/labour_market.py
+++ b/src/bolster/data_sources/nisra/labour_market.py
@@ -42,31 +42,31 @@ Architecture:
     - Uses standardized Excel parsing utilities from _base.py
 
 Usage:
-    >>> from bolster.data_sources.nisra import labour_market  # doctest: +SKIP
+    >>> from bolster.data_sources.nisra import labour_market
     >>> # Get latest quarterly employment data
-    >>> df = labour_market.get_latest_employment()  # doctest: +SKIP
+    >>> df = labour_market.get_latest_employment()
     >>> # Get economic inactivity data
-    >>> df = labour_market.get_latest_economic_inactivity()  # doctest: +SKIP
+    >>> df = labour_market.get_latest_economic_inactivity()
     >>> # Get all tables for a specific quarter
-    >>> data = labour_market.get_quarterly_data(year=2025, quarter="Jul-Sep")  # doctest: +SKIP
+    >>> data = labour_market.get_quarterly_data(year=2025, quarter="Jul-Sep")
     >>> # Get annual employment by Local Government District
-    >>> lgd_df = labour_market.get_latest_employment_by_lgd()  # doctest: +SKIP
+    >>> lgd_df = labour_market.get_latest_employment_by_lgd()
 
 Example:
-    >>> import pandas as pd  # doctest: +SKIP
-    >>> from bolster.data_sources.nisra import labour_market  # doctest: +SKIP
+    >>> import pandas as pd
+    >>> from bolster.data_sources.nisra import labour_market
     >>> # Get latest employment by age and sex
-    >>> emp_df = labour_market.get_latest_employment()  # doctest: +SKIP
+    >>> emp_df = labour_market.get_latest_employment()
     >>> # Filter for females aged 25-29
-    >>> young_females = emp_df[  # doctest: +SKIP
-    ...     (emp_df['sex'] == 'Female') &  # doctest: +SKIP
-    ...     (emp_df['age_group'] == '25 to 29')  # doctest: +SKIP
-    ... ]  # doctest: +SKIP
+    >>> young_females = emp_df[
+    ...     (emp_df['sex'] == 'Female') &
+    ...     (emp_df['age_group'] == '25 to 29')
+    ... ]
     >>> # Get employment by Local Government District
-    >>> lgd_df = labour_market.get_latest_employment_by_lgd()  # doctest: +SKIP
+    >>> lgd_df = labour_market.get_latest_employment_by_lgd()
     >>> # Compare Belfast and rural areas
-    >>> belfast = lgd_df[lgd_df['lgd'] == 'Belfast']  # doctest: +SKIP
-    >>> print(f"Belfast employment rate: {belfast['employment_rate'].values[0]:.1f}%")  # doctest: +SKIP
+    >>> belfast = lgd_df[lgd_df['lgd'] == 'Belfast']
+    >>> print(f"Belfast employment rate: {belfast['employment_rate'].values[0]:.1f}%")
 
 Author: Claude Code
 Date: 2025-12-21
@@ -108,9 +108,9 @@ def _quarter_to_month_names(quarter_str: str) -> tuple[str, str, str]:
         Tuple of (first_month, second_month, third_month)
 
     Examples:
-        >>> _quarter_to_month_names("Jul-Sep")  # doctest: +SKIP
+        >>> _quarter_to_month_names("Jul-Sep")
         ('July', 'August', 'September')
-        >>> _quarter_to_month_names("Jan-Mar")  # doctest: +SKIP
+        >>> _quarter_to_month_names("Jan-Mar")
         ('January', 'February', 'March')
     """
     quarter_map = {
@@ -198,8 +198,7 @@ def download_quarterly_lfs(year: int, quarter: str, force_refresh: bool = False,
         NISRADataNotFoundError: If the file cannot be downloaded
 
     Example:
-        >>> file_path = download_quarterly_lfs(2025, "Jul-Sep")  # doctest: +SKIP
-        >>> print(f"Downloaded to: {file_path}")  # doctest: +SKIP
+        >>> file_path = download_quarterly_lfs(2025, "Jul-Sep")
     """
     # Build download URL
     url = _build_lfs_url(year, quarter)
@@ -232,8 +231,7 @@ def parse_employment_by_age_sex(file_path: str | Path) -> pd.DataFrame:
             - number: Absolute number employed (from Table 2.15b)
 
     Example:
-        >>> df = parse_employment_by_age_sex("lfs_2025_Q3.xlsx")  # doctest: +SKIP
-        >>> print(df[df['sex'] == 'Female'].head())  # doctest: +SKIP
+        >>> df = parse_employment_by_age_sex("lfs_2025_Q3.xlsx")
     """
     wb = load_workbook(file_path, data_only=True)
 
@@ -381,10 +379,9 @@ def parse_economic_inactivity(file_path: str | Path) -> pd.DataFrame:
         allowing year-over-year comparisons for the same seasonal period.
 
     Example:
-        >>> df = parse_economic_inactivity("lfs_2025_Q3.xlsx")  # doctest: +SKIP
+        >>> df = parse_economic_inactivity("lfs_2025_Q3.xlsx")
         >>> # Get 2025 data
-        >>> df_2025 = df[df['time_period'].str.contains('2025')]  # doctest: +SKIP
-        >>> print(df_2025)  # doctest: +SKIP
+        >>> df_2025 = df[df['time_period'].str.contains('2025')]
     """
     wb = load_workbook(file_path, data_only=True)
 
@@ -483,8 +480,7 @@ def get_latest_lfs_publication_url() -> tuple[str, str, str]:
         NISRADataNotFoundError: If no publication found
 
     Example:
-        >>> url, year, quarter = get_latest_lfs_publication_url()  # doctest: +SKIP
-        >>> print(f"Latest data: {quarter} {year}")  # doctest: +SKIP
+        >>> url, year, quarter = get_latest_lfs_publication_url()
     """
     from bs4 import BeautifulSoup
 
@@ -618,10 +614,9 @@ def get_latest_employment(force_refresh: bool = False) -> pd.DataFrame:
         DataFrame with employment statistics by age group and sex
 
     Example:
-        >>> df = get_latest_employment()  # doctest: +SKIP
+        >>> df = get_latest_employment()
         >>> # Analyze employment for 25-29 age group
-        >>> young_adults = df[df['age_group'] == '25 to 29']  # doctest: +SKIP
-        >>> print(young_adults)  # doctest: +SKIP
+        >>> young_adults = df[df['age_group'] == '25 to 29']
     """
     # Discover latest publication from NISRA website
     excel_url, year, quarter = get_latest_lfs_publication_url()
@@ -649,8 +644,7 @@ def get_latest_economic_inactivity(force_refresh: bool = False) -> pd.DataFrame:
         DataFrame with economic inactivity statistics by sex
 
     Example:
-        >>> df = get_latest_economic_inactivity()  # doctest: +SKIP
-        >>> print(df)  # doctest: +SKIP
+        >>> df = get_latest_economic_inactivity()
     """
     # Discover latest publication from NISRA website
     excel_url, year, quarter = get_latest_lfs_publication_url()
@@ -683,9 +677,9 @@ def get_quarterly_data(
             - 'economic_inactivity': Economic inactivity data (Table 2.21)
 
     Example:
-        >>> data = get_quarterly_data(2025, "Jul-Sep")  # doctest: +SKIP
-        >>> emp_df = data['employment']  # doctest: +SKIP
-        >>> inact_df = data['economic_inactivity']  # doctest: +SKIP
+        >>> data = get_quarterly_data(2025, "Jul-Sep")
+        >>> emp_df = data['employment']
+        >>> inact_df = data['economic_inactivity']
     """
     if tables is None:
         tables = ["employment", "economic_inactivity"]
@@ -721,8 +715,7 @@ def get_latest_lgd_employment_url() -> tuple[str, int]:
         NISRADataNotFoundError: If unable to find the latest publication
 
     Example:
-        >>> url, year = get_latest_lgd_employment_url()  # doctest: +SKIP
-        >>> print(f"Latest LGD tables: {year} at {url}")  # doctest: +SKIP
+        >>> url, year = get_latest_lgd_employment_url()
     """
     from datetime import datetime
 
@@ -793,9 +786,8 @@ def parse_employment_by_lgd(file_path: str | Path, year: int = None) -> pd.DataF
             - employment_rate: float (%)
 
     Example:
-        >>> df = parse_employment_by_lgd("lfs-lgd-2024.xlsx", year=2024)  # doctest: +SKIP
-        >>> belfast = df[df['lgd'] == 'Belfast']  # doctest: +SKIP
-        >>> print(f"Belfast employment rate: {belfast['employment_rate'].values[0]}%")  # doctest: +SKIP
+        >>> df = parse_employment_by_lgd("lfs-lgd-2024.xlsx", year=2024)
+        >>> belfast = df[df['lgd'] == 'Belfast']
     """
     logger.info(f"Parsing LFS LGD employment from: {file_path}")
 
@@ -874,10 +866,9 @@ def get_latest_employment_by_lgd(force_refresh: bool = False) -> pd.DataFrame:
         DataFrame with employment statistics for all 11 NI Local Government Districts
 
     Example:
-        >>> df = get_latest_employment_by_lgd()  # doctest: +SKIP
+        >>> df = get_latest_employment_by_lgd()
         >>> # Compare Belfast to other LGDs
-        >>> df_sorted = df.sort_values('employment_rate', ascending=False)  # doctest: +SKIP
-        >>> print(df_sorted[['lgd', 'in_employment', 'employment_rate']])  # doctest: +SKIP
+        >>> df_sorted = df.sort_values('employment_rate', ascending=False)
     """
     excel_url, year = get_latest_lgd_employment_url()
 

--- a/src/bolster/data_sources/nisra/marriages.py
+++ b/src/bolster/data_sources/nisra/marriages.py
@@ -287,7 +287,7 @@ def get_latest_marriages(force_refresh: bool = False) -> pd.DataFrame:
 
         >>> df_2024 = df[df['year'] == 2024]
         >>> total_2024 = df_2024['marriages'].sum()
-        >>> total_2024 > 0
+        >>> bool(total_2024 > 0)
         True
     """
     # Discover latest publication
@@ -346,7 +346,7 @@ def get_marriages_by_year(df: pd.DataFrame, year: int) -> pd.DataFrame:
         >>> df = get_latest_marriages()
         >>> df_2024 = get_marriages_by_year(df, 2024)
         >>> total = df_2024['marriages'].sum()
-        >>> total > 0
+        >>> bool(total > 0)
         True
     """
     return df[df["year"] == year].reset_index(drop=True)
@@ -641,7 +641,7 @@ def get_latest_civil_partnerships(force_refresh: bool = False) -> pd.DataFrame:
         ['civil_partnerships', 'date', 'month', 'year']
         >>> df_2024 = df[df['year'] == 2024]
         >>> total = df_2024['civil_partnerships'].sum()
-        >>> total >= 0
+        >>> bool(total >= 0)
         True
     """
     excel_url, pub_date = get_latest_civil_partnerships_publication_url()

--- a/src/bolster/data_sources/nisra/marriages.py
+++ b/src/bolster/data_sources/nisra/marriages.py
@@ -25,18 +25,15 @@ Geographic Coverage: Northern Ireland
 Reference Date: Month of registration
 
 Example:
-    >>> from bolster.data_sources.nisra import marriages  # doctest: +SKIP
+    >>> from bolster.data_sources.nisra import marriages
     >>> # Get latest marriage registrations
-    >>> df = marriages.get_latest_marriages()  # doctest: +SKIP
-    >>> print(df.head())  # doctest: +SKIP
+    >>> df = marriages.get_latest_marriages()
 
     >>> # Get latest civil partnership registrations
-    >>> cp_df = marriages.get_latest_civil_partnerships()  # doctest: +SKIP
-    >>> print(f"Total civil partnerships in 2024: {cp_df[cp_df['year']==2024]['civil_partnerships'].sum()}")  # doctest: +SKIP
+    >>> cp_df = marriages.get_latest_civil_partnerships()
 
     >>> # Filter for a specific year
-    >>> df_2024 = df[df['year'] == 2024]  # doctest: +SKIP
-    >>> print(f"Total marriages in 2024: {df_2024['marriages'].sum():,}")  # doctest: +SKIP
+    >>> df_2024 = df[df['year'] == 2024]
 """
 
 import logging
@@ -279,16 +276,14 @@ def get_latest_marriages(force_refresh: bool = False) -> pd.DataFrame:
 
     Example:
         >>> # Get all data
-        >>> df = get_latest_marriages()  # doctest: +SKIP
+        >>> df = get_latest_marriages()
 
         >>> # Filter for 2024
-        >>> df_2024 = df[df['year'] == 2024]  # doctest: +SKIP
-        >>> total_2024 = df_2024['marriages'].sum()  # doctest: +SKIP
-        >>> print(f"Total marriages in 2024: {total_2024:,}")  # doctest: +SKIP
+        >>> df_2024 = df[df['year'] == 2024]
+        >>> total_2024 = df_2024['marriages'].sum()
 
         >>> # Get monthly average by month across all years
-        >>> monthly_avg = df.groupby('month')['marriages'].mean()  # doctest: +SKIP
-        >>> print(monthly_avg.sort_values(ascending=False))  # doctest: +SKIP
+        >>> monthly_avg = df.groupby('month')['marriages'].mean()
     """
     # Discover latest publication
     excel_url, pub_date = get_latest_marriages_publication_url()
@@ -343,10 +338,9 @@ def get_marriages_by_year(df: pd.DataFrame, year: int) -> pd.DataFrame:
         Filtered DataFrame
 
     Example:
-        >>> df = get_latest_marriages()  # doctest: +SKIP
-        >>> df_2024 = get_marriages_by_year(df, 2024)  # doctest: +SKIP
-        >>> total = df_2024['marriages'].sum()  # doctest: +SKIP
-        >>> print(f"Total marriages in 2024: {total:,}")  # doctest: +SKIP
+        >>> df = get_latest_marriages()
+        >>> df_2024 = get_marriages_by_year(df, 2024)
+        >>> total = df_2024['marriages'].sum()
     """
     return df[df["year"] == year].reset_index(drop=True)
 
@@ -365,9 +359,9 @@ def get_marriages_summary_by_year(df: pd.DataFrame) -> pd.DataFrame:
             - avg_per_month: float (average marriages per month)
 
     Example:
-        >>> df = get_latest_marriages()  # doctest: +SKIP
-        >>> summary = get_marriages_summary_by_year(df)  # doctest: +SKIP
-        >>> print(summary.tail(10))  # Last 10 years  # doctest: +SKIP
+        >>> df = get_latest_marriages()
+        >>> summary = get_marriages_summary_by_year(df)
+        >>> print(summary.tail(10))  # Last 10 years
     """
     summary = (
         df.groupby("year")
@@ -634,10 +628,9 @@ def get_latest_civil_partnerships(force_refresh: bool = False) -> pd.DataFrame:
         NISRAValidationError: If file structure is unexpected
 
     Example:
-        >>> df = get_latest_civil_partnerships()  # doctest: +SKIP
-        >>> df_2024 = df[df['year'] == 2024]  # doctest: +SKIP
-        >>> total = df_2024['civil_partnerships'].sum()  # doctest: +SKIP
-        >>> print(f"Total civil partnerships in 2024: {total}")  # doctest: +SKIP
+        >>> df = get_latest_civil_partnerships()
+        >>> df_2024 = df[df['year'] == 2024]
+        >>> total = df_2024['civil_partnerships'].sum()
     """
     excel_url, pub_date = get_latest_civil_partnerships_publication_url()
 

--- a/src/bolster/data_sources/nisra/marriages.py
+++ b/src/bolster/data_sources/nisra/marriages.py
@@ -28,12 +28,18 @@ Example:
     >>> from bolster.data_sources.nisra import marriages
     >>> # Get latest marriage registrations
     >>> df = marriages.get_latest_marriages()
+    >>> sorted(df.columns.tolist())
+    ['date', 'marriages', 'month', 'year']
 
     >>> # Get latest civil partnership registrations
     >>> cp_df = marriages.get_latest_civil_partnerships()
+    >>> sorted(cp_df.columns.tolist())
+    ['civil_partnerships', 'date', 'month', 'year']
 
     >>> # Filter for a specific year
     >>> df_2024 = df[df['year'] == 2024]
+    >>> len(df_2024) > 0
+    True
 """
 
 import logging
@@ -275,15 +281,14 @@ def get_latest_marriages(force_refresh: bool = False) -> pd.DataFrame:
         NISRAValidationError: If file structure is unexpected
 
     Example:
-        >>> # Get all data
         >>> df = get_latest_marriages()
+        >>> sorted(df.columns.tolist())
+        ['date', 'marriages', 'month', 'year']
 
-        >>> # Filter for 2024
         >>> df_2024 = df[df['year'] == 2024]
         >>> total_2024 = df_2024['marriages'].sum()
-
-        >>> # Get monthly average by month across all years
-        >>> monthly_avg = df.groupby('month')['marriages'].mean()
+        >>> total_2024 > 0
+        True
     """
     # Discover latest publication
     excel_url, pub_date = get_latest_marriages_publication_url()
@@ -341,6 +346,8 @@ def get_marriages_by_year(df: pd.DataFrame, year: int) -> pd.DataFrame:
         >>> df = get_latest_marriages()
         >>> df_2024 = get_marriages_by_year(df, 2024)
         >>> total = df_2024['marriages'].sum()
+        >>> total > 0
+        True
     """
     return df[df["year"] == year].reset_index(drop=True)
 
@@ -361,7 +368,8 @@ def get_marriages_summary_by_year(df: pd.DataFrame) -> pd.DataFrame:
     Example:
         >>> df = get_latest_marriages()
         >>> summary = get_marriages_summary_by_year(df)
-        >>> print(summary.tail(10))  # Last 10 years
+        >>> sorted(summary.columns.tolist())
+        ['avg_per_month', 'months_reported', 'total_marriages', 'year']
     """
     summary = (
         df.groupby("year")
@@ -629,8 +637,12 @@ def get_latest_civil_partnerships(force_refresh: bool = False) -> pd.DataFrame:
 
     Example:
         >>> df = get_latest_civil_partnerships()
+        >>> sorted(df.columns.tolist())
+        ['civil_partnerships', 'date', 'month', 'year']
         >>> df_2024 = df[df['year'] == 2024]
         >>> total = df_2024['civil_partnerships'].sum()
+        >>> total >= 0
+        True
     """
     excel_url, pub_date = get_latest_civil_partnerships_publication_url()
 

--- a/src/bolster/data_sources/nisra/marriages.py
+++ b/src/bolster/data_sources/nisra/marriages.py
@@ -25,18 +25,18 @@ Geographic Coverage: Northern Ireland
 Reference Date: Month of registration
 
 Example:
-    >>> from bolster.data_sources.nisra import marriages
+    >>> from bolster.data_sources.nisra import marriages  # doctest: +SKIP
     >>> # Get latest marriage registrations
-    >>> df = marriages.get_latest_marriages()
-    >>> print(df.head())
+    >>> df = marriages.get_latest_marriages()  # doctest: +SKIP
+    >>> print(df.head())  # doctest: +SKIP
 
     >>> # Get latest civil partnership registrations
-    >>> cp_df = marriages.get_latest_civil_partnerships()
-    >>> print(f"Total civil partnerships in 2024: {cp_df[cp_df['year']==2024]['civil_partnerships'].sum()}")
+    >>> cp_df = marriages.get_latest_civil_partnerships()  # doctest: +SKIP
+    >>> print(f"Total civil partnerships in 2024: {cp_df[cp_df['year']==2024]['civil_partnerships'].sum()}")  # doctest: +SKIP
 
     >>> # Filter for a specific year
-    >>> df_2024 = df[df['year'] == 2024]
-    >>> print(f"Total marriages in 2024: {df_2024['marriages'].sum():,}")
+    >>> df_2024 = df[df['year'] == 2024]  # doctest: +SKIP
+    >>> print(f"Total marriages in 2024: {df_2024['marriages'].sum():,}")  # doctest: +SKIP
 """
 
 import logging
@@ -279,16 +279,16 @@ def get_latest_marriages(force_refresh: bool = False) -> pd.DataFrame:
 
     Example:
         >>> # Get all data
-        >>> df = get_latest_marriages()
+        >>> df = get_latest_marriages()  # doctest: +SKIP
 
         >>> # Filter for 2024
-        >>> df_2024 = df[df['year'] == 2024]
-        >>> total_2024 = df_2024['marriages'].sum()
-        >>> print(f"Total marriages in 2024: {total_2024:,}")
+        >>> df_2024 = df[df['year'] == 2024]  # doctest: +SKIP
+        >>> total_2024 = df_2024['marriages'].sum()  # doctest: +SKIP
+        >>> print(f"Total marriages in 2024: {total_2024:,}")  # doctest: +SKIP
 
         >>> # Get monthly average by month across all years
-        >>> monthly_avg = df.groupby('month')['marriages'].mean()
-        >>> print(monthly_avg.sort_values(ascending=False))
+        >>> monthly_avg = df.groupby('month')['marriages'].mean()  # doctest: +SKIP
+        >>> print(monthly_avg.sort_values(ascending=False))  # doctest: +SKIP
     """
     # Discover latest publication
     excel_url, pub_date = get_latest_marriages_publication_url()
@@ -343,10 +343,10 @@ def get_marriages_by_year(df: pd.DataFrame, year: int) -> pd.DataFrame:
         Filtered DataFrame
 
     Example:
-        >>> df = get_latest_marriages()
-        >>> df_2024 = get_marriages_by_year(df, 2024)
-        >>> total = df_2024['marriages'].sum()
-        >>> print(f"Total marriages in 2024: {total:,}")
+        >>> df = get_latest_marriages()  # doctest: +SKIP
+        >>> df_2024 = get_marriages_by_year(df, 2024)  # doctest: +SKIP
+        >>> total = df_2024['marriages'].sum()  # doctest: +SKIP
+        >>> print(f"Total marriages in 2024: {total:,}")  # doctest: +SKIP
     """
     return df[df["year"] == year].reset_index(drop=True)
 
@@ -365,9 +365,9 @@ def get_marriages_summary_by_year(df: pd.DataFrame) -> pd.DataFrame:
             - avg_per_month: float (average marriages per month)
 
     Example:
-        >>> df = get_latest_marriages()
-        >>> summary = get_marriages_summary_by_year(df)
-        >>> print(summary.tail(10))  # Last 10 years
+        >>> df = get_latest_marriages()  # doctest: +SKIP
+        >>> summary = get_marriages_summary_by_year(df)  # doctest: +SKIP
+        >>> print(summary.tail(10))  # Last 10 years  # doctest: +SKIP
     """
     summary = (
         df.groupby("year")
@@ -634,10 +634,10 @@ def get_latest_civil_partnerships(force_refresh: bool = False) -> pd.DataFrame:
         NISRAValidationError: If file structure is unexpected
 
     Example:
-        >>> df = get_latest_civil_partnerships()
-        >>> df_2024 = df[df['year'] == 2024]
-        >>> total = df_2024['civil_partnerships'].sum()
-        >>> print(f"Total civil partnerships in 2024: {total}")
+        >>> df = get_latest_civil_partnerships()  # doctest: +SKIP
+        >>> df_2024 = df[df['year'] == 2024]  # doctest: +SKIP
+        >>> total = df_2024['civil_partnerships'].sum()  # doctest: +SKIP
+        >>> print(f"Total civil partnerships in 2024: {total}")  # doctest: +SKIP
     """
     excel_url, pub_date = get_latest_civil_partnerships_publication_url()
 

--- a/src/bolster/data_sources/nisra/migration.py
+++ b/src/bolster/data_sources/nisra/migration.py
@@ -29,19 +29,19 @@ Geographic Coverage: Northern Ireland
 Reference Period: Mid-year (July to June) for official; Calendar year for derived
 
 Example:
-    >>> from bolster.data_sources.nisra import migration
+    >>> from bolster.data_sources.nisra import migration  # doctest: +SKIP
     >>>
     >>> # Get official NISRA migration statistics
-    >>> official = migration.get_official_migration()
-    >>> print(official.head())
+    >>> official = migration.get_official_migration()  # doctest: +SKIP
+    >>> print(official.head())  # doctest: +SKIP
     >>>
     >>> # Get derived migration estimates (from demographic equation)
-    >>> derived = migration.get_derived_migration()
-    >>> print(derived.head())
+    >>> derived = migration.get_derived_migration()  # doctest: +SKIP
+    >>> print(derived.head())  # doctest: +SKIP
     >>>
     >>> # Compare official vs derived for validation
-    >>> comparison = migration.compare_official_vs_derived(official, derived)
-    >>> print(comparison[comparison['exceeds_threshold']])
+    >>> comparison = migration.compare_official_vs_derived(official, derived)  # doctest: +SKIP
+    >>> print(comparison[comparison['exceeds_threshold']])  # doctest: +SKIP
 """
 
 import logging
@@ -228,18 +228,18 @@ def get_latest_migration(force_refresh: bool = False) -> pd.DataFrame:
 
     Example:
         >>> # Get all migration data
-        >>> df = get_latest_migration()
+        >>> df = get_latest_migration()  # doctest: +SKIP
 
         >>> # Get recent migration trends
-        >>> recent = df[df['year'] >= 2010]
-        >>> print(recent[['year', 'net_migration', 'migration_rate']])
+        >>> recent = df[df['year'] >= 2010]  # doctest: +SKIP
+        >>> print(recent[['year', 'net_migration', 'migration_rate']])  # doctest: +SKIP
 
         >>> # Check if migration is positive or negative
-        >>> df_2024 = df[df['year'] == 2024]
-        >>> if df_2024['net_migration'].values[0] > 0:
-        >>>     print("Net immigration")
-        >>> else:
-        >>>     print("Net emigration")
+        >>> df_2024 = df[df['year'] == 2024]  # doctest: +SKIP
+        >>> if df_2024['net_migration'].values[0] > 0:  # doctest: +SKIP
+        >>>     print("Net immigration")  # doctest: +SKIP
+        >>> else:  # doctest: +SKIP
+        >>>     print("Net emigration")  # doctest: +SKIP
     """
     logger.info("Fetching data sources for migration calculation...")
 
@@ -304,9 +304,9 @@ def get_migration_by_year(df: pd.DataFrame, year: int) -> pd.DataFrame:
         Filtered DataFrame
 
     Example:
-        >>> df = get_latest_migration()
-        >>> df_2024 = get_migration_by_year(df, 2024)
-        >>> print(f"Net migration in 2024: {df_2024['net_migration'].values[0]:+,}")
+        >>> df = get_latest_migration()  # doctest: +SKIP
+        >>> df_2024 = get_migration_by_year(df, 2024)  # doctest: +SKIP
+        >>> print(f"Net migration in 2024: {df_2024['net_migration'].values[0]:+,}")  # doctest: +SKIP
     """
     return df[df["year"] == year].reset_index(drop=True)
 
@@ -334,10 +334,10 @@ def get_migration_summary_statistics(
             - max_emigration: Highest emigration value (as negative)
 
     Example:
-        >>> df = get_latest_migration()
-        >>> stats = get_migration_summary_statistics(df, start_year=2010)
-        >>> print(f"Average migration 2010-present: {stats['avg_net_migration']:+,.0f}")
-        >>> print(f"Years with net immigration: {stats['positive_years']}")
+        >>> df = get_latest_migration()  # doctest: +SKIP
+        >>> stats = get_migration_summary_statistics(df, start_year=2010)  # doctest: +SKIP
+        >>> print(f"Average migration 2010-present: {stats['avg_net_migration']:+,.0f}")  # doctest: +SKIP
+        >>> print(f"Years with net immigration: {stats['positive_years']}")  # doctest: +SKIP
     """
     # Filter by year range if specified
     filtered = df.copy()
@@ -597,11 +597,11 @@ def get_official_migration(force_refresh: bool = False) -> pd.DataFrame:
 
     Example:
         >>> # Get official migration data
-        >>> official = get_official_migration()
+        >>> official = get_official_migration()  # doctest: +SKIP
         >>>
         >>> # Filter to recent years
-        >>> recent = official[official['year'] >= 2010]
-        >>> print(recent[['year', 'net_migration']])
+        >>> recent = official[official['year'] >= 2010]  # doctest: +SKIP
+        >>> print(recent[['year', 'net_migration']])  # doctest: +SKIP
     """
     logger.info("Fetching latest official migration statistics...")
 
@@ -648,15 +648,15 @@ def compare_official_vs_derived(
             - exceeds_threshold: bool
 
     Example:
-        >>> official = get_official_migration()
-        >>> derived = get_derived_migration()
-        >>> comparison = compare_official_vs_derived(official, derived)
+        >>> official = get_official_migration()  # doctest: +SKIP
+        >>> derived = get_derived_migration()  # doctest: +SKIP
+        >>> comparison = compare_official_vs_derived(official, derived)  # doctest: +SKIP
         >>>
         >>> # Show years with significant discrepancies
-        >>> print(comparison[comparison['exceeds_threshold']])
+        >>> print(comparison[comparison['exceeds_threshold']])  # doctest: +SKIP
         >>>
         >>> # Calculate mean error
-        >>> print(f"Mean absolute error: {comparison['absolute_difference'].mean():,.0f}")
+        >>> print(f"Mean absolute error: {comparison['absolute_difference'].mean():,.0f}")  # doctest: +SKIP
     """
     # Merge on year (inner join to get only overlapping years)
     comparison = official_df[["year", "net_migration"]].merge(

--- a/src/bolster/data_sources/nisra/migration.py
+++ b/src/bolster/data_sources/nisra/migration.py
@@ -29,19 +29,16 @@ Geographic Coverage: Northern Ireland
 Reference Period: Mid-year (July to June) for official; Calendar year for derived
 
 Example:
-    >>> from bolster.data_sources.nisra import migration  # doctest: +SKIP
+    >>> from bolster.data_sources.nisra import migration
     >>>
     >>> # Get official NISRA migration statistics
-    >>> official = migration.get_official_migration()  # doctest: +SKIP
-    >>> print(official.head())  # doctest: +SKIP
+    >>> official = migration.get_official_migration()
     >>>
     >>> # Get derived migration estimates (from demographic equation)
-    >>> derived = migration.get_derived_migration()  # doctest: +SKIP
-    >>> print(derived.head())  # doctest: +SKIP
+    >>> derived = migration.get_derived_migration()
     >>>
     >>> # Compare official vs derived for validation
-    >>> comparison = migration.compare_official_vs_derived(official, derived)  # doctest: +SKIP
-    >>> print(comparison[comparison['exceeds_threshold']])  # doctest: +SKIP
+    >>> comparison = migration.compare_official_vs_derived(official, derived)
 """
 
 import logging
@@ -228,18 +225,15 @@ def get_latest_migration(force_refresh: bool = False) -> pd.DataFrame:
 
     Example:
         >>> # Get all migration data
-        >>> df = get_latest_migration()  # doctest: +SKIP
+        >>> df = get_latest_migration()
 
         >>> # Get recent migration trends
-        >>> recent = df[df['year'] >= 2010]  # doctest: +SKIP
-        >>> print(recent[['year', 'net_migration', 'migration_rate']])  # doctest: +SKIP
+        >>> recent = df[df['year'] >= 2010]
 
         >>> # Check if migration is positive or negative
-        >>> df_2024 = df[df['year'] == 2024]  # doctest: +SKIP
-        >>> if df_2024['net_migration'].values[0] > 0:  # doctest: +SKIP
-        >>>     print("Net immigration")  # doctest: +SKIP
-        >>> else:  # doctest: +SKIP
-        >>>     print("Net emigration")  # doctest: +SKIP
+        >>> df_2024 = df[df['year'] == 2024]
+        >>> if df_2024['net_migration'].values[0] > 0:
+        >>> else:
     """
     logger.info("Fetching data sources for migration calculation...")
 
@@ -304,9 +298,8 @@ def get_migration_by_year(df: pd.DataFrame, year: int) -> pd.DataFrame:
         Filtered DataFrame
 
     Example:
-        >>> df = get_latest_migration()  # doctest: +SKIP
-        >>> df_2024 = get_migration_by_year(df, 2024)  # doctest: +SKIP
-        >>> print(f"Net migration in 2024: {df_2024['net_migration'].values[0]:+,}")  # doctest: +SKIP
+        >>> df = get_latest_migration()
+        >>> df_2024 = get_migration_by_year(df, 2024)
     """
     return df[df["year"] == year].reset_index(drop=True)
 
@@ -334,10 +327,8 @@ def get_migration_summary_statistics(
             - max_emigration: Highest emigration value (as negative)
 
     Example:
-        >>> df = get_latest_migration()  # doctest: +SKIP
-        >>> stats = get_migration_summary_statistics(df, start_year=2010)  # doctest: +SKIP
-        >>> print(f"Average migration 2010-present: {stats['avg_net_migration']:+,.0f}")  # doctest: +SKIP
-        >>> print(f"Years with net immigration: {stats['positive_years']}")  # doctest: +SKIP
+        >>> df = get_latest_migration()
+        >>> stats = get_migration_summary_statistics(df, start_year=2010)
     """
     # Filter by year range if specified
     filtered = df.copy()
@@ -597,11 +588,10 @@ def get_official_migration(force_refresh: bool = False) -> pd.DataFrame:
 
     Example:
         >>> # Get official migration data
-        >>> official = get_official_migration()  # doctest: +SKIP
+        >>> official = get_official_migration()
         >>>
         >>> # Filter to recent years
-        >>> recent = official[official['year'] >= 2010]  # doctest: +SKIP
-        >>> print(recent[['year', 'net_migration']])  # doctest: +SKIP
+        >>> recent = official[official['year'] >= 2010]
     """
     logger.info("Fetching latest official migration statistics...")
 
@@ -648,15 +638,13 @@ def compare_official_vs_derived(
             - exceeds_threshold: bool
 
     Example:
-        >>> official = get_official_migration()  # doctest: +SKIP
-        >>> derived = get_derived_migration()  # doctest: +SKIP
-        >>> comparison = compare_official_vs_derived(official, derived)  # doctest: +SKIP
+        >>> official = get_official_migration()
+        >>> derived = get_derived_migration()
+        >>> comparison = compare_official_vs_derived(official, derived)
         >>>
         >>> # Show years with significant discrepancies
-        >>> print(comparison[comparison['exceeds_threshold']])  # doctest: +SKIP
         >>>
         >>> # Calculate mean error
-        >>> print(f"Mean absolute error: {comparison['absolute_difference'].mean():,.0f}")  # doctest: +SKIP
     """
     # Merge on year (inner join to get only overlapping years)
     comparison = official_df[["year", "net_migration"]].merge(

--- a/src/bolster/data_sources/nisra/migration.py
+++ b/src/bolster/data_sources/nisra/migration.py
@@ -33,12 +33,18 @@ Example:
     >>>
     >>> # Get official NISRA migration statistics
     >>> official = migration.get_official_migration()
-    >>>
+    >>> sorted(official.columns.tolist())
+    ['date', 'net_migration', 'year']
+
     >>> # Get derived migration estimates (from demographic equation)
     >>> derived = migration.get_derived_migration()
-    >>>
+    >>> 'net_migration' in derived.columns
+    True
+
     >>> # Compare official vs derived for validation
     >>> comparison = migration.compare_official_vs_derived(official, derived)
+    >>> 'absolute_difference' in comparison.columns
+    True
 """
 
 import logging
@@ -224,16 +230,11 @@ def get_latest_migration(force_refresh: bool = False) -> pd.DataFrame:
             - migration_rate: float (per 1,000 population)
 
     Example:
-        >>> # Get all migration data
         >>> df = get_latest_migration()
-
-        >>> # Get recent migration trends
-        >>> recent = df[df['year'] >= 2010]
-
-        >>> # Check if migration is positive or negative
-        >>> df_2024 = df[df['year'] == 2024]
-        >>> if df_2024['net_migration'].values[0] > 0:
-        >>> else:
+        >>> 'net_migration' in df.columns
+        True
+        >>> len(df) > 0
+        True
     """
     logger.info("Fetching data sources for migration calculation...")
 
@@ -300,6 +301,8 @@ def get_migration_by_year(df: pd.DataFrame, year: int) -> pd.DataFrame:
     Example:
         >>> df = get_latest_migration()
         >>> df_2024 = get_migration_by_year(df, 2024)
+        >>> 'net_migration' in df_2024.columns
+        True
     """
     return df[df["year"] == year].reset_index(drop=True)
 
@@ -329,6 +332,8 @@ def get_migration_summary_statistics(
     Example:
         >>> df = get_latest_migration()
         >>> stats = get_migration_summary_statistics(df, start_year=2010)
+        >>> 'avg_net_migration' in stats
+        True
     """
     # Filter by year range if specified
     filtered = df.copy()
@@ -587,11 +592,11 @@ def get_official_migration(force_refresh: bool = False) -> pd.DataFrame:
         NISRAValidationError: If data fails validation
 
     Example:
-        >>> # Get official migration data
         >>> official = get_official_migration()
-        >>>
-        >>> # Filter to recent years
-        >>> recent = official[official['year'] >= 2010]
+        >>> sorted(official.columns.tolist())
+        ['date', 'net_migration', 'year']
+        >>> len(official) > 0
+        True
     """
     logger.info("Fetching latest official migration statistics...")
 
@@ -641,10 +646,8 @@ def compare_official_vs_derived(
         >>> official = get_official_migration()
         >>> derived = get_derived_migration()
         >>> comparison = compare_official_vs_derived(official, derived)
-        >>>
-        >>> # Show years with significant discrepancies
-        >>>
-        >>> # Calculate mean error
+        >>> sorted(comparison.columns.tolist())
+        ['absolute_difference', 'derived_net_migration', 'exceeds_threshold', 'official_net_migration', 'percent_difference', 'year']
     """
     # Merge on year (inner join to get only overlapping years)
     comparison = official_df[["year", "net_migration"]].merge(

--- a/src/bolster/data_sources/nisra/population.py
+++ b/src/bolster/data_sources/nisra/population.py
@@ -24,13 +24,12 @@ Geographic Coverage: Northern Ireland
 Reference Date: June 30th of each year
 
 Example:
-    >>> from bolster.data_sources.nisra import population  # doctest: +SKIP
+    >>> from bolster.data_sources.nisra import population
     >>> # Get latest population estimates for all geographies
-    >>> df = population.get_latest_population()  # doctest: +SKIP
-    >>> print(df.head())  # doctest: +SKIP
+    >>> df = population.get_latest_population()
 
     >>> # Get only Northern Ireland overall
-    >>> ni_df = population.get_latest_population(area='Northern Ireland')  # doctest: +SKIP
+    >>> ni_df = population.get_latest_population(area='Northern Ireland')
 """
 
 import logging
@@ -251,14 +250,14 @@ def get_latest_population(
 
     Example:
         >>> # Get all data
-        >>> df = get_latest_population()  # doctest: +SKIP
+        >>> df = get_latest_population()
 
         >>> # Get only Northern Ireland overall
-        >>> ni_df = get_latest_population(area='Northern Ireland')  # doctest: +SKIP
+        >>> ni_df = get_latest_population(area='Northern Ireland')
 
         >>> # Calculate total NI population in latest year
-        >>> ni_2024 = ni_df[(ni_df['year'] == 2024) & (ni_df['sex'] == 'All persons')]  # doctest: +SKIP
-        >>> total = ni_2024['population'].sum()  # doctest: +SKIP
+        >>> ni_2024 = ni_df[(ni_df['year'] == 2024) & (ni_df['sex'] == 'All persons')]
+        >>> total = ni_2024['population'].sum()
     """
     # Discover latest publication
     excel_url, year = get_latest_population_publication_url()
@@ -319,10 +318,10 @@ def get_population_by_year(
         Filtered DataFrame
 
     Example:
-        >>> df = get_latest_population(area='Northern Ireland')  # doctest: +SKIP
-        >>> pop_2024 = get_population_by_year(df, 2024)  # doctest: +SKIP
+        >>> df = get_latest_population(area='Northern Ireland')
+        >>> pop_2024 = get_population_by_year(df, 2024)
         >>> # Calculate total population
-        >>> total = pop_2024['population'].sum()  # doctest: +SKIP
+        >>> total = pop_2024['population'].sum()
     """
     filtered = df[df["year"] == year].copy()
 
@@ -354,12 +353,12 @@ def get_population_pyramid_data(
             - females: Female population (negative values for pyramid)
 
     Example:
-        >>> df = get_latest_population(area='Northern Ireland')  # doctest: +SKIP
-        >>> pyramid = get_population_pyramid_data(df, 2024)  # doctest: +SKIP
+        >>> df = get_latest_population(area='Northern Ireland')
+        >>> pyramid = get_population_pyramid_data(df, 2024)
         >>> # Plot with matplotlib/plotly
-        >>> import matplotlib.pyplot as plt  # doctest: +SKIP
-        >>> plt.barh(pyramid['age_5'], pyramid['males'], label='Males')  # doctest: +SKIP
-        >>> plt.barh(pyramid['age_5'], pyramid['females'], label='Females')  # doctest: +SKIP
+        >>> import matplotlib.pyplot as plt
+        >>> plt.barh(pyramid['age_5'], pyramid['males'], label='Males')
+        >>> plt.barh(pyramid['age_5'], pyramid['females'], label='Females')
     """
     filtered = df[(df["year"] == year) & (df["area_name"] == area_name)].copy()
 

--- a/src/bolster/data_sources/nisra/population.py
+++ b/src/bolster/data_sources/nisra/population.py
@@ -27,9 +27,13 @@ Example:
     >>> from bolster.data_sources.nisra import population
     >>> # Get latest population estimates for all geographies
     >>> df = population.get_latest_population()
+    >>> 'population' in df.columns
+    True
 
     >>> # Get only Northern Ireland overall
     >>> ni_df = population.get_latest_population(area='Northern Ireland')
+    >>> len(ni_df) > 0
+    True
 """
 
 import logging
@@ -249,15 +253,13 @@ def get_latest_population(
         NISRAValidationError: If file structure is unexpected
 
     Example:
-        >>> # Get all data
         >>> df = get_latest_population()
+        >>> 'population' in df.columns
+        True
 
-        >>> # Get only Northern Ireland overall
         >>> ni_df = get_latest_population(area='Northern Ireland')
-
-        >>> # Calculate total NI population in latest year
-        >>> ni_2024 = ni_df[(ni_df['year'] == 2024) & (ni_df['sex'] == 'All persons')]
-        >>> total = ni_2024['population'].sum()
+        >>> sorted(df.columns.tolist())
+        ['age_5', 'age_band', 'age_broad', 'area', 'area_code', 'area_name', 'population', 'sex', 'year']
     """
     # Discover latest publication
     excel_url, year = get_latest_population_publication_url()
@@ -320,8 +322,9 @@ def get_population_by_year(
     Example:
         >>> df = get_latest_population(area='Northern Ireland')
         >>> pop_2024 = get_population_by_year(df, 2024)
-        >>> # Calculate total population
         >>> total = pop_2024['population'].sum()
+        >>> total > 0
+        True
     """
     filtered = df[df["year"] == year].copy()
 
@@ -355,10 +358,8 @@ def get_population_pyramid_data(
     Example:
         >>> df = get_latest_population(area='Northern Ireland')
         >>> pyramid = get_population_pyramid_data(df, 2024)
-        >>> # Plot with matplotlib/plotly
-        >>> import matplotlib.pyplot as plt
-        >>> plt.barh(pyramid['age_5'], pyramid['males'], label='Males')
-        >>> plt.barh(pyramid['age_5'], pyramid['females'], label='Females')
+        >>> sorted(pyramid.columns.tolist())
+        ['age_5', 'females', 'males']
     """
     filtered = df[(df["year"] == year) & (df["area_name"] == area_name)].copy()
 

--- a/src/bolster/data_sources/nisra/population.py
+++ b/src/bolster/data_sources/nisra/population.py
@@ -24,13 +24,13 @@ Geographic Coverage: Northern Ireland
 Reference Date: June 30th of each year
 
 Example:
-    >>> from bolster.data_sources.nisra import population
+    >>> from bolster.data_sources.nisra import population  # doctest: +SKIP
     >>> # Get latest population estimates for all geographies
-    >>> df = population.get_latest_population()
-    >>> print(df.head())
+    >>> df = population.get_latest_population()  # doctest: +SKIP
+    >>> print(df.head())  # doctest: +SKIP
 
     >>> # Get only Northern Ireland overall
-    >>> ni_df = population.get_latest_population(area='Northern Ireland')
+    >>> ni_df = population.get_latest_population(area='Northern Ireland')  # doctest: +SKIP
 """
 
 import logging
@@ -251,14 +251,14 @@ def get_latest_population(
 
     Example:
         >>> # Get all data
-        >>> df = get_latest_population()
+        >>> df = get_latest_population()  # doctest: +SKIP
 
         >>> # Get only Northern Ireland overall
-        >>> ni_df = get_latest_population(area='Northern Ireland')
+        >>> ni_df = get_latest_population(area='Northern Ireland')  # doctest: +SKIP
 
         >>> # Calculate total NI population in latest year
-        >>> ni_2024 = ni_df[(ni_df['year'] == 2024) & (ni_df['sex'] == 'All persons')]
-        >>> total = ni_2024['population'].sum()
+        >>> ni_2024 = ni_df[(ni_df['year'] == 2024) & (ni_df['sex'] == 'All persons')]  # doctest: +SKIP
+        >>> total = ni_2024['population'].sum()  # doctest: +SKIP
     """
     # Discover latest publication
     excel_url, year = get_latest_population_publication_url()
@@ -319,10 +319,10 @@ def get_population_by_year(
         Filtered DataFrame
 
     Example:
-        >>> df = get_latest_population(area='Northern Ireland')
-        >>> pop_2024 = get_population_by_year(df, 2024)
+        >>> df = get_latest_population(area='Northern Ireland')  # doctest: +SKIP
+        >>> pop_2024 = get_population_by_year(df, 2024)  # doctest: +SKIP
         >>> # Calculate total population
-        >>> total = pop_2024['population'].sum()
+        >>> total = pop_2024['population'].sum()  # doctest: +SKIP
     """
     filtered = df[df["year"] == year].copy()
 
@@ -354,12 +354,12 @@ def get_population_pyramid_data(
             - females: Female population (negative values for pyramid)
 
     Example:
-        >>> df = get_latest_population(area='Northern Ireland')
-        >>> pyramid = get_population_pyramid_data(df, 2024)
+        >>> df = get_latest_population(area='Northern Ireland')  # doctest: +SKIP
+        >>> pyramid = get_population_pyramid_data(df, 2024)  # doctest: +SKIP
         >>> # Plot with matplotlib/plotly
-        >>> import matplotlib.pyplot as plt
-        >>> plt.barh(pyramid['age_5'], pyramid['males'], label='Males')
-        >>> plt.barh(pyramid['age_5'], pyramid['females'], label='Females')
+        >>> import matplotlib.pyplot as plt  # doctest: +SKIP
+        >>> plt.barh(pyramid['age_5'], pyramid['males'], label='Males')  # doctest: +SKIP
+        >>> plt.barh(pyramid['age_5'], pyramid['females'], label='Females')  # doctest: +SKIP
     """
     filtered = df[(df["year"] == year) & (df["area_name"] == area_name)].copy()
 

--- a/src/bolster/data_sources/nisra/population.py
+++ b/src/bolster/data_sources/nisra/population.py
@@ -323,7 +323,7 @@ def get_population_by_year(
         >>> df = get_latest_population(area='Northern Ireland')
         >>> pop_2024 = get_population_by_year(df, 2024)
         >>> total = pop_2024['population'].sum()
-        >>> total > 0
+        >>> bool(total > 0)
         True
     """
     filtered = df[df["year"] == year].copy()

--- a/src/bolster/data_sources/nisra/population_projections.py
+++ b/src/bolster/data_sources/nisra/population_projections.py
@@ -29,23 +29,23 @@ Geographic Coverage: Northern Ireland
 Projection Horizon: Typically 50 years (e.g., 2022-2072)
 
 Example:
-    >>> from bolster.data_sources.nisra import population_projections
+    >>> from bolster.data_sources.nisra import population_projections  # doctest: +SKIP
     >>>
     >>> # Get all projections (default: principal projection)
-    >>> df = population_projections.get_latest_projections()
-    >>> print(df.head())
+    >>> df = population_projections.get_latest_projections()  # doctest: +SKIP
+    >>> print(df.head())  # doctest: +SKIP
     >>>
     >>> # Filter to specific year and demographics
-    >>> df_2030 = df[(df['year'] == 2030) & (df['sex'] == 'All Persons')]
-    >>> total_2030 = df_2030['population'].sum()
-    >>> print(f"Projected NI population in 2030: {total_2030:,}")
+    >>> df_2030 = df[(df['year'] == 2030) & (df['sex'] == 'All Persons')]  # doctest: +SKIP
+    >>> total_2030 = df_2030['population'].sum()  # doctest: +SKIP
+    >>> print(f"Projected NI population in 2030: {total_2030:,}")  # doctest: +SKIP
     >>>
     >>> # Get projections for specific year range
-    >>> df_decade = population_projections.get_latest_projections(
-    ...     area='Northern Ireland',
-    ...     start_year=2025,
-    ...     end_year=2035
-    ... )
+    >>> df_decade = population_projections.get_latest_projections(  # doctest: +SKIP
+    ...     area='Northern Ireland',  # doctest: +SKIP
+    ...     start_year=2025,  # doctest: +SKIP
+    ...     end_year=2035  # doctest: +SKIP
+    ... )  # doctest: +SKIP
 """
 
 import logging
@@ -313,21 +313,21 @@ def get_latest_projections(
 
     Example:
         >>> # Get all projections
-        >>> df = get_latest_projections()
+        >>> df = get_latest_projections()  # doctest: +SKIP
         >>>
         >>> # Get Northern Ireland projections for 2030s
-        >>> df_ni_2030s = get_latest_projections(
-        ...     area='Northern Ireland',
-        ...     start_year=2030,
-        ...     end_year=2039
-        ... )
+        >>> df_ni_2030s = get_latest_projections(  # doctest: +SKIP
+        ...     area='Northern Ireland',  # doctest: +SKIP
+        ...     start_year=2030,  # doctest: +SKIP
+        ...     end_year=2039  # doctest: +SKIP
+        ... )  # doctest: +SKIP
         >>>
         >>> # Get working-age population projection
-        >>> df_2030 = get_latest_projections(start_year=2030, end_year=2030)
-        >>> working_age = df_2030[
-        ...     (df_2030['sex'] == 'All Persons') &
-        ...     (df_2030['age_group'].isin(['15-19', '20-24', ..., '60-64']))
-        ... ]
+        >>> df_2030 = get_latest_projections(start_year=2030, end_year=2030)  # doctest: +SKIP
+        >>> working_age = df_2030[  # doctest: +SKIP
+        ...     (df_2030['sex'] == 'All Persons') &  # doctest: +SKIP
+        ...     (df_2030['age_group'].isin(['15-19', '20-24', ..., '60-64']))  # doctest: +SKIP
+        ... ]  # doctest: +SKIP
     """
     logger.info(f"Fetching latest population projections (variant: {variant})...")
 

--- a/src/bolster/data_sources/nisra/population_projections.py
+++ b/src/bolster/data_sources/nisra/population_projections.py
@@ -308,7 +308,7 @@ def get_latest_projections(
     Example:
         >>> df = get_latest_projections()
         >>> sorted(df.columns.tolist())
-        ['age_group', 'area', 'population', 'sex', 'variant', 'year']
+        ['age_group', 'area', 'base_year', 'population', 'sex', 'year']
         >>> df_ni_2030s = get_latest_projections(
         ...     area='Northern Ireland',
         ...     start_year=2030,

--- a/src/bolster/data_sources/nisra/population_projections.py
+++ b/src/bolster/data_sources/nisra/population_projections.py
@@ -30,20 +30,16 @@ Projection Horizon: Typically 50 years (e.g., 2022-2072)
 
 Example:
     >>> from bolster.data_sources.nisra import population_projections
-    >>>
-    >>> # Get all projections (default: principal projection)
     >>> df = population_projections.get_latest_projections()
-    >>>
-    >>> # Filter to specific year and demographics
-    >>> df_2030 = df[(df['year'] == 2030) & (df['sex'] == 'All Persons')]
-    >>> total_2030 = df_2030['population'].sum()
-    >>>
-    >>> # Get projections for specific year range
+    >>> 'population' in df.columns
+    True
     >>> df_decade = population_projections.get_latest_projections(
     ...     area='Northern Ireland',
     ...     start_year=2025,
     ...     end_year=2035
     ... )
+    >>> len(df_decade) > 0
+    True
 """
 
 import logging
@@ -310,22 +306,16 @@ def get_latest_projections(
         NISRAValidationError: If data fails integrity checks
 
     Example:
-        >>> # Get all projections
         >>> df = get_latest_projections()
-        >>>
-        >>> # Get Northern Ireland projections for 2030s
+        >>> sorted(df.columns.tolist())
+        ['age_group', 'area', 'population', 'sex', 'variant', 'year']
         >>> df_ni_2030s = get_latest_projections(
         ...     area='Northern Ireland',
         ...     start_year=2030,
         ...     end_year=2039
         ... )
-        >>>
-        >>> # Get working-age population projection
-        >>> df_2030 = get_latest_projections(start_year=2030, end_year=2030)
-        >>> working_age = df_2030[
-        ...     (df_2030['sex'] == 'All Persons') &
-        ...     (df_2030['age_group'].isin(['15-19', '20-24', ..., '60-64']))
-        ... ]
+        >>> len(df_ni_2030s) > 0
+        True
     """
     logger.info(f"Fetching latest population projections (variant: {variant})...")
 

--- a/src/bolster/data_sources/nisra/population_projections.py
+++ b/src/bolster/data_sources/nisra/population_projections.py
@@ -29,23 +29,21 @@ Geographic Coverage: Northern Ireland
 Projection Horizon: Typically 50 years (e.g., 2022-2072)
 
 Example:
-    >>> from bolster.data_sources.nisra import population_projections  # doctest: +SKIP
+    >>> from bolster.data_sources.nisra import population_projections
     >>>
     >>> # Get all projections (default: principal projection)
-    >>> df = population_projections.get_latest_projections()  # doctest: +SKIP
-    >>> print(df.head())  # doctest: +SKIP
+    >>> df = population_projections.get_latest_projections()
     >>>
     >>> # Filter to specific year and demographics
-    >>> df_2030 = df[(df['year'] == 2030) & (df['sex'] == 'All Persons')]  # doctest: +SKIP
-    >>> total_2030 = df_2030['population'].sum()  # doctest: +SKIP
-    >>> print(f"Projected NI population in 2030: {total_2030:,}")  # doctest: +SKIP
+    >>> df_2030 = df[(df['year'] == 2030) & (df['sex'] == 'All Persons')]
+    >>> total_2030 = df_2030['population'].sum()
     >>>
     >>> # Get projections for specific year range
-    >>> df_decade = population_projections.get_latest_projections(  # doctest: +SKIP
-    ...     area='Northern Ireland',  # doctest: +SKIP
-    ...     start_year=2025,  # doctest: +SKIP
-    ...     end_year=2035  # doctest: +SKIP
-    ... )  # doctest: +SKIP
+    >>> df_decade = population_projections.get_latest_projections(
+    ...     area='Northern Ireland',
+    ...     start_year=2025,
+    ...     end_year=2035
+    ... )
 """
 
 import logging
@@ -313,21 +311,21 @@ def get_latest_projections(
 
     Example:
         >>> # Get all projections
-        >>> df = get_latest_projections()  # doctest: +SKIP
+        >>> df = get_latest_projections()
         >>>
         >>> # Get Northern Ireland projections for 2030s
-        >>> df_ni_2030s = get_latest_projections(  # doctest: +SKIP
-        ...     area='Northern Ireland',  # doctest: +SKIP
-        ...     start_year=2030,  # doctest: +SKIP
-        ...     end_year=2039  # doctest: +SKIP
-        ... )  # doctest: +SKIP
+        >>> df_ni_2030s = get_latest_projections(
+        ...     area='Northern Ireland',
+        ...     start_year=2030,
+        ...     end_year=2039
+        ... )
         >>>
         >>> # Get working-age population projection
-        >>> df_2030 = get_latest_projections(start_year=2030, end_year=2030)  # doctest: +SKIP
-        >>> working_age = df_2030[  # doctest: +SKIP
-        ...     (df_2030['sex'] == 'All Persons') &  # doctest: +SKIP
-        ...     (df_2030['age_group'].isin(['15-19', '20-24', ..., '60-64']))  # doctest: +SKIP
-        ... ]  # doctest: +SKIP
+        >>> df_2030 = get_latest_projections(start_year=2030, end_year=2030)
+        >>> working_age = df_2030[
+        ...     (df_2030['sex'] == 'All Persons') &
+        ...     (df_2030['age_group'].isin(['15-19', '20-24', ..., '60-64']))
+        ... ]
     """
     logger.info(f"Fetching latest population projections (variant: {variant})...")
 

--- a/src/bolster/data_sources/nisra/quarterly_employment_survey.py
+++ b/src/bolster/data_sources/nisra/quarterly_employment_survey.py
@@ -21,13 +21,13 @@ Geographic Coverage: Northern Ireland
 Time Series: Q1 2005 to present (seasonally adjusted); Q1 2005 unadjusted
 
 Example:
-    >>> from bolster.data_sources.nisra import quarterly_employment_survey as qes
-    >>> df = qes.get_latest_qes()
-    >>> print(df.tail(4))
+    >>> from bolster.data_sources.nisra import quarterly_employment_survey as qes  # doctest: +SKIP
+    >>> df = qes.get_latest_qes()  # doctest: +SKIP
+    >>> print(df.tail(4))  # doctest: +SKIP
 
     >>> # Total employee jobs trend
-    >>> growth = qes.get_qes_growth(df)
-    >>> print(growth[['quarter_label', 'total_jobs', 'total_yoy']].tail(8))
+    >>> growth = qes.get_qes_growth(df)  # doctest: +SKIP
+    >>> print(growth[['quarter_label', 'total_jobs', 'total_yoy']].tail(8))  # doctest: +SKIP
 """
 
 import logging
@@ -263,9 +263,9 @@ def get_latest_qes(force_refresh: bool = False, adjusted: bool = True) -> pd.Dat
         NISRAValidationError: If file structure is unexpected
 
     Example:
-        >>> df = get_latest_qes()
-        >>> latest = df.iloc[-1]
-        >>> print(f"NI employee jobs {latest['quarter_label']}: {latest['total_jobs']:,}")
+        >>> df = get_latest_qes()  # doctest: +SKIP
+        >>> latest = df.iloc[-1]  # doctest: +SKIP
+        >>> print(f"NI employee jobs {latest['quarter_label']}: {latest['total_jobs']:,}")  # doctest: +SKIP
         NI employee jobs Q4 2025: 843,860
     """
     excel_url = get_latest_qes_publication_url()
@@ -330,9 +330,9 @@ def get_qes_by_year(df: pd.DataFrame, year: int) -> pd.DataFrame:
         Filtered DataFrame (up to 4 quarters)
 
     Example:
-        >>> df = get_latest_qes()
-        >>> df_2024 = get_qes_by_year(df, 2024)
-        >>> print(df_2024[['quarter_label', 'total_jobs']])
+        >>> df = get_latest_qes()  # doctest: +SKIP
+        >>> df_2024 = get_qes_by_year(df, 2024)  # doctest: +SKIP
+        >>> print(df_2024[['quarter_label', 'total_jobs']])  # doctest: +SKIP
     """
     return df[df["year"] == year].reset_index(drop=True)
 
@@ -351,9 +351,9 @@ def get_qes_growth(df: pd.DataFrame) -> pd.DataFrame:
             - manufacturing_yoy: Manufacturing jobs year-on-year % change
 
     Example:
-        >>> df = get_latest_qes()
-        >>> growth = get_qes_growth(df)
-        >>> print(growth[['quarter_label', 'total_jobs', 'total_yoy']].tail(8))
+        >>> df = get_latest_qes()  # doctest: +SKIP
+        >>> growth = get_qes_growth(df)  # doctest: +SKIP
+        >>> print(growth[['quarter_label', 'total_jobs', 'total_yoy']].tail(8))  # doctest: +SKIP
     """
     result = df.copy()
     result["total_qoq"] = result["total_jobs"].diff(1)
@@ -377,10 +377,10 @@ def get_sector_shares(df: pd.DataFrame) -> pd.DataFrame:
             - other_share: Other industries % of total
 
     Example:
-        >>> df = get_latest_qes()
-        >>> shares = get_sector_shares(df)
-        >>> latest = shares.iloc[-1]
-        >>> print(f"Services share: {latest['services_share']:.1f}%")
+        >>> df = get_latest_qes()  # doctest: +SKIP
+        >>> shares = get_sector_shares(df)  # doctest: +SKIP
+        >>> latest = shares.iloc[-1]  # doctest: +SKIP
+        >>> print(f"Services share: {latest['services_share']:.1f}%")  # doctest: +SKIP
     """
     result = df.copy()
     for sector in ("manufacturing", "construction", "services", "other"):

--- a/src/bolster/data_sources/nisra/quarterly_employment_survey.py
+++ b/src/bolster/data_sources/nisra/quarterly_employment_survey.py
@@ -23,9 +23,11 @@ Time Series: Q1 2005 to present (seasonally adjusted); Q1 2005 unadjusted
 Example:
     >>> from bolster.data_sources.nisra import quarterly_employment_survey as qes
     >>> df = qes.get_latest_qes()
-
-    >>> # Total employee jobs trend
+    >>> 'total_jobs' in df.columns
+    True
     >>> growth = qes.get_qes_growth(df)
+    >>> 'total_yoy' in growth.columns
+    True
 """
 
 import logging
@@ -262,9 +264,8 @@ def get_latest_qes(force_refresh: bool = False, adjusted: bool = True) -> pd.Dat
 
     Example:
         >>> df = get_latest_qes()
-        >>> latest = df.iloc[-1]
-        >>> print(f"NI employee jobs {latest['quarter_label']}: {latest['total_jobs']:,}")
-        NI employee jobs Q4 2025: 843,860
+        >>> 'total_jobs' in df.columns
+        True
     """
     excel_url = get_latest_qes_publication_url()
     logger.info(f"Downloading QES supplementary tables from: {excel_url}")
@@ -330,6 +331,8 @@ def get_qes_by_year(df: pd.DataFrame, year: int) -> pd.DataFrame:
     Example:
         >>> df = get_latest_qes()
         >>> df_2024 = get_qes_by_year(df, 2024)
+        >>> len(df_2024) <= 4
+        True
     """
     return df[df["year"] == year].reset_index(drop=True)
 
@@ -350,6 +353,8 @@ def get_qes_growth(df: pd.DataFrame) -> pd.DataFrame:
     Example:
         >>> df = get_latest_qes()
         >>> growth = get_qes_growth(df)
+        >>> 'total_yoy' in growth.columns
+        True
     """
     result = df.copy()
     result["total_qoq"] = result["total_jobs"].diff(1)
@@ -375,7 +380,8 @@ def get_sector_shares(df: pd.DataFrame) -> pd.DataFrame:
     Example:
         >>> df = get_latest_qes()
         >>> shares = get_sector_shares(df)
-        >>> latest = shares.iloc[-1]
+        >>> 'services_share' in shares.columns
+        True
     """
     result = df.copy()
     for sector in ("manufacturing", "construction", "services", "other"):

--- a/src/bolster/data_sources/nisra/quarterly_employment_survey.py
+++ b/src/bolster/data_sources/nisra/quarterly_employment_survey.py
@@ -21,13 +21,11 @@ Geographic Coverage: Northern Ireland
 Time Series: Q1 2005 to present (seasonally adjusted); Q1 2005 unadjusted
 
 Example:
-    >>> from bolster.data_sources.nisra import quarterly_employment_survey as qes  # doctest: +SKIP
-    >>> df = qes.get_latest_qes()  # doctest: +SKIP
-    >>> print(df.tail(4))  # doctest: +SKIP
+    >>> from bolster.data_sources.nisra import quarterly_employment_survey as qes
+    >>> df = qes.get_latest_qes()
 
     >>> # Total employee jobs trend
-    >>> growth = qes.get_qes_growth(df)  # doctest: +SKIP
-    >>> print(growth[['quarter_label', 'total_jobs', 'total_yoy']].tail(8))  # doctest: +SKIP
+    >>> growth = qes.get_qes_growth(df)
 """
 
 import logging
@@ -263,9 +261,9 @@ def get_latest_qes(force_refresh: bool = False, adjusted: bool = True) -> pd.Dat
         NISRAValidationError: If file structure is unexpected
 
     Example:
-        >>> df = get_latest_qes()  # doctest: +SKIP
-        >>> latest = df.iloc[-1]  # doctest: +SKIP
-        >>> print(f"NI employee jobs {latest['quarter_label']}: {latest['total_jobs']:,}")  # doctest: +SKIP
+        >>> df = get_latest_qes()
+        >>> latest = df.iloc[-1]
+        >>> print(f"NI employee jobs {latest['quarter_label']}: {latest['total_jobs']:,}")
         NI employee jobs Q4 2025: 843,860
     """
     excel_url = get_latest_qes_publication_url()
@@ -330,9 +328,8 @@ def get_qes_by_year(df: pd.DataFrame, year: int) -> pd.DataFrame:
         Filtered DataFrame (up to 4 quarters)
 
     Example:
-        >>> df = get_latest_qes()  # doctest: +SKIP
-        >>> df_2024 = get_qes_by_year(df, 2024)  # doctest: +SKIP
-        >>> print(df_2024[['quarter_label', 'total_jobs']])  # doctest: +SKIP
+        >>> df = get_latest_qes()
+        >>> df_2024 = get_qes_by_year(df, 2024)
     """
     return df[df["year"] == year].reset_index(drop=True)
 
@@ -351,9 +348,8 @@ def get_qes_growth(df: pd.DataFrame) -> pd.DataFrame:
             - manufacturing_yoy: Manufacturing jobs year-on-year % change
 
     Example:
-        >>> df = get_latest_qes()  # doctest: +SKIP
-        >>> growth = get_qes_growth(df)  # doctest: +SKIP
-        >>> print(growth[['quarter_label', 'total_jobs', 'total_yoy']].tail(8))  # doctest: +SKIP
+        >>> df = get_latest_qes()
+        >>> growth = get_qes_growth(df)
     """
     result = df.copy()
     result["total_qoq"] = result["total_jobs"].diff(1)
@@ -377,10 +373,9 @@ def get_sector_shares(df: pd.DataFrame) -> pd.DataFrame:
             - other_share: Other industries % of total
 
     Example:
-        >>> df = get_latest_qes()  # doctest: +SKIP
-        >>> shares = get_sector_shares(df)  # doctest: +SKIP
-        >>> latest = shares.iloc[-1]  # doctest: +SKIP
-        >>> print(f"Services share: {latest['services_share']:.1f}%")  # doctest: +SKIP
+        >>> df = get_latest_qes()
+        >>> shares = get_sector_shares(df)
+        >>> latest = shares.iloc[-1]
     """
     result = df.copy()
     for sector in ("manufacturing", "construction", "services", "other"):

--- a/src/bolster/data_sources/nisra/registrar_general.py
+++ b/src/bolster/data_sources/nisra/registrar_general.py
@@ -19,22 +19,18 @@ Update Frequency: Quarterly (February, May, August, November)
 Geographic Coverage: Northern Ireland (with LGD breakdowns)
 
 Example:
-    >>> from bolster.data_sources.nisra import registrar_general  # doctest: +SKIP
+    >>> from bolster.data_sources.nisra import registrar_general
     >>> # Get all quarterly vital statistics
-    >>> data = registrar_general.get_quarterly_vital_statistics()  # doctest: +SKIP
-    >>> print(data['births'].tail())  # doctest: +SKIP
+    >>> data = registrar_general.get_quarterly_vital_statistics()
 
     >>> # Get quarterly births only
-    >>> births = registrar_general.get_quarterly_births()  # doctest: +SKIP
-    >>> print(f"Q1 2024 births: {births[(births['year']==2024) & (births['quarter']==1)]['total_births'].values[0]}")  # doctest: +SKIP
+    >>> births = registrar_general.get_quarterly_births()
 
     >>> # Get LGD-level statistics
-    >>> lgd_df = registrar_general.get_lgd_statistics()  # doctest: +SKIP
-    >>> print(lgd_df)  # doctest: +SKIP
+    >>> lgd_df = registrar_general.get_lgd_statistics()
 
     >>> # Cross-validate with monthly data
-    >>> report = registrar_general.get_validation_report()  # doctest: +SKIP
-    >>> print(report['births_validation'])  # doctest: +SKIP
+    >>> report = registrar_general.get_validation_report()
 """
 
 import logging
@@ -521,9 +517,7 @@ def get_quarterly_vital_statistics(
         NISRADataNotFoundError: If latest publication cannot be found
 
     Example:
-        >>> data = get_quarterly_vital_statistics()  # doctest: +SKIP
-        >>> print(data['births'].columns)  # doctest: +SKIP
-        >>> print(data['births'].tail())  # doctest: +SKIP
+        >>> data = get_quarterly_vital_statistics()
     """
     excel_url, pub_url, year, quarter = get_latest_publication_url()
 
@@ -554,9 +548,8 @@ def get_quarterly_births(force_refresh: bool = False) -> pd.DataFrame:
             - stillbirths: int (if available)
 
     Example:
-        >>> births = get_quarterly_births()  # doctest: +SKIP
-        >>> q1_2024 = births[(births['year']==2024) & (births['quarter']==1)]  # doctest: +SKIP
-        >>> print(f"Q1 2024 births: {q1_2024['total_births'].values[0]}")  # doctest: +SKIP
+        >>> births = get_quarterly_births()
+        >>> q1_2024 = births[(births['year']==2024) & (births['quarter']==1)]
     """
     data = get_quarterly_vital_statistics(force_refresh=force_refresh)
     return data["births"]
@@ -581,8 +574,7 @@ def get_quarterly_deaths(force_refresh: bool = False) -> pd.DataFrame:
             - civil_partnerships: int
 
     Example:
-        >>> deaths = get_quarterly_deaths()  # doctest: +SKIP
-        >>> print(deaths[deaths['year'] == 2024])  # doctest: +SKIP
+        >>> deaths = get_quarterly_deaths()
     """
     data = get_quarterly_vital_statistics(force_refresh=force_refresh)
     return data["deaths"]
@@ -607,8 +599,7 @@ def get_lgd_statistics(force_refresh: bool = False) -> pd.DataFrame:
             - marriages: int
 
     Example:
-        >>> lgd = get_lgd_statistics()  # doctest: +SKIP
-        >>> print(lgd.sort_values('births', ascending=False))  # doctest: +SKIP
+        >>> lgd = get_lgd_statistics()
     """
     data = get_quarterly_vital_statistics(force_refresh=force_refresh)
     return data["lgd"]
@@ -637,9 +628,8 @@ def validate_against_monthly_births(
             - pct_diff: float (percentage difference)
 
     Example:
-        >>> births_q = get_quarterly_births()  # doctest: +SKIP
-        >>> validation = validate_against_monthly_births(births_q)  # doctest: +SKIP
-        >>> print(validation[validation['pct_diff'].abs() > 1])  # doctest: +SKIP
+        >>> births_q = get_quarterly_births()
+        >>> validation = validate_against_monthly_births(births_q)
     """
     if monthly_df is None:
         from . import births
@@ -684,9 +674,8 @@ def validate_against_monthly_marriages(
         DataFrame with comparison columns
 
     Example:
-        >>> deaths_q = get_quarterly_deaths()  # doctest: +SKIP
-        >>> validation = validate_against_monthly_marriages(deaths_q)  # doctest: +SKIP
-        >>> print(validation)  # doctest: +SKIP
+        >>> deaths_q = get_quarterly_deaths()
+        >>> validation = validate_against_monthly_marriages(deaths_q)
     """
     if monthly_df is None:
         from . import marriages
@@ -728,9 +717,7 @@ def get_validation_report(
             - 'summary': Overall validation statistics
 
     Example:
-        >>> report = get_validation_report()  # doctest: +SKIP
-        >>> print(report['summary'])  # doctest: +SKIP
-        >>> print(report['births_validation'])  # doctest: +SKIP
+        >>> report = get_validation_report()
     """
     data = get_quarterly_vital_statistics(force_refresh=force_refresh)
 

--- a/src/bolster/data_sources/nisra/registrar_general.py
+++ b/src/bolster/data_sources/nisra/registrar_general.py
@@ -20,17 +20,15 @@ Geographic Coverage: Northern Ireland (with LGD breakdowns)
 
 Example:
     >>> from bolster.data_sources.nisra import registrar_general
-    >>> # Get all quarterly vital statistics
     >>> data = registrar_general.get_quarterly_vital_statistics()
-
-    >>> # Get quarterly births only
+    >>> sorted(data.keys())
+    ['births', 'deaths', 'lgd']
     >>> births = registrar_general.get_quarterly_births()
-
-    >>> # Get LGD-level statistics
+    >>> 'total_births' in births.columns
+    True
     >>> lgd_df = registrar_general.get_lgd_statistics()
-
-    >>> # Cross-validate with monthly data
-    >>> report = registrar_general.get_validation_report()
+    >>> 'lgd' in lgd_df.columns
+    True
 """
 
 import logging
@@ -518,6 +516,8 @@ def get_quarterly_vital_statistics(
 
     Example:
         >>> data = get_quarterly_vital_statistics()
+        >>> sorted(data.keys())
+        ['births', 'deaths', 'lgd']
     """
     excel_url, pub_url, year, quarter = get_latest_publication_url()
 
@@ -549,7 +549,8 @@ def get_quarterly_births(force_refresh: bool = False) -> pd.DataFrame:
 
     Example:
         >>> births = get_quarterly_births()
-        >>> q1_2024 = births[(births['year']==2024) & (births['quarter']==1)]
+        >>> 'total_births' in births.columns
+        True
     """
     data = get_quarterly_vital_statistics(force_refresh=force_refresh)
     return data["births"]
@@ -575,6 +576,8 @@ def get_quarterly_deaths(force_refresh: bool = False) -> pd.DataFrame:
 
     Example:
         >>> deaths = get_quarterly_deaths()
+        >>> 'deaths' in deaths.columns
+        True
     """
     data = get_quarterly_vital_statistics(force_refresh=force_refresh)
     return data["deaths"]
@@ -600,6 +603,8 @@ def get_lgd_statistics(force_refresh: bool = False) -> pd.DataFrame:
 
     Example:
         >>> lgd = get_lgd_statistics()
+        >>> 'lgd' in lgd.columns
+        True
     """
     data = get_quarterly_vital_statistics(force_refresh=force_refresh)
     return data["lgd"]
@@ -630,6 +635,8 @@ def validate_against_monthly_births(
     Example:
         >>> births_q = get_quarterly_births()
         >>> validation = validate_against_monthly_births(births_q)
+        >>> 'quarterly_total' in validation.columns
+        True
     """
     if monthly_df is None:
         from . import births
@@ -676,6 +683,8 @@ def validate_against_monthly_marriages(
     Example:
         >>> deaths_q = get_quarterly_deaths()
         >>> validation = validate_against_monthly_marriages(deaths_q)
+        >>> 'quarterly_total' in validation.columns
+        True
     """
     if monthly_df is None:
         from . import marriages
@@ -718,6 +727,8 @@ def get_validation_report(
 
     Example:
         >>> report = get_validation_report()
+        >>> 'summary' in report
+        True
     """
     data = get_quarterly_vital_statistics(force_refresh=force_refresh)
 

--- a/src/bolster/data_sources/nisra/registrar_general.py
+++ b/src/bolster/data_sources/nisra/registrar_general.py
@@ -19,22 +19,22 @@ Update Frequency: Quarterly (February, May, August, November)
 Geographic Coverage: Northern Ireland (with LGD breakdowns)
 
 Example:
-    >>> from bolster.data_sources.nisra import registrar_general
+    >>> from bolster.data_sources.nisra import registrar_general  # doctest: +SKIP
     >>> # Get all quarterly vital statistics
-    >>> data = registrar_general.get_quarterly_vital_statistics()
-    >>> print(data['births'].tail())
+    >>> data = registrar_general.get_quarterly_vital_statistics()  # doctest: +SKIP
+    >>> print(data['births'].tail())  # doctest: +SKIP
 
     >>> # Get quarterly births only
-    >>> births = registrar_general.get_quarterly_births()
-    >>> print(f"Q1 2024 births: {births[(births['year']==2024) & (births['quarter']==1)]['total_births'].values[0]}")
+    >>> births = registrar_general.get_quarterly_births()  # doctest: +SKIP
+    >>> print(f"Q1 2024 births: {births[(births['year']==2024) & (births['quarter']==1)]['total_births'].values[0]}")  # doctest: +SKIP
 
     >>> # Get LGD-level statistics
-    >>> lgd_df = registrar_general.get_lgd_statistics()
-    >>> print(lgd_df)
+    >>> lgd_df = registrar_general.get_lgd_statistics()  # doctest: +SKIP
+    >>> print(lgd_df)  # doctest: +SKIP
 
     >>> # Cross-validate with monthly data
-    >>> report = registrar_general.get_validation_report()
-    >>> print(report['births_validation'])
+    >>> report = registrar_general.get_validation_report()  # doctest: +SKIP
+    >>> print(report['births_validation'])  # doctest: +SKIP
 """
 
 import logging
@@ -521,9 +521,9 @@ def get_quarterly_vital_statistics(
         NISRADataNotFoundError: If latest publication cannot be found
 
     Example:
-        >>> data = get_quarterly_vital_statistics()
-        >>> print(data['births'].columns)
-        >>> print(data['births'].tail())
+        >>> data = get_quarterly_vital_statistics()  # doctest: +SKIP
+        >>> print(data['births'].columns)  # doctest: +SKIP
+        >>> print(data['births'].tail())  # doctest: +SKIP
     """
     excel_url, pub_url, year, quarter = get_latest_publication_url()
 
@@ -554,9 +554,9 @@ def get_quarterly_births(force_refresh: bool = False) -> pd.DataFrame:
             - stillbirths: int (if available)
 
     Example:
-        >>> births = get_quarterly_births()
-        >>> q1_2024 = births[(births['year']==2024) & (births['quarter']==1)]
-        >>> print(f"Q1 2024 births: {q1_2024['total_births'].values[0]}")
+        >>> births = get_quarterly_births()  # doctest: +SKIP
+        >>> q1_2024 = births[(births['year']==2024) & (births['quarter']==1)]  # doctest: +SKIP
+        >>> print(f"Q1 2024 births: {q1_2024['total_births'].values[0]}")  # doctest: +SKIP
     """
     data = get_quarterly_vital_statistics(force_refresh=force_refresh)
     return data["births"]
@@ -581,8 +581,8 @@ def get_quarterly_deaths(force_refresh: bool = False) -> pd.DataFrame:
             - civil_partnerships: int
 
     Example:
-        >>> deaths = get_quarterly_deaths()
-        >>> print(deaths[deaths['year'] == 2024])
+        >>> deaths = get_quarterly_deaths()  # doctest: +SKIP
+        >>> print(deaths[deaths['year'] == 2024])  # doctest: +SKIP
     """
     data = get_quarterly_vital_statistics(force_refresh=force_refresh)
     return data["deaths"]
@@ -607,8 +607,8 @@ def get_lgd_statistics(force_refresh: bool = False) -> pd.DataFrame:
             - marriages: int
 
     Example:
-        >>> lgd = get_lgd_statistics()
-        >>> print(lgd.sort_values('births', ascending=False))
+        >>> lgd = get_lgd_statistics()  # doctest: +SKIP
+        >>> print(lgd.sort_values('births', ascending=False))  # doctest: +SKIP
     """
     data = get_quarterly_vital_statistics(force_refresh=force_refresh)
     return data["lgd"]
@@ -637,9 +637,9 @@ def validate_against_monthly_births(
             - pct_diff: float (percentage difference)
 
     Example:
-        >>> births_q = get_quarterly_births()
-        >>> validation = validate_against_monthly_births(births_q)
-        >>> print(validation[validation['pct_diff'].abs() > 1])
+        >>> births_q = get_quarterly_births()  # doctest: +SKIP
+        >>> validation = validate_against_monthly_births(births_q)  # doctest: +SKIP
+        >>> print(validation[validation['pct_diff'].abs() > 1])  # doctest: +SKIP
     """
     if monthly_df is None:
         from . import births
@@ -684,9 +684,9 @@ def validate_against_monthly_marriages(
         DataFrame with comparison columns
 
     Example:
-        >>> deaths_q = get_quarterly_deaths()
-        >>> validation = validate_against_monthly_marriages(deaths_q)
-        >>> print(validation)
+        >>> deaths_q = get_quarterly_deaths()  # doctest: +SKIP
+        >>> validation = validate_against_monthly_marriages(deaths_q)  # doctest: +SKIP
+        >>> print(validation)  # doctest: +SKIP
     """
     if monthly_df is None:
         from . import marriages
@@ -728,9 +728,9 @@ def get_validation_report(
             - 'summary': Overall validation statistics
 
     Example:
-        >>> report = get_validation_report()
-        >>> print(report['summary'])
-        >>> print(report['births_validation'])
+        >>> report = get_validation_report()  # doctest: +SKIP
+        >>> print(report['summary'])  # doctest: +SKIP
+        >>> print(report['births_validation'])  # doctest: +SKIP
     """
     data = get_quarterly_vital_statistics(force_refresh=force_refresh)
 

--- a/src/bolster/data_sources/nisra/stillbirths.py
+++ b/src/bolster/data_sources/nisra/stillbirths.py
@@ -16,13 +16,11 @@ Update Frequency: Monthly (published ~6 weeks after reference month)
 Geographic Coverage: Northern Ireland (resident stillbirths)
 
 Example:
-    >>> from bolster.data_sources.nisra import stillbirths  # doctest: +SKIP
-    >>> df = stillbirths.get_latest_stillbirths()  # doctest: +SKIP
-    >>> print(df.head())  # doctest: +SKIP
+    >>> from bolster.data_sources.nisra import stillbirths
+    >>> df = stillbirths.get_latest_stillbirths()
 
     >>> # Total stillbirths in 2024
-    >>> total_2024 = df[df['year'] == 2024]['stillbirths'].sum()  # doctest: +SKIP
-    >>> print(f"Stillbirths in 2024: {total_2024}")  # doctest: +SKIP
+    >>> total_2024 = df[df['year'] == 2024]['stillbirths'].sum()
 """
 
 import logging
@@ -202,9 +200,8 @@ def get_latest_stillbirths(force_refresh: bool = False) -> pd.DataFrame:
         NISRAValidationError: If file structure is unexpected
 
     Example:
-        >>> df = get_latest_stillbirths()  # doctest: +SKIP
-        >>> annual = df.groupby('year')['stillbirths'].sum()  # doctest: +SKIP
-        >>> print(annual.tail())  # doctest: +SKIP
+        >>> df = get_latest_stillbirths()
+        >>> annual = df.groupby('year')['stillbirths'].sum()
     """
     excel_url = get_latest_stillbirths_publication_url()
     logger.info(f"Downloading stillbirths data from: {excel_url}")
@@ -254,9 +251,8 @@ def get_stillbirths_by_year(df: pd.DataFrame, year: int) -> pd.DataFrame:
         Filtered DataFrame
 
     Example:
-        >>> df = get_latest_stillbirths()  # doctest: +SKIP
-        >>> df_2024 = get_stillbirths_by_year(df, 2024)  # doctest: +SKIP
-        >>> print(df_2024['stillbirths'].sum())  # doctest: +SKIP
+        >>> df = get_latest_stillbirths()
+        >>> df_2024 = get_stillbirths_by_year(df, 2024)
     """
     return df[df["year"] == year].reset_index(drop=True)
 
@@ -276,11 +272,10 @@ def get_stillbirth_rate(
         total_births, stillbirth_rate
 
     Example:
-        >>> from bolster.data_sources.nisra import stillbirths, births  # doctest: +SKIP
-        >>> sb = stillbirths.get_latest_stillbirths()  # doctest: +SKIP
-        >>> lb = births.get_latest_births(event_type='registration')  # doctest: +SKIP
-        >>> rate = stillbirths.get_stillbirth_rate(sb, lb)  # doctest: +SKIP
-        >>> print(rate[['year', 'month', 'stillbirth_rate']].tail(12))  # doctest: +SKIP
+        >>> from bolster.data_sources.nisra import stillbirths, births
+        >>> sb = stillbirths.get_latest_stillbirths()
+        >>> lb = births.get_latest_births(event_type='registration')
+        >>> rate = stillbirths.get_stillbirth_rate(sb, lb)
     """
     # births_df has 'tests_conducted' or 'births_persons' depending on event_type
     births_col = next(
@@ -307,9 +302,8 @@ def get_annual_summary(df: pd.DataFrame) -> pd.DataFrame:
         DataFrame with columns: year, total_stillbirths, yoy_change, yoy_pct_change
 
     Example:
-        >>> df = get_latest_stillbirths()  # doctest: +SKIP
-        >>> summary = get_annual_summary(df)  # doctest: +SKIP
-        >>> print(summary.tail(5))  # doctest: +SKIP
+        >>> df = get_latest_stillbirths()
+        >>> summary = get_annual_summary(df)
     """
     annual = df.groupby("year")["stillbirths"].sum().reset_index()
     annual = annual.rename(columns={"stillbirths": "total_stillbirths"})

--- a/src/bolster/data_sources/nisra/stillbirths.py
+++ b/src/bolster/data_sources/nisra/stillbirths.py
@@ -23,7 +23,7 @@ Example:
 
     >>> # Total stillbirths in 2024
     >>> total_2024 = df[df['year'] == 2024]['stillbirths'].sum()
-    >>> total_2024 >= 0
+    >>> bool(total_2024 >= 0)
     True
 """
 
@@ -295,7 +295,11 @@ def get_stillbirth_rate(
     if births_col is None:
         raise NISRAValidationError("Could not identify births count column in births DataFrame")
 
-    live = births_df[["date", births_col]].rename(columns={births_col: "live_births"})
+    # births_df has 'month' and a 'sex' column; filter to Persons and align on date
+    if "sex" in births_df.columns:
+        births_df = births_df[births_df["sex"] == "Persons"].copy()
+    date_col = "date" if "date" in births_df.columns else "month"
+    live = births_df[[date_col, births_col]].rename(columns={date_col: "date", births_col: "live_births"})
     merged = stillbirths_df.merge(live, on="date", how="inner")
     merged["total_births"] = merged["live_births"] + merged["stillbirths"]
     merged["stillbirth_rate"] = ((merged["stillbirths"] / merged["total_births"]) * 1000).round(2)

--- a/src/bolster/data_sources/nisra/stillbirths.py
+++ b/src/bolster/data_sources/nisra/stillbirths.py
@@ -18,9 +18,13 @@ Geographic Coverage: Northern Ireland (resident stillbirths)
 Example:
     >>> from bolster.data_sources.nisra import stillbirths
     >>> df = stillbirths.get_latest_stillbirths()
+    >>> sorted(df.columns.tolist())
+    ['date', 'month', 'stillbirths', 'year']
 
     >>> # Total stillbirths in 2024
     >>> total_2024 = df[df['year'] == 2024]['stillbirths'].sum()
+    >>> total_2024 >= 0
+    True
 """
 
 import logging
@@ -201,7 +205,11 @@ def get_latest_stillbirths(force_refresh: bool = False) -> pd.DataFrame:
 
     Example:
         >>> df = get_latest_stillbirths()
+        >>> sorted(df.columns.tolist())
+        ['date', 'month', 'stillbirths', 'year']
         >>> annual = df.groupby('year')['stillbirths'].sum()
+        >>> len(annual) > 0
+        True
     """
     excel_url = get_latest_stillbirths_publication_url()
     logger.info(f"Downloading stillbirths data from: {excel_url}")
@@ -253,6 +261,8 @@ def get_stillbirths_by_year(df: pd.DataFrame, year: int) -> pd.DataFrame:
     Example:
         >>> df = get_latest_stillbirths()
         >>> df_2024 = get_stillbirths_by_year(df, 2024)
+        >>> 'stillbirths' in df_2024.columns
+        True
     """
     return df[df["year"] == year].reset_index(drop=True)
 
@@ -304,6 +314,8 @@ def get_annual_summary(df: pd.DataFrame) -> pd.DataFrame:
     Example:
         >>> df = get_latest_stillbirths()
         >>> summary = get_annual_summary(df)
+        >>> sorted(summary.columns.tolist())
+        ['total_stillbirths', 'year', 'yoy_change', 'yoy_pct_change']
     """
     annual = df.groupby("year")["stillbirths"].sum().reset_index()
     annual = annual.rename(columns={"stillbirths": "total_stillbirths"})

--- a/src/bolster/data_sources/nisra/stillbirths.py
+++ b/src/bolster/data_sources/nisra/stillbirths.py
@@ -16,13 +16,13 @@ Update Frequency: Monthly (published ~6 weeks after reference month)
 Geographic Coverage: Northern Ireland (resident stillbirths)
 
 Example:
-    >>> from bolster.data_sources.nisra import stillbirths
-    >>> df = stillbirths.get_latest_stillbirths()
-    >>> print(df.head())
+    >>> from bolster.data_sources.nisra import stillbirths  # doctest: +SKIP
+    >>> df = stillbirths.get_latest_stillbirths()  # doctest: +SKIP
+    >>> print(df.head())  # doctest: +SKIP
 
     >>> # Total stillbirths in 2024
-    >>> total_2024 = df[df['year'] == 2024]['stillbirths'].sum()
-    >>> print(f"Stillbirths in 2024: {total_2024}")
+    >>> total_2024 = df[df['year'] == 2024]['stillbirths'].sum()  # doctest: +SKIP
+    >>> print(f"Stillbirths in 2024: {total_2024}")  # doctest: +SKIP
 """
 
 import logging
@@ -202,9 +202,9 @@ def get_latest_stillbirths(force_refresh: bool = False) -> pd.DataFrame:
         NISRAValidationError: If file structure is unexpected
 
     Example:
-        >>> df = get_latest_stillbirths()
-        >>> annual = df.groupby('year')['stillbirths'].sum()
-        >>> print(annual.tail())
+        >>> df = get_latest_stillbirths()  # doctest: +SKIP
+        >>> annual = df.groupby('year')['stillbirths'].sum()  # doctest: +SKIP
+        >>> print(annual.tail())  # doctest: +SKIP
     """
     excel_url = get_latest_stillbirths_publication_url()
     logger.info(f"Downloading stillbirths data from: {excel_url}")
@@ -254,9 +254,9 @@ def get_stillbirths_by_year(df: pd.DataFrame, year: int) -> pd.DataFrame:
         Filtered DataFrame
 
     Example:
-        >>> df = get_latest_stillbirths()
-        >>> df_2024 = get_stillbirths_by_year(df, 2024)
-        >>> print(df_2024['stillbirths'].sum())
+        >>> df = get_latest_stillbirths()  # doctest: +SKIP
+        >>> df_2024 = get_stillbirths_by_year(df, 2024)  # doctest: +SKIP
+        >>> print(df_2024['stillbirths'].sum())  # doctest: +SKIP
     """
     return df[df["year"] == year].reset_index(drop=True)
 
@@ -276,11 +276,11 @@ def get_stillbirth_rate(
         total_births, stillbirth_rate
 
     Example:
-        >>> from bolster.data_sources.nisra import stillbirths, births
-        >>> sb = stillbirths.get_latest_stillbirths()
-        >>> lb = births.get_latest_births(event_type='registration')
-        >>> rate = stillbirths.get_stillbirth_rate(sb, lb)
-        >>> print(rate[['year', 'month', 'stillbirth_rate']].tail(12))
+        >>> from bolster.data_sources.nisra import stillbirths, births  # doctest: +SKIP
+        >>> sb = stillbirths.get_latest_stillbirths()  # doctest: +SKIP
+        >>> lb = births.get_latest_births(event_type='registration')  # doctest: +SKIP
+        >>> rate = stillbirths.get_stillbirth_rate(sb, lb)  # doctest: +SKIP
+        >>> print(rate[['year', 'month', 'stillbirth_rate']].tail(12))  # doctest: +SKIP
     """
     # births_df has 'tests_conducted' or 'births_persons' depending on event_type
     births_col = next(
@@ -307,9 +307,9 @@ def get_annual_summary(df: pd.DataFrame) -> pd.DataFrame:
         DataFrame with columns: year, total_stillbirths, yoy_change, yoy_pct_change
 
     Example:
-        >>> df = get_latest_stillbirths()
-        >>> summary = get_annual_summary(df)
-        >>> print(summary.tail(5))
+        >>> df = get_latest_stillbirths()  # doctest: +SKIP
+        >>> summary = get_annual_summary(df)  # doctest: +SKIP
+        >>> print(summary.tail(5))  # doctest: +SKIP
     """
     annual = df.groupby("year")["stillbirths"].sum().reset_index()
     annual = annual.rename(columns={"stillbirths": "total_stillbirths"})

--- a/src/bolster/data_sources/nisra/tourism/__init__.py
+++ b/src/bolster/data_sources/nisra/tourism/__init__.py
@@ -11,18 +11,17 @@ and published under the Open Government Licence.
 
 Example:
     >>> from bolster.data_sources.nisra.tourism import occupancy
-    >>> # Get hotel occupancy rates
     >>> df = occupancy.get_latest_hotel_occupancy()
-    >>>
-    >>> # Get combined hotel + SSA data
+    >>> 'room_occupancy' in df.columns
+    True
     >>> df_combined = occupancy.get_combined_occupancy()
     >>> comparison = occupancy.compare_accommodation_types(df_combined)
-    >>>
+    >>> 'difference' in comparison.columns
+    True
     >>> from bolster.data_sources.nisra.tourism import visitor_statistics
-    >>> # Get visitor statistics by market
     >>> vs = visitor_statistics.get_latest_visitor_statistics()
-    >>> gb = vs[vs['market'] == 'Great Britain'].iloc[0]
-    >>> print(f"GB: {gb['trips']:,.0f} trips, £{gb['expenditure']:.1f}M spent")
+    >>> 'market' in vs.columns
+    True
 
 See individual module docstrings for detailed documentation.
 """

--- a/src/bolster/data_sources/nisra/tourism/__init__.py
+++ b/src/bolster/data_sources/nisra/tourism/__init__.py
@@ -10,21 +10,19 @@ All data is sourced from NISRA (Northern Ireland Statistics and Research Agency)
 and published under the Open Government Licence.
 
 Example:
-    >>> from bolster.data_sources.nisra.tourism import occupancy  # doctest: +SKIP
+    >>> from bolster.data_sources.nisra.tourism import occupancy
     >>> # Get hotel occupancy rates
-    >>> df = occupancy.get_latest_hotel_occupancy()  # doctest: +SKIP
-    >>> print(df.head())  # doctest: +SKIP
+    >>> df = occupancy.get_latest_hotel_occupancy()
     >>>
     >>> # Get combined hotel + SSA data
-    >>> df_combined = occupancy.get_combined_occupancy()  # doctest: +SKIP
-    >>> comparison = occupancy.compare_accommodation_types(df_combined)  # doctest: +SKIP
-    >>> print(comparison)  # doctest: +SKIP
+    >>> df_combined = occupancy.get_combined_occupancy()
+    >>> comparison = occupancy.compare_accommodation_types(df_combined)
     >>>
-    >>> from bolster.data_sources.nisra.tourism import visitor_statistics  # doctest: +SKIP
+    >>> from bolster.data_sources.nisra.tourism import visitor_statistics
     >>> # Get visitor statistics by market
-    >>> vs = visitor_statistics.get_latest_visitor_statistics()  # doctest: +SKIP
-    >>> gb = vs[vs['market'] == 'Great Britain'].iloc[0]  # doctest: +SKIP
-    >>> print(f"GB: {gb['trips']:,.0f} trips, £{gb['expenditure']:.1f}M spent")  # doctest: +SKIP
+    >>> vs = visitor_statistics.get_latest_visitor_statistics()
+    >>> gb = vs[vs['market'] == 'Great Britain'].iloc[0]
+    >>> print(f"GB: {gb['trips']:,.0f} trips, £{gb['expenditure']:.1f}M spent")
 
 See individual module docstrings for detailed documentation.
 """

--- a/src/bolster/data_sources/nisra/tourism/__init__.py
+++ b/src/bolster/data_sources/nisra/tourism/__init__.py
@@ -10,21 +10,21 @@ All data is sourced from NISRA (Northern Ireland Statistics and Research Agency)
 and published under the Open Government Licence.
 
 Example:
-    >>> from bolster.data_sources.nisra.tourism import occupancy
+    >>> from bolster.data_sources.nisra.tourism import occupancy  # doctest: +SKIP
     >>> # Get hotel occupancy rates
-    >>> df = occupancy.get_latest_hotel_occupancy()
-    >>> print(df.head())
+    >>> df = occupancy.get_latest_hotel_occupancy()  # doctest: +SKIP
+    >>> print(df.head())  # doctest: +SKIP
     >>>
     >>> # Get combined hotel + SSA data
-    >>> df_combined = occupancy.get_combined_occupancy()
-    >>> comparison = occupancy.compare_accommodation_types(df_combined)
-    >>> print(comparison)
+    >>> df_combined = occupancy.get_combined_occupancy()  # doctest: +SKIP
+    >>> comparison = occupancy.compare_accommodation_types(df_combined)  # doctest: +SKIP
+    >>> print(comparison)  # doctest: +SKIP
     >>>
-    >>> from bolster.data_sources.nisra.tourism import visitor_statistics
+    >>> from bolster.data_sources.nisra.tourism import visitor_statistics  # doctest: +SKIP
     >>> # Get visitor statistics by market
-    >>> vs = visitor_statistics.get_latest_visitor_statistics()
-    >>> gb = vs[vs['market'] == 'Great Britain'].iloc[0]
-    >>> print(f"GB: {gb['trips']:,.0f} trips, £{gb['expenditure']:.1f}M spent")
+    >>> vs = visitor_statistics.get_latest_visitor_statistics()  # doctest: +SKIP
+    >>> gb = vs[vs['market'] == 'Great Britain'].iloc[0]  # doctest: +SKIP
+    >>> print(f"GB: {gb['trips']:,.0f} trips, £{gb['expenditure']:.1f}M spent")  # doctest: +SKIP
 
 See individual module docstrings for detailed documentation.
 """

--- a/src/bolster/data_sources/nisra/tourism/occupancy.py
+++ b/src/bolster/data_sources/nisra/tourism/occupancy.py
@@ -610,11 +610,11 @@ def parse_ssa_occupancy_rates(file_path: str | Path) -> pd.DataFrame:
         # SSA files have trailing space on some sheet names
         # Try both "Table 1" and "Table 1 "
         sheet_name = None
-        xl = pd.ExcelFile(file_path)
-        for name in xl.sheet_names:
-            if name.strip() == "Table 1":
-                sheet_name = name
-                break
+        with pd.ExcelFile(file_path) as xl:
+            for name in xl.sheet_names:
+                if name.strip() == "Table 1":
+                    sheet_name = name
+                    break
 
         if not sheet_name:
             raise NISRAValidationError("Could not find Table 1 in SSA file")

--- a/src/bolster/data_sources/nisra/tourism/occupancy.py
+++ b/src/bolster/data_sources/nisra/tourism/occupancy.py
@@ -24,22 +24,22 @@ Geographic Coverage: Northern Ireland
 Reference Date: Month of survey
 
 Example:
-    >>> from bolster.data_sources.nisra.tourism import occupancy
+    >>> from bolster.data_sources.nisra.tourism import occupancy  # doctest: +SKIP
     >>> # Get latest hotel occupancy rates
-    >>> df = occupancy.get_latest_hotel_occupancy()
-    >>> print(df.head())
+    >>> df = occupancy.get_latest_hotel_occupancy()  # doctest: +SKIP
+    >>> print(df.head())  # doctest: +SKIP
 
     >>> # Get rooms/beds sold
-    >>> df_sold = occupancy.get_latest_rooms_beds_sold()
-    >>> print(f"Total rooms sold in 2024: {df_sold[df_sold['year']==2024]['rooms_sold'].sum():,.0f}")
+    >>> df_sold = occupancy.get_latest_rooms_beds_sold()  # doctest: +SKIP
+    >>> print(f"Total rooms sold in 2024: {df_sold[df_sold['year']==2024]['rooms_sold'].sum():,.0f}")  # doctest: +SKIP
 
     >>> # Get SSA (B&B/guest house) occupancy rates
-    >>> df_ssa = occupancy.get_latest_ssa_occupancy()
-    >>> print(df_ssa.head())
+    >>> df_ssa = occupancy.get_latest_ssa_occupancy()  # doctest: +SKIP
+    >>> print(df_ssa.head())  # doctest: +SKIP
 
     >>> # Compare hotel vs SSA occupancy
-    >>> df_combined = occupancy.get_combined_occupancy()
-    >>> print(df_combined.groupby('accommodation_type')['room_occupancy'].mean())
+    >>> df_combined = occupancy.get_combined_occupancy()  # doctest: +SKIP
+    >>> print(df_combined.groupby('accommodation_type')['room_occupancy'].mean())  # doctest: +SKIP
 """
 
 import logging
@@ -542,10 +542,10 @@ def get_latest_hotel_occupancy(force_refresh: bool = False) -> pd.DataFrame:
         NISRAValidationError: If file structure is unexpected
 
     Example:
-        >>> df = get_latest_hotel_occupancy()
+        >>> df = get_latest_hotel_occupancy()  # doctest: +SKIP
         >>> # Get 2024 average occupancy
-        >>> avg_2024 = df[df['year'] == 2024]['room_occupancy'].mean()
-        >>> print(f"2024 average room occupancy: {avg_2024:.1%}")
+        >>> avg_2024 = df[df['year'] == 2024]['room_occupancy'].mean()  # doctest: +SKIP
+        >>> print(f"2024 average room occupancy: {avg_2024:.1%}")  # doctest: +SKIP
     """
     excel_url, pub_date = get_latest_hotel_occupancy_publication_url()
 
@@ -573,9 +573,9 @@ def get_latest_rooms_beds_sold(force_refresh: bool = False) -> pd.DataFrame:
             - beds_sold: float (number of beds sold)
 
     Example:
-        >>> df = get_latest_rooms_beds_sold()
-        >>> total_2024 = df[df['year'] == 2024]['rooms_sold'].sum()
-        >>> print(f"Total rooms sold in 2024: {total_2024:,.0f}")
+        >>> df = get_latest_rooms_beds_sold()  # doctest: +SKIP
+        >>> total_2024 = df[df['year'] == 2024]['rooms_sold'].sum()  # doctest: +SKIP
+        >>> print(f"Total rooms sold in 2024: {total_2024:,.0f}")  # doctest: +SKIP
     """
     excel_url, pub_date = get_latest_hotel_occupancy_publication_url()
 
@@ -881,10 +881,10 @@ def get_latest_ssa_occupancy(force_refresh: bool = False) -> pd.DataFrame:
         NISRAValidationError: If file structure is unexpected
 
     Example:
-        >>> df = get_latest_ssa_occupancy()
+        >>> df = get_latest_ssa_occupancy()  # doctest: +SKIP
         >>> # Get 2024 average occupancy for B&Bs
-        >>> avg_2024 = df[df['year'] == 2024]['room_occupancy'].mean()
-        >>> print(f"2024 average SSA room occupancy: {avg_2024:.1%}")
+        >>> avg_2024 = df[df['year'] == 2024]['room_occupancy'].mean()  # doctest: +SKIP
+        >>> print(f"2024 average SSA room occupancy: {avg_2024:.1%}")  # doctest: +SKIP
     """
     excel_url, pub_date = get_latest_ssa_occupancy_publication_url()
 
@@ -914,9 +914,9 @@ def get_latest_ssa_rooms_beds_sold(force_refresh: bool = False) -> pd.DataFrame:
             - beds_sold: float (number of beds sold)
 
     Example:
-        >>> df = get_latest_ssa_rooms_beds_sold()
-        >>> total_2024 = df[df['year'] == 2024]['rooms_sold'].sum()
-        >>> print(f"Total SSA rooms sold in 2024: {total_2024:,.0f}")
+        >>> df = get_latest_ssa_rooms_beds_sold()  # doctest: +SKIP
+        >>> total_2024 = df[df['year'] == 2024]['rooms_sold'].sum()  # doctest: +SKIP
+        >>> print(f"Total SSA rooms sold in 2024: {total_2024:,.0f}")  # doctest: +SKIP
     """
     excel_url, pub_date = get_latest_ssa_occupancy_publication_url()
 
@@ -953,9 +953,9 @@ def get_combined_occupancy(force_refresh: bool = False) -> pd.DataFrame:
             - accommodation_type: str ('hotel' or 'ssa')
 
     Example:
-        >>> df = get_combined_occupancy()
+        >>> df = get_combined_occupancy()  # doctest: +SKIP
         >>> # Compare hotel vs SSA occupancy by year
-        >>> df.groupby(['year', 'accommodation_type'])['room_occupancy'].mean()
+        >>> df.groupby(['year', 'accommodation_type'])['room_occupancy'].mean()  # doctest: +SKIP
     """
     hotel_df = get_latest_hotel_occupancy(force_refresh=force_refresh)
     hotel_df["accommodation_type"] = "hotel"
@@ -989,10 +989,10 @@ def compare_accommodation_types(
             - ratio: float (hotel / ssa)
 
     Example:
-        >>> df = get_combined_occupancy()
-        >>> comparison = compare_accommodation_types(df)
+        >>> df = get_combined_occupancy()  # doctest: +SKIP
+        >>> comparison = compare_accommodation_types(df)  # doctest: +SKIP
         >>> # Hotels typically have higher occupancy than B&Bs
-        >>> print(comparison[['year', 'hotel_room_occupancy', 'ssa_room_occupancy', 'difference']])
+        >>> print(comparison[['year', 'hotel_room_occupancy', 'ssa_room_occupancy', 'difference']])  # doctest: +SKIP
     """
     pivot = df.pivot_table(
         index="year",
@@ -1061,11 +1061,11 @@ def get_seasonal_patterns(df: pd.DataFrame) -> pd.DataFrame:
             - avg_bed_occupancy: float
 
     Example:
-        >>> df = get_latest_hotel_occupancy()
-        >>> seasonal = get_seasonal_patterns(df)
+        >>> df = get_latest_hotel_occupancy()  # doctest: +SKIP
+        >>> seasonal = get_seasonal_patterns(df)  # doctest: +SKIP
         >>> # Find peak season
-        >>> peak = seasonal.loc[seasonal['avg_room_occupancy'].idxmax()]
-        >>> print(f"Peak month: {peak['month']} ({peak['avg_room_occupancy']:.1%})")
+        >>> peak = seasonal.loc[seasonal['avg_room_occupancy'].idxmax()]  # doctest: +SKIP
+        >>> print(f"Peak month: {peak['month']} ({peak['avg_room_occupancy']:.1%})")  # doctest: +SKIP
     """
     month_order = [
         "January",

--- a/src/bolster/data_sources/nisra/tourism/occupancy.py
+++ b/src/bolster/data_sources/nisra/tourism/occupancy.py
@@ -25,17 +25,15 @@ Reference Date: Month of survey
 
 Example:
     >>> from bolster.data_sources.nisra.tourism import occupancy
-    >>> # Get latest hotel occupancy rates
     >>> df = occupancy.get_latest_hotel_occupancy()
-
-    >>> # Get rooms/beds sold
+    >>> 'room_occupancy' in df.columns
+    True
     >>> df_sold = occupancy.get_latest_rooms_beds_sold()
-
-    >>> # Get SSA (B&B/guest house) occupancy rates
-    >>> df_ssa = occupancy.get_latest_ssa_occupancy()
-
-    >>> # Compare hotel vs SSA occupancy
+    >>> 'rooms_sold' in df_sold.columns
+    True
     >>> df_combined = occupancy.get_combined_occupancy()
+    >>> 'accommodation_type' in df_combined.columns
+    True
 """
 
 import logging
@@ -539,8 +537,8 @@ def get_latest_hotel_occupancy(force_refresh: bool = False) -> pd.DataFrame:
 
     Example:
         >>> df = get_latest_hotel_occupancy()
-        >>> # Get 2024 average occupancy
-        >>> avg_2024 = df[df['year'] == 2024]['room_occupancy'].mean()
+        >>> 'room_occupancy' in df.columns
+        True
     """
     excel_url, pub_date = get_latest_hotel_occupancy_publication_url()
 
@@ -569,7 +567,8 @@ def get_latest_rooms_beds_sold(force_refresh: bool = False) -> pd.DataFrame:
 
     Example:
         >>> df = get_latest_rooms_beds_sold()
-        >>> total_2024 = df[df['year'] == 2024]['rooms_sold'].sum()
+        >>> 'rooms_sold' in df.columns
+        True
     """
     excel_url, pub_date = get_latest_hotel_occupancy_publication_url()
 
@@ -876,8 +875,8 @@ def get_latest_ssa_occupancy(force_refresh: bool = False) -> pd.DataFrame:
 
     Example:
         >>> df = get_latest_ssa_occupancy()
-        >>> # Get 2024 average occupancy for B&Bs
-        >>> avg_2024 = df[df['year'] == 2024]['room_occupancy'].mean()
+        >>> 'room_occupancy' in df.columns
+        True
     """
     excel_url, pub_date = get_latest_ssa_occupancy_publication_url()
 
@@ -908,7 +907,8 @@ def get_latest_ssa_rooms_beds_sold(force_refresh: bool = False) -> pd.DataFrame:
 
     Example:
         >>> df = get_latest_ssa_rooms_beds_sold()
-        >>> total_2024 = df[df['year'] == 2024]['rooms_sold'].sum()
+        >>> 'rooms_sold' in df.columns
+        True
     """
     excel_url, pub_date = get_latest_ssa_occupancy_publication_url()
 
@@ -946,8 +946,8 @@ def get_combined_occupancy(force_refresh: bool = False) -> pd.DataFrame:
 
     Example:
         >>> df = get_combined_occupancy()
-        >>> # Compare hotel vs SSA occupancy by year
-        >>> df.groupby(['year', 'accommodation_type'])['room_occupancy'].mean()
+        >>> 'accommodation_type' in df.columns
+        True
     """
     hotel_df = get_latest_hotel_occupancy(force_refresh=force_refresh)
     hotel_df["accommodation_type"] = "hotel"
@@ -983,7 +983,8 @@ def compare_accommodation_types(
     Example:
         >>> df = get_combined_occupancy()
         >>> comparison = compare_accommodation_types(df)
-        >>> # Hotels typically have higher occupancy than B&Bs
+        >>> 'difference' in comparison.columns
+        True
     """
     pivot = df.pivot_table(
         index="year",
@@ -1054,8 +1055,8 @@ def get_seasonal_patterns(df: pd.DataFrame) -> pd.DataFrame:
     Example:
         >>> df = get_latest_hotel_occupancy()
         >>> seasonal = get_seasonal_patterns(df)
-        >>> # Find peak season
-        >>> peak = seasonal.loc[seasonal['avg_room_occupancy'].idxmax()]
+        >>> 'avg_room_occupancy' in seasonal.columns
+        True
     """
     month_order = [
         "January",

--- a/src/bolster/data_sources/nisra/tourism/occupancy.py
+++ b/src/bolster/data_sources/nisra/tourism/occupancy.py
@@ -24,22 +24,18 @@ Geographic Coverage: Northern Ireland
 Reference Date: Month of survey
 
 Example:
-    >>> from bolster.data_sources.nisra.tourism import occupancy  # doctest: +SKIP
+    >>> from bolster.data_sources.nisra.tourism import occupancy
     >>> # Get latest hotel occupancy rates
-    >>> df = occupancy.get_latest_hotel_occupancy()  # doctest: +SKIP
-    >>> print(df.head())  # doctest: +SKIP
+    >>> df = occupancy.get_latest_hotel_occupancy()
 
     >>> # Get rooms/beds sold
-    >>> df_sold = occupancy.get_latest_rooms_beds_sold()  # doctest: +SKIP
-    >>> print(f"Total rooms sold in 2024: {df_sold[df_sold['year']==2024]['rooms_sold'].sum():,.0f}")  # doctest: +SKIP
+    >>> df_sold = occupancy.get_latest_rooms_beds_sold()
 
     >>> # Get SSA (B&B/guest house) occupancy rates
-    >>> df_ssa = occupancy.get_latest_ssa_occupancy()  # doctest: +SKIP
-    >>> print(df_ssa.head())  # doctest: +SKIP
+    >>> df_ssa = occupancy.get_latest_ssa_occupancy()
 
     >>> # Compare hotel vs SSA occupancy
-    >>> df_combined = occupancy.get_combined_occupancy()  # doctest: +SKIP
-    >>> print(df_combined.groupby('accommodation_type')['room_occupancy'].mean())  # doctest: +SKIP
+    >>> df_combined = occupancy.get_combined_occupancy()
 """
 
 import logging
@@ -542,10 +538,9 @@ def get_latest_hotel_occupancy(force_refresh: bool = False) -> pd.DataFrame:
         NISRAValidationError: If file structure is unexpected
 
     Example:
-        >>> df = get_latest_hotel_occupancy()  # doctest: +SKIP
+        >>> df = get_latest_hotel_occupancy()
         >>> # Get 2024 average occupancy
-        >>> avg_2024 = df[df['year'] == 2024]['room_occupancy'].mean()  # doctest: +SKIP
-        >>> print(f"2024 average room occupancy: {avg_2024:.1%}")  # doctest: +SKIP
+        >>> avg_2024 = df[df['year'] == 2024]['room_occupancy'].mean()
     """
     excel_url, pub_date = get_latest_hotel_occupancy_publication_url()
 
@@ -573,9 +568,8 @@ def get_latest_rooms_beds_sold(force_refresh: bool = False) -> pd.DataFrame:
             - beds_sold: float (number of beds sold)
 
     Example:
-        >>> df = get_latest_rooms_beds_sold()  # doctest: +SKIP
-        >>> total_2024 = df[df['year'] == 2024]['rooms_sold'].sum()  # doctest: +SKIP
-        >>> print(f"Total rooms sold in 2024: {total_2024:,.0f}")  # doctest: +SKIP
+        >>> df = get_latest_rooms_beds_sold()
+        >>> total_2024 = df[df['year'] == 2024]['rooms_sold'].sum()
     """
     excel_url, pub_date = get_latest_hotel_occupancy_publication_url()
 
@@ -881,10 +875,9 @@ def get_latest_ssa_occupancy(force_refresh: bool = False) -> pd.DataFrame:
         NISRAValidationError: If file structure is unexpected
 
     Example:
-        >>> df = get_latest_ssa_occupancy()  # doctest: +SKIP
+        >>> df = get_latest_ssa_occupancy()
         >>> # Get 2024 average occupancy for B&Bs
-        >>> avg_2024 = df[df['year'] == 2024]['room_occupancy'].mean()  # doctest: +SKIP
-        >>> print(f"2024 average SSA room occupancy: {avg_2024:.1%}")  # doctest: +SKIP
+        >>> avg_2024 = df[df['year'] == 2024]['room_occupancy'].mean()
     """
     excel_url, pub_date = get_latest_ssa_occupancy_publication_url()
 
@@ -914,9 +907,8 @@ def get_latest_ssa_rooms_beds_sold(force_refresh: bool = False) -> pd.DataFrame:
             - beds_sold: float (number of beds sold)
 
     Example:
-        >>> df = get_latest_ssa_rooms_beds_sold()  # doctest: +SKIP
-        >>> total_2024 = df[df['year'] == 2024]['rooms_sold'].sum()  # doctest: +SKIP
-        >>> print(f"Total SSA rooms sold in 2024: {total_2024:,.0f}")  # doctest: +SKIP
+        >>> df = get_latest_ssa_rooms_beds_sold()
+        >>> total_2024 = df[df['year'] == 2024]['rooms_sold'].sum()
     """
     excel_url, pub_date = get_latest_ssa_occupancy_publication_url()
 
@@ -953,9 +945,9 @@ def get_combined_occupancy(force_refresh: bool = False) -> pd.DataFrame:
             - accommodation_type: str ('hotel' or 'ssa')
 
     Example:
-        >>> df = get_combined_occupancy()  # doctest: +SKIP
+        >>> df = get_combined_occupancy()
         >>> # Compare hotel vs SSA occupancy by year
-        >>> df.groupby(['year', 'accommodation_type'])['room_occupancy'].mean()  # doctest: +SKIP
+        >>> df.groupby(['year', 'accommodation_type'])['room_occupancy'].mean()
     """
     hotel_df = get_latest_hotel_occupancy(force_refresh=force_refresh)
     hotel_df["accommodation_type"] = "hotel"
@@ -989,10 +981,9 @@ def compare_accommodation_types(
             - ratio: float (hotel / ssa)
 
     Example:
-        >>> df = get_combined_occupancy()  # doctest: +SKIP
-        >>> comparison = compare_accommodation_types(df)  # doctest: +SKIP
+        >>> df = get_combined_occupancy()
+        >>> comparison = compare_accommodation_types(df)
         >>> # Hotels typically have higher occupancy than B&Bs
-        >>> print(comparison[['year', 'hotel_room_occupancy', 'ssa_room_occupancy', 'difference']])  # doctest: +SKIP
     """
     pivot = df.pivot_table(
         index="year",
@@ -1061,11 +1052,10 @@ def get_seasonal_patterns(df: pd.DataFrame) -> pd.DataFrame:
             - avg_bed_occupancy: float
 
     Example:
-        >>> df = get_latest_hotel_occupancy()  # doctest: +SKIP
-        >>> seasonal = get_seasonal_patterns(df)  # doctest: +SKIP
+        >>> df = get_latest_hotel_occupancy()
+        >>> seasonal = get_seasonal_patterns(df)
         >>> # Find peak season
-        >>> peak = seasonal.loc[seasonal['avg_room_occupancy'].idxmax()]  # doctest: +SKIP
-        >>> print(f"Peak month: {peak['month']} ({peak['avg_room_occupancy']:.1%})")  # doctest: +SKIP
+        >>> peak = seasonal.loc[seasonal['avg_room_occupancy'].idxmax()]
     """
     month_order = [
         "January",

--- a/src/bolster/data_sources/nisra/tourism/visitor_statistics.py
+++ b/src/bolster/data_sources/nisra/tourism/visitor_statistics.py
@@ -27,18 +27,15 @@ Geographic Coverage: Northern Ireland (by visitor origin market)
 Reference Period: Rolling 12-month and year-to-date
 
 Example:
-    >>> from bolster.data_sources.nisra.tourism import visitor_statistics  # doctest: +SKIP
+    >>> from bolster.data_sources.nisra.tourism import visitor_statistics
     >>> # Get latest visitor statistics by market
-    >>> df = visitor_statistics.get_latest_visitor_statistics()  # doctest: +SKIP
-    >>> print(df.head())  # doctest: +SKIP
+    >>> df = visitor_statistics.get_latest_visitor_statistics()
 
     >>> # Get trips from Great Britain
-    >>> gb_trips = df[df['market'] == 'Great Britain']['trips'].values[0]  # doctest: +SKIP
-    >>> print(f"GB trips (12-month): {gb_trips:,.0f}")  # doctest: +SKIP
+    >>> gb_trips = df[df['market'] == 'Great Britain']['trips'].values[0]
 
     >>> # Get total expenditure
-    >>> total_spend = df['expenditure'].sum()  # doctest: +SKIP
-    >>> print(f"Total visitor spend: £{total_spend:.1f}M")  # doctest: +SKIP
+    >>> total_spend = df['expenditure'].sum()
 """
 
 import logging
@@ -317,9 +314,8 @@ def get_latest_visitor_statistics(
         NISRAValidationError: If data parsing fails
 
     Example:
-        >>> df = get_latest_visitor_statistics()  # doctest: +SKIP
-        >>> gb = df[df['market'] == 'Great Britain'].iloc[0]  # doctest: +SKIP
-        >>> print(f"GB: {gb['trips']:,.0f} trips, £{gb['expenditure']:.1f}M spent")  # doctest: +SKIP
+        >>> df = get_latest_visitor_statistics()
+        >>> gb = df[df['market'] == 'Great Britain'].iloc[0]
     """
     excel_url, pub_period = get_latest_visitor_statistics_publication_url()
 
@@ -383,10 +379,9 @@ def get_visitor_statistics_by_market(df: pd.DataFrame, market: str) -> pd.Series
         Series with statistics for the market, or None if not found
 
     Example:
-        >>> df = get_latest_visitor_statistics()  # doctest: +SKIP
-        >>> gb = get_visitor_statistics_by_market(df, "Great Britain")  # doctest: +SKIP
-        >>> if gb is not None:  # doctest: +SKIP
-        ...     print(f"GB trips: {gb['trips']:,.0f}")  # doctest: +SKIP
+        >>> df = get_latest_visitor_statistics()
+        >>> gb = get_visitor_statistics_by_market(df, "Great Britain")
+        >>> if gb is not None:
     """
     matches = df[df["market"].str.lower() == market.lower()]
     if matches.empty:
@@ -416,9 +411,8 @@ def get_domestic_vs_external(df: pd.DataFrame) -> pd.DataFrame:
         DataFrame with domestic and external totals and percentages
 
     Example:
-        >>> df = get_latest_visitor_statistics()  # doctest: +SKIP
-        >>> comparison = get_domestic_vs_external(df)  # doctest: +SKIP
-        >>> print(comparison)  # doctest: +SKIP
+        >>> df = get_latest_visitor_statistics()
+        >>> comparison = get_domestic_vs_external(df)
     """
     domestic = df[df["market"] == "NI Residents"]
     external = df[~df["market"].isin(["NI Residents", "Total"])]
@@ -468,9 +462,8 @@ def get_expenditure_per_trip(df: pd.DataFrame) -> pd.DataFrame:
         DataFrame with market and expenditure_per_trip columns
 
     Example:
-        >>> df = get_latest_visitor_statistics()  # doctest: +SKIP
-        >>> spend = get_expenditure_per_trip(df)  # doctest: +SKIP
-        >>> print(spend.sort_values('expenditure_per_trip', ascending=False))  # doctest: +SKIP
+        >>> df = get_latest_visitor_statistics()
+        >>> spend = get_expenditure_per_trip(df)
     """
     result = df[df["market"] != "Total"].copy()
     # Expenditure is in millions, trips are individual
@@ -488,9 +481,8 @@ def get_nights_per_trip(df: pd.DataFrame) -> pd.DataFrame:
         DataFrame with market and nights_per_trip columns
 
     Example:
-        >>> df = get_latest_visitor_statistics()  # doctest: +SKIP
-        >>> duration = get_nights_per_trip(df)  # doctest: +SKIP
-        >>> print(duration.sort_values('nights_per_trip', ascending=False))  # doctest: +SKIP
+        >>> df = get_latest_visitor_statistics()
+        >>> duration = get_nights_per_trip(df)
     """
     result = df[df["market"] != "Total"].copy()
     result["nights_per_trip"] = (result["nights"] / result["trips"]).round(2)
@@ -507,9 +499,8 @@ def get_market_summary(df: pd.DataFrame) -> pd.DataFrame:
         DataFrame with market summary including percentages and per-trip metrics
 
     Example:
-        >>> df = get_latest_visitor_statistics()  # doctest: +SKIP
-        >>> summary = get_market_summary(df)  # doctest: +SKIP
-        >>> print(summary)  # doctest: +SKIP
+        >>> df = get_latest_visitor_statistics()
+        >>> summary = get_market_summary(df)
     """
     total = get_total_visitor_statistics(df)
     if total is None:

--- a/src/bolster/data_sources/nisra/tourism/visitor_statistics.py
+++ b/src/bolster/data_sources/nisra/tourism/visitor_statistics.py
@@ -27,18 +27,18 @@ Geographic Coverage: Northern Ireland (by visitor origin market)
 Reference Period: Rolling 12-month and year-to-date
 
 Example:
-    >>> from bolster.data_sources.nisra.tourism import visitor_statistics
+    >>> from bolster.data_sources.nisra.tourism import visitor_statistics  # doctest: +SKIP
     >>> # Get latest visitor statistics by market
-    >>> df = visitor_statistics.get_latest_visitor_statistics()
-    >>> print(df.head())
+    >>> df = visitor_statistics.get_latest_visitor_statistics()  # doctest: +SKIP
+    >>> print(df.head())  # doctest: +SKIP
 
     >>> # Get trips from Great Britain
-    >>> gb_trips = df[df['market'] == 'Great Britain']['trips'].values[0]
-    >>> print(f"GB trips (12-month): {gb_trips:,.0f}")
+    >>> gb_trips = df[df['market'] == 'Great Britain']['trips'].values[0]  # doctest: +SKIP
+    >>> print(f"GB trips (12-month): {gb_trips:,.0f}")  # doctest: +SKIP
 
     >>> # Get total expenditure
-    >>> total_spend = df['expenditure'].sum()
-    >>> print(f"Total visitor spend: £{total_spend:.1f}M")
+    >>> total_spend = df['expenditure'].sum()  # doctest: +SKIP
+    >>> print(f"Total visitor spend: £{total_spend:.1f}M")  # doctest: +SKIP
 """
 
 import logging
@@ -317,9 +317,9 @@ def get_latest_visitor_statistics(
         NISRAValidationError: If data parsing fails
 
     Example:
-        >>> df = get_latest_visitor_statistics()
-        >>> gb = df[df['market'] == 'Great Britain'].iloc[0]
-        >>> print(f"GB: {gb['trips']:,.0f} trips, £{gb['expenditure']:.1f}M spent")
+        >>> df = get_latest_visitor_statistics()  # doctest: +SKIP
+        >>> gb = df[df['market'] == 'Great Britain'].iloc[0]  # doctest: +SKIP
+        >>> print(f"GB: {gb['trips']:,.0f} trips, £{gb['expenditure']:.1f}M spent")  # doctest: +SKIP
     """
     excel_url, pub_period = get_latest_visitor_statistics_publication_url()
 
@@ -383,10 +383,10 @@ def get_visitor_statistics_by_market(df: pd.DataFrame, market: str) -> pd.Series
         Series with statistics for the market, or None if not found
 
     Example:
-        >>> df = get_latest_visitor_statistics()
-        >>> gb = get_visitor_statistics_by_market(df, "Great Britain")
-        >>> if gb is not None:
-        ...     print(f"GB trips: {gb['trips']:,.0f}")
+        >>> df = get_latest_visitor_statistics()  # doctest: +SKIP
+        >>> gb = get_visitor_statistics_by_market(df, "Great Britain")  # doctest: +SKIP
+        >>> if gb is not None:  # doctest: +SKIP
+        ...     print(f"GB trips: {gb['trips']:,.0f}")  # doctest: +SKIP
     """
     matches = df[df["market"].str.lower() == market.lower()]
     if matches.empty:
@@ -416,9 +416,9 @@ def get_domestic_vs_external(df: pd.DataFrame) -> pd.DataFrame:
         DataFrame with domestic and external totals and percentages
 
     Example:
-        >>> df = get_latest_visitor_statistics()
-        >>> comparison = get_domestic_vs_external(df)
-        >>> print(comparison)
+        >>> df = get_latest_visitor_statistics()  # doctest: +SKIP
+        >>> comparison = get_domestic_vs_external(df)  # doctest: +SKIP
+        >>> print(comparison)  # doctest: +SKIP
     """
     domestic = df[df["market"] == "NI Residents"]
     external = df[~df["market"].isin(["NI Residents", "Total"])]
@@ -468,9 +468,9 @@ def get_expenditure_per_trip(df: pd.DataFrame) -> pd.DataFrame:
         DataFrame with market and expenditure_per_trip columns
 
     Example:
-        >>> df = get_latest_visitor_statistics()
-        >>> spend = get_expenditure_per_trip(df)
-        >>> print(spend.sort_values('expenditure_per_trip', ascending=False))
+        >>> df = get_latest_visitor_statistics()  # doctest: +SKIP
+        >>> spend = get_expenditure_per_trip(df)  # doctest: +SKIP
+        >>> print(spend.sort_values('expenditure_per_trip', ascending=False))  # doctest: +SKIP
     """
     result = df[df["market"] != "Total"].copy()
     # Expenditure is in millions, trips are individual
@@ -488,9 +488,9 @@ def get_nights_per_trip(df: pd.DataFrame) -> pd.DataFrame:
         DataFrame with market and nights_per_trip columns
 
     Example:
-        >>> df = get_latest_visitor_statistics()
-        >>> duration = get_nights_per_trip(df)
-        >>> print(duration.sort_values('nights_per_trip', ascending=False))
+        >>> df = get_latest_visitor_statistics()  # doctest: +SKIP
+        >>> duration = get_nights_per_trip(df)  # doctest: +SKIP
+        >>> print(duration.sort_values('nights_per_trip', ascending=False))  # doctest: +SKIP
     """
     result = df[df["market"] != "Total"].copy()
     result["nights_per_trip"] = (result["nights"] / result["trips"]).round(2)
@@ -507,9 +507,9 @@ def get_market_summary(df: pd.DataFrame) -> pd.DataFrame:
         DataFrame with market summary including percentages and per-trip metrics
 
     Example:
-        >>> df = get_latest_visitor_statistics()
-        >>> summary = get_market_summary(df)
-        >>> print(summary)
+        >>> df = get_latest_visitor_statistics()  # doctest: +SKIP
+        >>> summary = get_market_summary(df)  # doctest: +SKIP
+        >>> print(summary)  # doctest: +SKIP
     """
     total = get_total_visitor_statistics(df)
     if total is None:

--- a/src/bolster/data_sources/nisra/tourism/visitor_statistics.py
+++ b/src/bolster/data_sources/nisra/tourism/visitor_statistics.py
@@ -28,14 +28,11 @@ Reference Period: Rolling 12-month and year-to-date
 
 Example:
     >>> from bolster.data_sources.nisra.tourism import visitor_statistics
-    >>> # Get latest visitor statistics by market
     >>> df = visitor_statistics.get_latest_visitor_statistics()
-
-    >>> # Get trips from Great Britain
-    >>> gb_trips = df[df['market'] == 'Great Britain']['trips'].values[0]
-
-    >>> # Get total expenditure
-    >>> total_spend = df['expenditure'].sum()
+    >>> 'market' in df.columns
+    True
+    >>> 'expenditure' in df.columns
+    True
 """
 
 import logging
@@ -315,7 +312,8 @@ def get_latest_visitor_statistics(
 
     Example:
         >>> df = get_latest_visitor_statistics()
-        >>> gb = df[df['market'] == 'Great Britain'].iloc[0]
+        >>> 'market' in df.columns
+        True
     """
     excel_url, pub_period = get_latest_visitor_statistics_publication_url()
 
@@ -381,7 +379,8 @@ def get_visitor_statistics_by_market(df: pd.DataFrame, market: str) -> pd.Series
     Example:
         >>> df = get_latest_visitor_statistics()
         >>> gb = get_visitor_statistics_by_market(df, "Great Britain")
-        >>> if gb is not None:
+        >>> gb is not None
+        True
     """
     matches = df[df["market"].str.lower() == market.lower()]
     if matches.empty:
@@ -413,6 +412,8 @@ def get_domestic_vs_external(df: pd.DataFrame) -> pd.DataFrame:
     Example:
         >>> df = get_latest_visitor_statistics()
         >>> comparison = get_domestic_vs_external(df)
+        >>> 'category' in comparison.columns
+        True
     """
     domestic = df[df["market"] == "NI Residents"]
     external = df[~df["market"].isin(["NI Residents", "Total"])]
@@ -464,6 +465,8 @@ def get_expenditure_per_trip(df: pd.DataFrame) -> pd.DataFrame:
     Example:
         >>> df = get_latest_visitor_statistics()
         >>> spend = get_expenditure_per_trip(df)
+        >>> 'expenditure_per_trip' in spend.columns
+        True
     """
     result = df[df["market"] != "Total"].copy()
     # Expenditure is in millions, trips are individual
@@ -483,6 +486,8 @@ def get_nights_per_trip(df: pd.DataFrame) -> pd.DataFrame:
     Example:
         >>> df = get_latest_visitor_statistics()
         >>> duration = get_nights_per_trip(df)
+        >>> 'nights_per_trip' in duration.columns
+        True
     """
     result = df[df["market"] != "Total"].copy()
     result["nights_per_trip"] = (result["nights"] / result["trips"]).round(2)
@@ -501,6 +506,8 @@ def get_market_summary(df: pd.DataFrame) -> pd.DataFrame:
     Example:
         >>> df = get_latest_visitor_statistics()
         >>> summary = get_market_summary(df)
+        >>> 'market' in summary.columns
+        True
     """
     total = get_total_visitor_statistics(df)
     if total is None:

--- a/src/bolster/data_sources/nisra/wellbeing.py
+++ b/src/bolster/data_sources/nisra/wellbeing.py
@@ -175,7 +175,11 @@ def parse_personal_wellbeing(file_path: str | Path) -> pd.DataFrame:
             - anxiety: float (mean score 0-10, lower is better)
 
     Example:
-        >>> df = parse_personal_wellbeing("individual-wellbeing-ni-202425-data-tables.xlsx")
+        >>> _, year = get_latest_wellbeing_publication_url()
+        >>> path = download_file(get_wellbeing_file_url(year), cache_ttl_hours=90*24)
+        >>> df = parse_personal_wellbeing(path)
+        >>> 'life_satisfaction' in df.columns
+        True
     """
     logger.info(f"Parsing personal wellbeing from {file_path}")
 
@@ -249,7 +253,11 @@ def parse_loneliness(file_path: str | Path) -> pd.DataFrame:
             - confidence_interval: str (e.g., "+/- 1.1")
 
     Example:
-        >>> df = parse_loneliness("individual-wellbeing-ni-202425-data-tables.xlsx")
+        >>> _, year = get_latest_wellbeing_publication_url()
+        >>> path = download_file(get_wellbeing_file_url(year), cache_ttl_hours=90*24)
+        >>> df = parse_loneliness(path)
+        >>> 'lonely_some_of_time' in df.columns
+        True
     """
     logger.info(f"Parsing loneliness from {file_path}")
 
@@ -302,7 +310,11 @@ def parse_self_efficacy(file_path: str | Path) -> pd.DataFrame:
             - confidence_interval: str (e.g., "+/- 0.1")
 
     Example:
-        >>> df = parse_self_efficacy("individual-wellbeing-ni-202425-data-tables.xlsx")
+        >>> _, year = get_latest_wellbeing_publication_url()
+        >>> path = download_file(get_wellbeing_file_url(year), cache_ttl_hours=90*24)
+        >>> df = parse_self_efficacy(path)
+        >>> 'self_efficacy_mean' in df.columns
+        True
     """
     logger.info(f"Parsing self-efficacy from {file_path}")
 

--- a/src/bolster/data_sources/nisra/wellbeing.py
+++ b/src/bolster/data_sources/nisra/wellbeing.py
@@ -30,18 +30,16 @@ Demographics available:
     - Religion, Dependant status, Health status, Employment status
 
 Examples:
-    >>> from bolster.data_sources.nisra import wellbeing  # doctest: +SKIP
+    >>> from bolster.data_sources.nisra import wellbeing
     >>> # Get latest personal wellbeing timeseries (ONS4 measures)
-    >>> df = wellbeing.get_latest_personal_wellbeing()  # doctest: +SKIP
-    >>> print(df.tail())  # doctest: +SKIP
+    >>> df = wellbeing.get_latest_personal_wellbeing()
 
     >>> # Get loneliness data
-    >>> df_lonely = wellbeing.get_latest_loneliness()  # doctest: +SKIP
-    >>> print(df_lonely[df_lonely['year'] == '2024/25'])  # doctest: +SKIP
+    >>> df_lonely = wellbeing.get_latest_loneliness()
 
     >>> # Get summary across all measures
-    >>> summary = wellbeing.get_wellbeing_summary()  # doctest: +SKIP
-    >>> print(summary)  # doctest: +SKIP
+    >>> summary = wellbeing.get_wellbeing_summary()
+    >>> print(summary)
 
 Publication Details:
     - Frequency: Annual (January publication)
@@ -79,8 +77,7 @@ def get_latest_wellbeing_publication_url() -> tuple[str, str]:
         NISRADataNotFoundError: If unable to find the latest publication
 
     Example:
-        >>> url, year = get_latest_wellbeing_publication_url()  # doctest: +SKIP
-        >>> print(f"Latest Wellbeing: {year} at {url}")  # doctest: +SKIP
+        >>> url, year = get_latest_wellbeing_publication_url()
     """
     from bs4 import BeautifulSoup
 
@@ -138,8 +135,7 @@ def get_wellbeing_file_url(year_str: str) -> str:
         URL to the Excel data tables file
 
     Example:
-        >>> url = get_wellbeing_file_url("2024/25")  # doctest: +SKIP
-        >>> print(url)  # doctest: +SKIP
+        >>> url = get_wellbeing_file_url("2024/25")
     """
     # Convert "2024/25" to "202425"
     year_code = year_str.replace("/", "")
@@ -175,8 +171,7 @@ def parse_personal_wellbeing(file_path: str | Path) -> pd.DataFrame:
             - anxiety: float (mean score 0-10, lower is better)
 
     Example:
-        >>> df = parse_personal_wellbeing("individual-wellbeing-ni-202425-data-tables.xlsx")  # doctest: +SKIP
-        >>> print(df.tail())  # doctest: +SKIP
+        >>> df = parse_personal_wellbeing("individual-wellbeing-ni-202425-data-tables.xlsx")
     """
     logger.info(f"Parsing personal wellbeing from {file_path}")
 
@@ -250,8 +245,7 @@ def parse_loneliness(file_path: str | Path) -> pd.DataFrame:
             - confidence_interval: str (e.g., "+/- 1.1")
 
     Example:
-        >>> df = parse_loneliness("individual-wellbeing-ni-202425-data-tables.xlsx")  # doctest: +SKIP
-        >>> print(df.tail())  # doctest: +SKIP
+        >>> df = parse_loneliness("individual-wellbeing-ni-202425-data-tables.xlsx")
     """
     logger.info(f"Parsing loneliness from {file_path}")
 
@@ -304,8 +298,7 @@ def parse_self_efficacy(file_path: str | Path) -> pd.DataFrame:
             - confidence_interval: str (e.g., "+/- 0.1")
 
     Example:
-        >>> df = parse_self_efficacy("individual-wellbeing-ni-202425-data-tables.xlsx")  # doctest: +SKIP
-        >>> print(df.tail())  # doctest: +SKIP
+        >>> df = parse_self_efficacy("individual-wellbeing-ni-202425-data-tables.xlsx")
     """
     logger.info(f"Parsing self-efficacy from {file_path}")
 
@@ -361,9 +354,8 @@ def get_latest_personal_wellbeing(force_refresh: bool = False) -> pd.DataFrame:
             - anxiety: float (mean 0-10, lower is better)
 
     Example:
-        >>> df = get_latest_personal_wellbeing()  # doctest: +SKIP
-        >>> latest = df.iloc[-1]  # doctest: +SKIP
-        >>> print(f"Life Satisfaction {latest['year']}: {latest['life_satisfaction']}")  # doctest: +SKIP
+        >>> df = get_latest_personal_wellbeing()
+        >>> latest = df.iloc[-1]
     """
     _, year_str = get_latest_wellbeing_publication_url()
     file_url = get_wellbeing_file_url(year_str)
@@ -390,9 +382,8 @@ def get_latest_loneliness(force_refresh: bool = False) -> pd.DataFrame:
             - confidence_interval: str
 
     Example:
-        >>> df = get_latest_loneliness()  # doctest: +SKIP
-        >>> latest = df.iloc[-1]  # doctest: +SKIP
-        >>> print(f"Loneliness {latest['year']}: {latest['lonely_some_of_time']:.1%}")  # doctest: +SKIP
+        >>> df = get_latest_loneliness()
+        >>> latest = df.iloc[-1]
     """
     _, year_str = get_latest_wellbeing_publication_url()
     file_url = get_wellbeing_file_url(year_str)
@@ -418,9 +409,8 @@ def get_latest_self_efficacy(force_refresh: bool = False) -> pd.DataFrame:
             - confidence_interval: str
 
     Example:
-        >>> df = get_latest_self_efficacy()  # doctest: +SKIP
-        >>> latest = df.iloc[-1]  # doctest: +SKIP
-        >>> print(f"Self-efficacy {latest['year']}: {latest['self_efficacy_mean']}")  # doctest: +SKIP
+        >>> df = get_latest_self_efficacy()
+        >>> latest = df.iloc[-1]
     """
     _, year_str = get_latest_wellbeing_publication_url()
     file_url = get_wellbeing_file_url(year_str)
@@ -450,8 +440,8 @@ def get_wellbeing_summary(force_refresh: bool = False) -> pd.DataFrame:
             - self_efficacy_mean: float
 
     Example:
-        >>> summary = get_wellbeing_summary()  # doctest: +SKIP
-        >>> print(summary.T)  # Transpose for readable output  # doctest: +SKIP
+        >>> summary = get_wellbeing_summary()
+        >>> print(summary.T)  # Transpose for readable output
     """
     # Get all data
     df_personal = get_latest_personal_wellbeing(force_refresh=force_refresh)
@@ -494,8 +484,8 @@ def get_personal_wellbeing_by_year(df: pd.DataFrame, year: str) -> pd.DataFrame:
         DataFrame filtered to the specified year
 
     Example:
-        >>> df = get_latest_personal_wellbeing()  # doctest: +SKIP
-        >>> df_2024 = get_personal_wellbeing_by_year(df, "2024/25")  # doctest: +SKIP
+        >>> df = get_latest_personal_wellbeing()
+        >>> df_2024 = get_personal_wellbeing_by_year(df, "2024/25")
     """
     return df[df["year"] == year].copy()
 

--- a/src/bolster/data_sources/nisra/wellbeing.py
+++ b/src/bolster/data_sources/nisra/wellbeing.py
@@ -30,18 +30,18 @@ Demographics available:
     - Religion, Dependant status, Health status, Employment status
 
 Examples:
-    >>> from bolster.data_sources.nisra import wellbeing
+    >>> from bolster.data_sources.nisra import wellbeing  # doctest: +SKIP
     >>> # Get latest personal wellbeing timeseries (ONS4 measures)
-    >>> df = wellbeing.get_latest_personal_wellbeing()
-    >>> print(df.tail())
+    >>> df = wellbeing.get_latest_personal_wellbeing()  # doctest: +SKIP
+    >>> print(df.tail())  # doctest: +SKIP
 
     >>> # Get loneliness data
-    >>> df_lonely = wellbeing.get_latest_loneliness()
-    >>> print(df_lonely[df_lonely['year'] == '2024/25'])
+    >>> df_lonely = wellbeing.get_latest_loneliness()  # doctest: +SKIP
+    >>> print(df_lonely[df_lonely['year'] == '2024/25'])  # doctest: +SKIP
 
     >>> # Get summary across all measures
-    >>> summary = wellbeing.get_wellbeing_summary()
-    >>> print(summary)
+    >>> summary = wellbeing.get_wellbeing_summary()  # doctest: +SKIP
+    >>> print(summary)  # doctest: +SKIP
 
 Publication Details:
     - Frequency: Annual (January publication)
@@ -79,8 +79,8 @@ def get_latest_wellbeing_publication_url() -> tuple[str, str]:
         NISRADataNotFoundError: If unable to find the latest publication
 
     Example:
-        >>> url, year = get_latest_wellbeing_publication_url()
-        >>> print(f"Latest Wellbeing: {year} at {url}")
+        >>> url, year = get_latest_wellbeing_publication_url()  # doctest: +SKIP
+        >>> print(f"Latest Wellbeing: {year} at {url}")  # doctest: +SKIP
     """
     from bs4 import BeautifulSoup
 
@@ -138,8 +138,8 @@ def get_wellbeing_file_url(year_str: str) -> str:
         URL to the Excel data tables file
 
     Example:
-        >>> url = get_wellbeing_file_url("2024/25")
-        >>> print(url)
+        >>> url = get_wellbeing_file_url("2024/25")  # doctest: +SKIP
+        >>> print(url)  # doctest: +SKIP
     """
     # Convert "2024/25" to "202425"
     year_code = year_str.replace("/", "")
@@ -175,8 +175,8 @@ def parse_personal_wellbeing(file_path: str | Path) -> pd.DataFrame:
             - anxiety: float (mean score 0-10, lower is better)
 
     Example:
-        >>> df = parse_personal_wellbeing("individual-wellbeing-ni-202425-data-tables.xlsx")
-        >>> print(df.tail())
+        >>> df = parse_personal_wellbeing("individual-wellbeing-ni-202425-data-tables.xlsx")  # doctest: +SKIP
+        >>> print(df.tail())  # doctest: +SKIP
     """
     logger.info(f"Parsing personal wellbeing from {file_path}")
 
@@ -250,8 +250,8 @@ def parse_loneliness(file_path: str | Path) -> pd.DataFrame:
             - confidence_interval: str (e.g., "+/- 1.1")
 
     Example:
-        >>> df = parse_loneliness("individual-wellbeing-ni-202425-data-tables.xlsx")
-        >>> print(df.tail())
+        >>> df = parse_loneliness("individual-wellbeing-ni-202425-data-tables.xlsx")  # doctest: +SKIP
+        >>> print(df.tail())  # doctest: +SKIP
     """
     logger.info(f"Parsing loneliness from {file_path}")
 
@@ -304,8 +304,8 @@ def parse_self_efficacy(file_path: str | Path) -> pd.DataFrame:
             - confidence_interval: str (e.g., "+/- 0.1")
 
     Example:
-        >>> df = parse_self_efficacy("individual-wellbeing-ni-202425-data-tables.xlsx")
-        >>> print(df.tail())
+        >>> df = parse_self_efficacy("individual-wellbeing-ni-202425-data-tables.xlsx")  # doctest: +SKIP
+        >>> print(df.tail())  # doctest: +SKIP
     """
     logger.info(f"Parsing self-efficacy from {file_path}")
 
@@ -361,9 +361,9 @@ def get_latest_personal_wellbeing(force_refresh: bool = False) -> pd.DataFrame:
             - anxiety: float (mean 0-10, lower is better)
 
     Example:
-        >>> df = get_latest_personal_wellbeing()
-        >>> latest = df.iloc[-1]
-        >>> print(f"Life Satisfaction {latest['year']}: {latest['life_satisfaction']}")
+        >>> df = get_latest_personal_wellbeing()  # doctest: +SKIP
+        >>> latest = df.iloc[-1]  # doctest: +SKIP
+        >>> print(f"Life Satisfaction {latest['year']}: {latest['life_satisfaction']}")  # doctest: +SKIP
     """
     _, year_str = get_latest_wellbeing_publication_url()
     file_url = get_wellbeing_file_url(year_str)
@@ -390,9 +390,9 @@ def get_latest_loneliness(force_refresh: bool = False) -> pd.DataFrame:
             - confidence_interval: str
 
     Example:
-        >>> df = get_latest_loneliness()
-        >>> latest = df.iloc[-1]
-        >>> print(f"Loneliness {latest['year']}: {latest['lonely_some_of_time']:.1%}")
+        >>> df = get_latest_loneliness()  # doctest: +SKIP
+        >>> latest = df.iloc[-1]  # doctest: +SKIP
+        >>> print(f"Loneliness {latest['year']}: {latest['lonely_some_of_time']:.1%}")  # doctest: +SKIP
     """
     _, year_str = get_latest_wellbeing_publication_url()
     file_url = get_wellbeing_file_url(year_str)
@@ -418,9 +418,9 @@ def get_latest_self_efficacy(force_refresh: bool = False) -> pd.DataFrame:
             - confidence_interval: str
 
     Example:
-        >>> df = get_latest_self_efficacy()
-        >>> latest = df.iloc[-1]
-        >>> print(f"Self-efficacy {latest['year']}: {latest['self_efficacy_mean']}")
+        >>> df = get_latest_self_efficacy()  # doctest: +SKIP
+        >>> latest = df.iloc[-1]  # doctest: +SKIP
+        >>> print(f"Self-efficacy {latest['year']}: {latest['self_efficacy_mean']}")  # doctest: +SKIP
     """
     _, year_str = get_latest_wellbeing_publication_url()
     file_url = get_wellbeing_file_url(year_str)
@@ -450,8 +450,8 @@ def get_wellbeing_summary(force_refresh: bool = False) -> pd.DataFrame:
             - self_efficacy_mean: float
 
     Example:
-        >>> summary = get_wellbeing_summary()
-        >>> print(summary.T)  # Transpose for readable output
+        >>> summary = get_wellbeing_summary()  # doctest: +SKIP
+        >>> print(summary.T)  # Transpose for readable output  # doctest: +SKIP
     """
     # Get all data
     df_personal = get_latest_personal_wellbeing(force_refresh=force_refresh)
@@ -494,8 +494,8 @@ def get_personal_wellbeing_by_year(df: pd.DataFrame, year: str) -> pd.DataFrame:
         DataFrame filtered to the specified year
 
     Example:
-        >>> df = get_latest_personal_wellbeing()
-        >>> df_2024 = get_personal_wellbeing_by_year(df, "2024/25")
+        >>> df = get_latest_personal_wellbeing()  # doctest: +SKIP
+        >>> df_2024 = get_personal_wellbeing_by_year(df, "2024/25")  # doctest: +SKIP
     """
     return df[df["year"] == year].copy()
 

--- a/src/bolster/data_sources/nisra/wellbeing.py
+++ b/src/bolster/data_sources/nisra/wellbeing.py
@@ -31,15 +31,15 @@ Demographics available:
 
 Examples:
     >>> from bolster.data_sources.nisra import wellbeing
-    >>> # Get latest personal wellbeing timeseries (ONS4 measures)
     >>> df = wellbeing.get_latest_personal_wellbeing()
-
-    >>> # Get loneliness data
+    >>> 'life_satisfaction' in df.columns
+    True
     >>> df_lonely = wellbeing.get_latest_loneliness()
-
-    >>> # Get summary across all measures
+    >>> 'lonely_some_of_time' in df_lonely.columns
+    True
     >>> summary = wellbeing.get_wellbeing_summary()
-    >>> print(summary)
+    >>> 'life_satisfaction' in summary.columns
+    True
 
 Publication Details:
     - Frequency: Annual (January publication)
@@ -78,6 +78,8 @@ def get_latest_wellbeing_publication_url() -> tuple[str, str]:
 
     Example:
         >>> url, year = get_latest_wellbeing_publication_url()
+        >>> url.startswith('https://')
+        True
     """
     from bs4 import BeautifulSoup
 
@@ -136,6 +138,8 @@ def get_wellbeing_file_url(year_str: str) -> str:
 
     Example:
         >>> url = get_wellbeing_file_url("2024/25")
+        >>> url.startswith('https://')
+        True
     """
     # Convert "2024/25" to "202425"
     year_code = year_str.replace("/", "")
@@ -355,7 +359,8 @@ def get_latest_personal_wellbeing(force_refresh: bool = False) -> pd.DataFrame:
 
     Example:
         >>> df = get_latest_personal_wellbeing()
-        >>> latest = df.iloc[-1]
+        >>> 'life_satisfaction' in df.columns
+        True
     """
     _, year_str = get_latest_wellbeing_publication_url()
     file_url = get_wellbeing_file_url(year_str)
@@ -383,7 +388,8 @@ def get_latest_loneliness(force_refresh: bool = False) -> pd.DataFrame:
 
     Example:
         >>> df = get_latest_loneliness()
-        >>> latest = df.iloc[-1]
+        >>> 'lonely_some_of_time' in df.columns
+        True
     """
     _, year_str = get_latest_wellbeing_publication_url()
     file_url = get_wellbeing_file_url(year_str)
@@ -410,7 +416,8 @@ def get_latest_self_efficacy(force_refresh: bool = False) -> pd.DataFrame:
 
     Example:
         >>> df = get_latest_self_efficacy()
-        >>> latest = df.iloc[-1]
+        >>> 'self_efficacy_mean' in df.columns
+        True
     """
     _, year_str = get_latest_wellbeing_publication_url()
     file_url = get_wellbeing_file_url(year_str)
@@ -441,7 +448,8 @@ def get_wellbeing_summary(force_refresh: bool = False) -> pd.DataFrame:
 
     Example:
         >>> summary = get_wellbeing_summary()
-        >>> print(summary.T)  # Transpose for readable output
+        >>> 'life_satisfaction' in summary.columns
+        True
     """
     # Get all data
     df_personal = get_latest_personal_wellbeing(force_refresh=force_refresh)
@@ -486,6 +494,8 @@ def get_personal_wellbeing_by_year(df: pd.DataFrame, year: str) -> pd.DataFrame:
     Example:
         >>> df = get_latest_personal_wellbeing()
         >>> df_2024 = get_personal_wellbeing_by_year(df, "2024/25")
+        >>> 'life_satisfaction' in df_2024.columns
+        True
     """
     return df[df["year"] == year].copy()
 

--- a/src/bolster/data_sources/psni/__init__.py
+++ b/src/bolster/data_sources/psni/__init__.py
@@ -10,21 +10,21 @@ Northern Ireland's Local Government Districts (LGDs), enabling integration
 with other NISRA datasets.
 
 Example:
-    >>> from bolster.data_sources.psni import crime_statistics, road_traffic_collisions  # doctest: +SKIP
+    >>> from bolster.data_sources.psni import crime_statistics, road_traffic_collisions
     >>> # Get latest crime data
-    >>> df = crime_statistics.get_latest_crime_statistics()  # doctest: +SKIP
+    >>> df = crime_statistics.get_latest_crime_statistics()
     >>>
     >>> # Filter to Belfast
-    >>> belfast = crime_statistics.filter_by_district(df, "Belfast City")  # doctest: +SKIP
+    >>> belfast = crime_statistics.filter_by_district(df, "Belfast City")
     >>>
     >>> # Get LGD code for cross-referencing
-    >>> lgd_code = crime_statistics.get_lgd_code("Belfast City")  # doctest: +SKIP
-    >>> print(f"Belfast LGD: {lgd_code}")  # N09000003  # doctest: +SKIP
+    >>> lgd_code = crime_statistics.get_lgd_code("Belfast City")
+    >>> print(f"Belfast LGD: {lgd_code}")  # N09000003
     >>>
     >>> # Get road traffic collision data
-    >>> collisions = road_traffic_collisions.get_collisions()  # doctest: +SKIP
-    >>> casualties = road_traffic_collisions.get_casualties()  # doctest: +SKIP
-    >>> print(f"Fatal casualties: {len(casualties[casualties['severity'] == 'Fatal'])}")  # doctest: +SKIP
+    >>> collisions = road_traffic_collisions.get_collisions()
+    >>> casualties = road_traffic_collisions.get_casualties()
+    >>> print(f"Fatal casualties: {len(casualties[casualties['severity'] == 'Fatal'])}")
 
 See individual module docstrings for detailed documentation.
 """

--- a/src/bolster/data_sources/psni/__init__.py
+++ b/src/bolster/data_sources/psni/__init__.py
@@ -10,21 +10,21 @@ Northern Ireland's Local Government Districts (LGDs), enabling integration
 with other NISRA datasets.
 
 Example:
-    >>> from bolster.data_sources.psni import crime_statistics, road_traffic_collisions
+    >>> from bolster.data_sources.psni import crime_statistics, road_traffic_collisions  # doctest: +SKIP
     >>> # Get latest crime data
-    >>> df = crime_statistics.get_latest_crime_statistics()
+    >>> df = crime_statistics.get_latest_crime_statistics()  # doctest: +SKIP
     >>>
     >>> # Filter to Belfast
-    >>> belfast = crime_statistics.filter_by_district(df, "Belfast City")
+    >>> belfast = crime_statistics.filter_by_district(df, "Belfast City")  # doctest: +SKIP
     >>>
     >>> # Get LGD code for cross-referencing
-    >>> lgd_code = crime_statistics.get_lgd_code("Belfast City")
-    >>> print(f"Belfast LGD: {lgd_code}")  # N09000003
+    >>> lgd_code = crime_statistics.get_lgd_code("Belfast City")  # doctest: +SKIP
+    >>> print(f"Belfast LGD: {lgd_code}")  # N09000003  # doctest: +SKIP
     >>>
     >>> # Get road traffic collision data
-    >>> collisions = road_traffic_collisions.get_collisions()
-    >>> casualties = road_traffic_collisions.get_casualties()
-    >>> print(f"Fatal casualties: {len(casualties[casualties['severity'] == 'Fatal'])}")
+    >>> collisions = road_traffic_collisions.get_collisions()  # doctest: +SKIP
+    >>> casualties = road_traffic_collisions.get_casualties()  # doctest: +SKIP
+    >>> print(f"Fatal casualties: {len(casualties[casualties['severity'] == 'Fatal'])}")  # doctest: +SKIP
 
 See individual module docstrings for detailed documentation.
 """

--- a/src/bolster/data_sources/psni/__init__.py
+++ b/src/bolster/data_sources/psni/__init__.py
@@ -11,20 +11,15 @@ with other NISRA datasets.
 
 Example:
     >>> from bolster.data_sources.psni import crime_statistics, road_traffic_collisions
-    >>> # Get latest crime data
     >>> df = crime_statistics.get_latest_crime_statistics()
-    >>>
-    >>> # Filter to Belfast
-    >>> belfast = crime_statistics.filter_by_district(df, "Belfast City")
-    >>>
-    >>> # Get LGD code for cross-referencing
+    >>> 'lgd_code' in df.columns
+    True
     >>> lgd_code = crime_statistics.get_lgd_code("Belfast City")
-    >>> print(f"Belfast LGD: {lgd_code}")  # N09000003
-    >>>
-    >>> # Get road traffic collision data
-    >>> collisions = road_traffic_collisions.get_collisions()
+    >>> lgd_code
+    'N09000003'
     >>> casualties = road_traffic_collisions.get_casualties()
-    >>> print(f"Fatal casualties: {len(casualties[casualties['severity'] == 'Fatal'])}")
+    >>> 'severity' in casualties.columns
+    True
 
 See individual module docstrings for detailed documentation.
 """

--- a/src/bolster/data_sources/psni/_base.py
+++ b/src/bolster/data_sources/psni/_base.py
@@ -197,7 +197,7 @@ def download_file(url: str, cache_ttl_hours: int = 24, force_refresh: bool = Fal
         >>> path = download_file(
         ...     "https://example.com/data.csv",
         ...     cache_ttl_hours=24
-        ... )  # doctest: +SKIP
+        ... )
     """
     try:
         return _downloader.download(url, cache_ttl_hours=cache_ttl_hours, force_refresh=force_refresh)
@@ -217,6 +217,6 @@ def clear_cache(pattern: str | None = None) -> int:
 
     Example:
         >>> from bolster.data_sources.psni._base import clear_cache
-        >>> deleted = clear_cache("*.csv")  # doctest: +SKIP
+        >>> deleted = clear_cache("*.csv")
     """
     return _downloader.clear(pattern)

--- a/src/bolster/data_sources/psni/_base.py
+++ b/src/bolster/data_sources/psni/_base.py
@@ -193,11 +193,12 @@ def download_file(url: str, cache_ttl_hours: int = 24, force_refresh: bool = Fal
         PSNIDataNotFoundError: If download fails due to network or HTTP errors
 
     Example:
-        >>> from bolster.data_sources.psni._base import download_file
-        >>> path = download_file(
-        ...     "https://example.com/data.csv",
-        ...     cache_ttl_hours=24
-        ... )
+        >>> from bolster.data_sources.psni._base import PSNIDataNotFoundError
+        >>> try:
+        ...     download_file("https://example.com/no-such-file.csv")
+        ... except PSNIDataNotFoundError:
+        ...     print("PSNIDataNotFoundError raised for unreachable URL")
+        PSNIDataNotFoundError raised for unreachable URL
     """
     try:
         return _downloader.download(url, cache_ttl_hours=cache_ttl_hours, force_refresh=force_refresh)

--- a/src/bolster/data_sources/psni/_base.py
+++ b/src/bolster/data_sources/psni/_base.py
@@ -218,5 +218,7 @@ def clear_cache(pattern: str | None = None) -> int:
     Example:
         >>> from bolster.data_sources.psni._base import clear_cache
         >>> deleted = clear_cache("*.csv")
+        >>> isinstance(deleted, int)
+        True
     """
     return _downloader.clear(pattern)

--- a/src/bolster/data_sources/psni/crime_statistics.py
+++ b/src/bolster/data_sources/psni/crime_statistics.py
@@ -32,17 +32,12 @@ Reference Date: Month of crime occurrence
 Time Coverage: April 2001 to December 2021 (OpenDataNI dataset)
 
 Example:
-    >>> from bolster.data_sources.psni import crime_statistics
-    >>> # Get latest crime data
-    >>> df = crime_statistics.get_latest_crime_statistics()
-    >>> print(df.head())
-    >>>
-    >>> # Filter to Belfast
-    >>> belfast = df[df['policing_district'] == 'Belfast City']
-    >>>
-    >>> # Get LGD code for cross-referencing with NISRA data
-    >>> belfast_lgd = crime_statistics.get_lgd_code('Belfast City')
-    >>> print(f"Belfast LGD code: {belfast_lgd}")  # N09000003
+    >>> from bolster.data_sources.psni import crime_statistics  # doctest: +SKIP
+    >>> df = crime_statistics.get_latest_crime_statistics()  # doctest: +SKIP
+    >>> print(df.head())  # doctest: +SKIP
+    >>> belfast = df[df['policing_district'] == 'Belfast City']  # doctest: +SKIP
+    >>> belfast_lgd = crime_statistics.get_lgd_code('Belfast City')  # doctest: +SKIP
+    >>> print(f"Belfast LGD code: {belfast_lgd}")  # doctest: +SKIP
 """
 
 import logging
@@ -88,9 +83,9 @@ def get_data_source_info() -> dict:
             - last_update: Last known update date for OpenDataNI
 
     Example:
-        >>> info = get_data_source_info()
-        >>> print(f"For current data, visit: {info['psni_official_url']}")
-        >>> print(f"Or contact: {info['contact_email']}")
+        >>> info = get_data_source_info()  # doctest: +SKIP
+        >>> print(f"For current data, visit: {info['psni_official_url']}")  # doctest: +SKIP
+        >>> print(f"Or contact: {info['contact_email']}")  # doctest: +SKIP
     """
     return {
         "opendatani_url": "https://www.opendatani.gov.uk/dataset/police-recorded-crime-in-northern-ireland",
@@ -138,11 +133,11 @@ def parse_crime_statistics_file(
         PSNIValidationError: If file structure is unexpected
 
     Example:
-        >>> from pathlib import Path
-        >>> df = parse_crime_statistics_file(Path("crime_data.csv"))
-        >>> print(df.columns.tolist())
-        >>> print(f"Date range: {df['date'].min()} to {df['date'].max()}")
-        >>> print(f"Districts: {df['policing_district'].nunique()}")
+        >>> from pathlib import Path  # doctest: +SKIP
+        >>> df = parse_crime_statistics_file(Path("crime_data.csv"))  # doctest: +SKIP
+        >>> print(df.columns.tolist())  # doctest: +SKIP
+        >>> print(f"Date range: {df['date'].min()} to {df['date'].max()}")  # doctest: +SKIP
+        >>> print(f"Districts: {df['policing_district'].nunique()}")  # doctest: +SKIP
     """
     file_path = Path(file_path)
 
@@ -255,18 +250,18 @@ def get_latest_crime_statistics(
 
     Example:
         >>> # Get all crime data (NOTE: only through Dec 2021)
-        >>> df = get_latest_crime_statistics()
+        >>> df = get_latest_crime_statistics()  # doctest: +SKIP
         >>>
         >>> # Filter to recent data
-        >>> recent = df[df['date'] >= '2020-01-01']
+        >>> recent = df[df['date'] >= '2020-01-01']  # doctest: +SKIP
         >>>
         >>> # Get total crimes by district for 2021
-        >>> crimes_2021 = df[
-        ...     (df['calendar_year'] == 2021) &
-        ...     (df['data_measure'] == 'Police Recorded Crime') &
-        ...     (df['crime_type'] == 'Total police recorded crime')
-        ... ].groupby('policing_district')['count'].sum()
-        >>> print(crimes_2021.sort_values(ascending=False))
+        >>> crimes_2021 = df[  # doctest: +SKIP
+        ...     (df['calendar_year'] == 2021) &  # doctest: +SKIP
+        ...     (df['data_measure'] == 'Police Recorded Crime') &  # doctest: +SKIP
+        ...     (df['crime_type'] == 'Total police recorded crime')  # doctest: +SKIP
+        ... ].groupby('policing_district')['count'].sum()  # doctest: +SKIP
+        >>> print(crimes_2021.sort_values(ascending=False))  # doctest: +SKIP
     """
     logger.info("Fetching PSNI crime statistics from OpenDataNI")
 
@@ -311,8 +306,8 @@ def validate_crime_statistics(df: pd.DataFrame) -> bool:  # pragma: no cover
         PSNIValidationError: If validation fails
 
     Example:
-        >>> df = get_latest_crime_statistics()
-        >>> validate_crime_statistics(df)
+        >>> df = get_latest_crime_statistics()  # doctest: +SKIP
+        >>> validate_crime_statistics(df)  # doctest: +SKIP
         True
     """
     # Check for negative crime counts (excluding NA which represents "/0")
@@ -380,12 +375,12 @@ def filter_by_district(
         Filtered DataFrame
 
     Example:
-        >>> df = get_latest_crime_statistics()
-        >>> belfast = filter_by_district(df, "Belfast City")
-        >>> print(f"Belfast records: {len(belfast):,}")
+        >>> df = get_latest_crime_statistics()  # doctest: +SKIP
+        >>> belfast = filter_by_district(df, "Belfast City")  # doctest: +SKIP
+        >>> print(f"Belfast records: {len(belfast):,}")  # doctest: +SKIP
         >>>
         >>> # Multiple districts
-        >>> cities = filter_by_district(df, ["Belfast City", "Derry City & Strabane"])
+        >>> cities = filter_by_district(df, ["Belfast City", "Derry City & Strabane"])  # doctest: +SKIP
     """
     if isinstance(district, str):
         district = [district]
@@ -407,9 +402,9 @@ def filter_by_crime_type(
         Filtered DataFrame
 
     Example:
-        >>> df = get_latest_crime_statistics()
-        >>> violence = filter_by_crime_type(df, "Violence with injury (including homicide & death/serious injury by unlawful driving)")
-        >>> print(f"Violence crimes: {len(violence):,}")
+        >>> df = get_latest_crime_statistics()  # doctest: +SKIP
+        >>> violence = filter_by_crime_type(df, "Violence with injury (including homicide & death/serious injury by unlawful driving)")  # doctest: +SKIP
+        >>> print(f"Violence crimes: {len(violence):,}")  # doctest: +SKIP
     """
     if isinstance(crime_type, str):
         crime_type = [crime_type]
@@ -433,12 +428,12 @@ def filter_by_date_range(
         Filtered DataFrame
 
     Example:
-        >>> df = get_latest_crime_statistics()
+        >>> df = get_latest_crime_statistics()  # doctest: +SKIP
         >>> # Get 2020 data
-        >>> df_2020 = filter_by_date_range(df, "2020-01-01", "2020-12-31")
+        >>> df_2020 = filter_by_date_range(df, "2020-01-01", "2020-12-31")  # doctest: +SKIP
         >>>
         >>> # Get data from 2018 onwards
-        >>> recent = filter_by_date_range(df, start_date="2018-01-01")
+        >>> recent = filter_by_date_range(df, start_date="2018-01-01")  # doctest: +SKIP
     """
     filtered = df.copy()
 
@@ -469,9 +464,9 @@ def get_total_crimes_by_district(
         DataFrame with columns: policing_district, lgd_code, nuts3_code, total_crimes
 
     Example:
-        >>> df = get_latest_crime_statistics()
-        >>> totals_2021 = get_total_crimes_by_district(df, year=2021)
-        >>> print(totals_2021.sort_values('total_crimes', ascending=False))
+        >>> df = get_latest_crime_statistics()  # doctest: +SKIP
+        >>> totals_2021 = get_total_crimes_by_district(df, year=2021)  # doctest: +SKIP
+        >>> print(totals_2021.sort_values('total_crimes', ascending=False))  # doctest: +SKIP
     """
     # Filter to total crimes measure
     crime_df = df[
@@ -511,20 +506,20 @@ def get_crime_trends(
         DataFrame with columns: date, calendar_year, month, count
 
     Example:
-        >>> df = get_latest_crime_statistics()
+        >>> df = get_latest_crime_statistics()  # doctest: +SKIP
         >>> # Belfast violence trends
-        >>> trends = get_crime_trends(
-        ...     df,
-        ...     crime_type="Violence with injury (including homicide & death/serious injury by unlawful driving)",
-        ...     district="Belfast City"
-        ... )
-        >>> print(trends.tail())
+        >>> trends = get_crime_trends(  # doctest: +SKIP
+        ...     df,  # doctest: +SKIP
+        ...     crime_type="Violence with injury (including homicide & death/serious injury by unlawful driving)",  # doctest: +SKIP
+        ...     district="Belfast City"  # doctest: +SKIP
+        ... )  # doctest: +SKIP
+        >>> print(trends.tail())  # doctest: +SKIP
         >>>
         >>> # Plot with pandas
-        >>> import matplotlib.pyplot as plt
-        >>> trends.set_index('date')['count'].plot()
-        >>> plt.title('Crime Trends')
-        >>> plt.show()
+        >>> import matplotlib.pyplot as plt  # doctest: +SKIP
+        >>> trends.set_index('date')['count'].plot()  # doctest: +SKIP
+        >>> plt.title('Crime Trends')  # doctest: +SKIP
+        >>> plt.show()  # doctest: +SKIP
     """
     filtered = df[
         (df["crime_type"] == crime_type) & (df["policing_district"] == district) & (df["data_measure"] == measure)
@@ -552,9 +547,9 @@ def get_outcome_rates_by_district(
         DataFrame with columns: policing_district, lgd_code, average_outcome_rate
 
     Example:
-        >>> df = get_latest_crime_statistics()
-        >>> outcomes = get_outcome_rates_by_district(df, year=2021)
-        >>> print(outcomes.sort_values('average_outcome_rate', ascending=False))
+        >>> df = get_latest_crime_statistics()  # doctest: +SKIP
+        >>> outcomes = get_outcome_rates_by_district(df, year=2021)  # doctest: +SKIP
+        >>> print(outcomes.sort_values('average_outcome_rate', ascending=False))  # doctest: +SKIP
     """
     # Filter to outcome rate measure
     outcome_df = df[
@@ -589,10 +584,10 @@ def get_available_crime_types(df: pd.DataFrame) -> list[str]:
         Sorted list of crime type names
 
     Example:
-        >>> df = get_latest_crime_statistics()
-        >>> crime_types = get_available_crime_types(df)
-        >>> for crime_type in crime_types:
-        ...     print(crime_type)
+        >>> df = get_latest_crime_statistics()  # doctest: +SKIP
+        >>> crime_types = get_available_crime_types(df)  # doctest: +SKIP
+        >>> for crime_type in crime_types:  # doctest: +SKIP
+        ...     print(crime_type)  # doctest: +SKIP
     """
     return sorted(df["crime_type"].unique().tolist())
 
@@ -607,10 +602,10 @@ def get_available_districts(df: pd.DataFrame) -> list[str]:
         Sorted list of district names
 
     Example:
-        >>> df = get_latest_crime_statistics()
-        >>> districts = get_available_districts(df)
-        >>> for district in districts:
-        ...     lgd = get_lgd_code(district)
-        ...     print(f"{district}: {lgd}")
+        >>> df = get_latest_crime_statistics()  # doctest: +SKIP
+        >>> districts = get_available_districts(df)  # doctest: +SKIP
+        >>> for district in districts:  # doctest: +SKIP
+        ...     lgd = get_lgd_code(district)  # doctest: +SKIP
+        ...     print(f"{district}: {lgd}")  # doctest: +SKIP
     """
     return sorted(df["policing_district"].unique().tolist())

--- a/src/bolster/data_sources/psni/crime_statistics.py
+++ b/src/bolster/data_sources/psni/crime_statistics.py
@@ -32,12 +32,10 @@ Reference Date: Month of crime occurrence
 Time Coverage: April 2001 to December 2021 (OpenDataNI dataset)
 
 Example:
-    >>> from bolster.data_sources.psni import crime_statistics  # doctest: +SKIP
-    >>> df = crime_statistics.get_latest_crime_statistics()  # doctest: +SKIP
-    >>> print(df.head())  # doctest: +SKIP
-    >>> belfast = df[df['policing_district'] == 'Belfast City']  # doctest: +SKIP
-    >>> belfast_lgd = crime_statistics.get_lgd_code('Belfast City')  # doctest: +SKIP
-    >>> print(f"Belfast LGD code: {belfast_lgd}")  # doctest: +SKIP
+    >>> from bolster.data_sources.psni import crime_statistics
+    >>> df = crime_statistics.get_latest_crime_statistics()
+    >>> belfast = df[df['policing_district'] == 'Belfast City']
+    >>> belfast_lgd = crime_statistics.get_lgd_code('Belfast City')
 """
 
 import logging
@@ -83,9 +81,7 @@ def get_data_source_info() -> dict:
             - last_update: Last known update date for OpenDataNI
 
     Example:
-        >>> info = get_data_source_info()  # doctest: +SKIP
-        >>> print(f"For current data, visit: {info['psni_official_url']}")  # doctest: +SKIP
-        >>> print(f"Or contact: {info['contact_email']}")  # doctest: +SKIP
+        >>> info = get_data_source_info()
     """
     return {
         "opendatani_url": "https://www.opendatani.gov.uk/dataset/police-recorded-crime-in-northern-ireland",
@@ -133,11 +129,8 @@ def parse_crime_statistics_file(
         PSNIValidationError: If file structure is unexpected
 
     Example:
-        >>> from pathlib import Path  # doctest: +SKIP
-        >>> df = parse_crime_statistics_file(Path("crime_data.csv"))  # doctest: +SKIP
-        >>> print(df.columns.tolist())  # doctest: +SKIP
-        >>> print(f"Date range: {df['date'].min()} to {df['date'].max()}")  # doctest: +SKIP
-        >>> print(f"Districts: {df['policing_district'].nunique()}")  # doctest: +SKIP
+        >>> from pathlib import Path
+        >>> df = parse_crime_statistics_file(Path("crime_data.csv"))
     """
     file_path = Path(file_path)
 
@@ -250,18 +243,17 @@ def get_latest_crime_statistics(
 
     Example:
         >>> # Get all crime data (NOTE: only through Dec 2021)
-        >>> df = get_latest_crime_statistics()  # doctest: +SKIP
+        >>> df = get_latest_crime_statistics()
         >>>
         >>> # Filter to recent data
-        >>> recent = df[df['date'] >= '2020-01-01']  # doctest: +SKIP
+        >>> recent = df[df['date'] >= '2020-01-01']
         >>>
         >>> # Get total crimes by district for 2021
-        >>> crimes_2021 = df[  # doctest: +SKIP
-        ...     (df['calendar_year'] == 2021) &  # doctest: +SKIP
-        ...     (df['data_measure'] == 'Police Recorded Crime') &  # doctest: +SKIP
-        ...     (df['crime_type'] == 'Total police recorded crime')  # doctest: +SKIP
-        ... ].groupby('policing_district')['count'].sum()  # doctest: +SKIP
-        >>> print(crimes_2021.sort_values(ascending=False))  # doctest: +SKIP
+        >>> crimes_2021 = df[
+        ...     (df['calendar_year'] == 2021) &
+        ...     (df['data_measure'] == 'Police Recorded Crime') &
+        ...     (df['crime_type'] == 'Total police recorded crime')
+        ... ].groupby('policing_district')['count'].sum()
     """
     logger.info("Fetching PSNI crime statistics from OpenDataNI")
 
@@ -306,8 +298,8 @@ def validate_crime_statistics(df: pd.DataFrame) -> bool:  # pragma: no cover
         PSNIValidationError: If validation fails
 
     Example:
-        >>> df = get_latest_crime_statistics()  # doctest: +SKIP
-        >>> validate_crime_statistics(df)  # doctest: +SKIP
+        >>> df = get_latest_crime_statistics()
+        >>> validate_crime_statistics(df)
         True
     """
     # Check for negative crime counts (excluding NA which represents "/0")
@@ -375,12 +367,11 @@ def filter_by_district(
         Filtered DataFrame
 
     Example:
-        >>> df = get_latest_crime_statistics()  # doctest: +SKIP
-        >>> belfast = filter_by_district(df, "Belfast City")  # doctest: +SKIP
-        >>> print(f"Belfast records: {len(belfast):,}")  # doctest: +SKIP
+        >>> df = get_latest_crime_statistics()
+        >>> belfast = filter_by_district(df, "Belfast City")
         >>>
         >>> # Multiple districts
-        >>> cities = filter_by_district(df, ["Belfast City", "Derry City & Strabane"])  # doctest: +SKIP
+        >>> cities = filter_by_district(df, ["Belfast City", "Derry City & Strabane"])
     """
     if isinstance(district, str):
         district = [district]
@@ -402,9 +393,8 @@ def filter_by_crime_type(
         Filtered DataFrame
 
     Example:
-        >>> df = get_latest_crime_statistics()  # doctest: +SKIP
-        >>> violence = filter_by_crime_type(df, "Violence with injury (including homicide & death/serious injury by unlawful driving)")  # doctest: +SKIP
-        >>> print(f"Violence crimes: {len(violence):,}")  # doctest: +SKIP
+        >>> df = get_latest_crime_statistics()
+        >>> violence = filter_by_crime_type(df, "Violence with injury (including homicide & death/serious injury by unlawful driving)")
     """
     if isinstance(crime_type, str):
         crime_type = [crime_type]
@@ -428,12 +418,12 @@ def filter_by_date_range(
         Filtered DataFrame
 
     Example:
-        >>> df = get_latest_crime_statistics()  # doctest: +SKIP
+        >>> df = get_latest_crime_statistics()
         >>> # Get 2020 data
-        >>> df_2020 = filter_by_date_range(df, "2020-01-01", "2020-12-31")  # doctest: +SKIP
+        >>> df_2020 = filter_by_date_range(df, "2020-01-01", "2020-12-31")
         >>>
         >>> # Get data from 2018 onwards
-        >>> recent = filter_by_date_range(df, start_date="2018-01-01")  # doctest: +SKIP
+        >>> recent = filter_by_date_range(df, start_date="2018-01-01")
     """
     filtered = df.copy()
 
@@ -464,9 +454,8 @@ def get_total_crimes_by_district(
         DataFrame with columns: policing_district, lgd_code, nuts3_code, total_crimes
 
     Example:
-        >>> df = get_latest_crime_statistics()  # doctest: +SKIP
-        >>> totals_2021 = get_total_crimes_by_district(df, year=2021)  # doctest: +SKIP
-        >>> print(totals_2021.sort_values('total_crimes', ascending=False))  # doctest: +SKIP
+        >>> df = get_latest_crime_statistics()
+        >>> totals_2021 = get_total_crimes_by_district(df, year=2021)
     """
     # Filter to total crimes measure
     crime_df = df[
@@ -506,20 +495,19 @@ def get_crime_trends(
         DataFrame with columns: date, calendar_year, month, count
 
     Example:
-        >>> df = get_latest_crime_statistics()  # doctest: +SKIP
+        >>> df = get_latest_crime_statistics()
         >>> # Belfast violence trends
-        >>> trends = get_crime_trends(  # doctest: +SKIP
-        ...     df,  # doctest: +SKIP
-        ...     crime_type="Violence with injury (including homicide & death/serious injury by unlawful driving)",  # doctest: +SKIP
-        ...     district="Belfast City"  # doctest: +SKIP
-        ... )  # doctest: +SKIP
-        >>> print(trends.tail())  # doctest: +SKIP
+        >>> trends = get_crime_trends(
+        ...     df,
+        ...     crime_type="Violence with injury (including homicide & death/serious injury by unlawful driving)",
+        ...     district="Belfast City"
+        ... )
         >>>
         >>> # Plot with pandas
-        >>> import matplotlib.pyplot as plt  # doctest: +SKIP
-        >>> trends.set_index('date')['count'].plot()  # doctest: +SKIP
-        >>> plt.title('Crime Trends')  # doctest: +SKIP
-        >>> plt.show()  # doctest: +SKIP
+        >>> import matplotlib.pyplot as plt
+        >>> trends.set_index('date')['count'].plot()
+        >>> plt.title('Crime Trends')
+        >>> plt.show()
     """
     filtered = df[
         (df["crime_type"] == crime_type) & (df["policing_district"] == district) & (df["data_measure"] == measure)
@@ -547,9 +535,8 @@ def get_outcome_rates_by_district(
         DataFrame with columns: policing_district, lgd_code, average_outcome_rate
 
     Example:
-        >>> df = get_latest_crime_statistics()  # doctest: +SKIP
-        >>> outcomes = get_outcome_rates_by_district(df, year=2021)  # doctest: +SKIP
-        >>> print(outcomes.sort_values('average_outcome_rate', ascending=False))  # doctest: +SKIP
+        >>> df = get_latest_crime_statistics()
+        >>> outcomes = get_outcome_rates_by_district(df, year=2021)
     """
     # Filter to outcome rate measure
     outcome_df = df[
@@ -584,10 +571,9 @@ def get_available_crime_types(df: pd.DataFrame) -> list[str]:
         Sorted list of crime type names
 
     Example:
-        >>> df = get_latest_crime_statistics()  # doctest: +SKIP
-        >>> crime_types = get_available_crime_types(df)  # doctest: +SKIP
-        >>> for crime_type in crime_types:  # doctest: +SKIP
-        ...     print(crime_type)  # doctest: +SKIP
+        >>> df = get_latest_crime_statistics()
+        >>> crime_types = get_available_crime_types(df)
+        >>> for crime_type in crime_types:
     """
     return sorted(df["crime_type"].unique().tolist())
 
@@ -602,10 +588,9 @@ def get_available_districts(df: pd.DataFrame) -> list[str]:
         Sorted list of district names
 
     Example:
-        >>> df = get_latest_crime_statistics()  # doctest: +SKIP
-        >>> districts = get_available_districts(df)  # doctest: +SKIP
-        >>> for district in districts:  # doctest: +SKIP
-        ...     lgd = get_lgd_code(district)  # doctest: +SKIP
-        ...     print(f"{district}: {lgd}")  # doctest: +SKIP
+        >>> df = get_latest_crime_statistics()
+        >>> districts = get_available_districts(df)
+        >>> for district in districts:
+        ...     lgd = get_lgd_code(district)
     """
     return sorted(df["policing_district"].unique().tolist())

--- a/src/bolster/data_sources/psni/crime_statistics.py
+++ b/src/bolster/data_sources/psni/crime_statistics.py
@@ -34,8 +34,12 @@ Time Coverage: April 2001 to December 2021 (OpenDataNI dataset)
 Example:
     >>> from bolster.data_sources.psni import crime_statistics
     >>> df = crime_statistics.get_latest_crime_statistics()
+    >>> sorted(df.columns.tolist())
+    ['calendar_year', 'count', 'crime_type', 'data_measure', 'date', 'lgd_code', 'month', 'nuts3_code', 'nuts3_name', 'policing_district']
     >>> belfast = df[df['policing_district'] == 'Belfast City']
     >>> belfast_lgd = crime_statistics.get_lgd_code('Belfast City')
+    >>> belfast_lgd
+    'N09000003'
 """
 
 import logging
@@ -82,6 +86,8 @@ def get_data_source_info() -> dict:
 
     Example:
         >>> info = get_data_source_info()
+        >>> sorted(info.keys())
+        ['contact_email', 'data_guide_url', 'data_limitation', 'last_update', 'opendatani_url', 'psni_official_url']
     """
     return {
         "opendatani_url": "https://www.opendatani.gov.uk/dataset/police-recorded-crime-in-northern-ireland",
@@ -244,16 +250,13 @@ def get_latest_crime_statistics(
     Example:
         >>> # Get all crime data (NOTE: only through Dec 2021)
         >>> df = get_latest_crime_statistics()
+        >>> sorted(df.columns.tolist())
+        ['calendar_year', 'count', 'crime_type', 'data_measure', 'date', 'lgd_code', 'month', 'nuts3_code', 'nuts3_name', 'policing_district']
         >>>
         >>> # Filter to recent data
         >>> recent = df[df['date'] >= '2020-01-01']
-        >>>
-        >>> # Get total crimes by district for 2021
-        >>> crimes_2021 = df[
-        ...     (df['calendar_year'] == 2021) &
-        ...     (df['data_measure'] == 'Police Recorded Crime') &
-        ...     (df['crime_type'] == 'Total police recorded crime')
-        ... ].groupby('policing_district')['count'].sum()
+        >>> len(recent) > 0
+        True
     """
     logger.info("Fetching PSNI crime statistics from OpenDataNI")
 
@@ -369,9 +372,13 @@ def filter_by_district(
     Example:
         >>> df = get_latest_crime_statistics()
         >>> belfast = filter_by_district(df, "Belfast City")
+        >>> belfast['policing_district'].unique().tolist()
+        ['Belfast City']
         >>>
         >>> # Multiple districts
         >>> cities = filter_by_district(df, ["Belfast City", "Derry City & Strabane"])
+        >>> len(cities['policing_district'].unique()) == 2
+        True
     """
     if isinstance(district, str):
         district = [district]
@@ -395,6 +402,8 @@ def filter_by_crime_type(
     Example:
         >>> df = get_latest_crime_statistics()
         >>> violence = filter_by_crime_type(df, "Violence with injury (including homicide & death/serious injury by unlawful driving)")
+        >>> len(violence) > 0
+        True
     """
     if isinstance(crime_type, str):
         crime_type = [crime_type]
@@ -421,9 +430,13 @@ def filter_by_date_range(
         >>> df = get_latest_crime_statistics()
         >>> # Get 2020 data
         >>> df_2020 = filter_by_date_range(df, "2020-01-01", "2020-12-31")
+        >>> df_2020['calendar_year'].unique().tolist()
+        [2020]
         >>>
         >>> # Get data from 2018 onwards
         >>> recent = filter_by_date_range(df, start_date="2018-01-01")
+        >>> len(recent) > 0
+        True
     """
     filtered = df.copy()
 
@@ -456,6 +469,8 @@ def get_total_crimes_by_district(
     Example:
         >>> df = get_latest_crime_statistics()
         >>> totals_2021 = get_total_crimes_by_district(df, year=2021)
+        >>> sorted(totals_2021.columns.tolist())
+        ['lgd_code', 'nuts3_code', 'policing_district', 'total_crimes']
     """
     # Filter to total crimes measure
     crime_df = df[
@@ -537,6 +552,8 @@ def get_outcome_rates_by_district(
     Example:
         >>> df = get_latest_crime_statistics()
         >>> outcomes = get_outcome_rates_by_district(df, year=2021)
+        >>> 'average_outcome_rate' in outcomes.columns
+        True
     """
     # Filter to outcome rate measure
     outcome_df = df[
@@ -573,7 +590,10 @@ def get_available_crime_types(df: pd.DataFrame) -> list[str]:
     Example:
         >>> df = get_latest_crime_statistics()
         >>> crime_types = get_available_crime_types(df)
-        >>> for crime_type in crime_types:
+        >>> isinstance(crime_types, list)
+        True
+        >>> 'Total police recorded crime' in crime_types
+        True
     """
     return sorted(df["crime_type"].unique().tolist())
 
@@ -590,7 +610,9 @@ def get_available_districts(df: pd.DataFrame) -> list[str]:
     Example:
         >>> df = get_latest_crime_statistics()
         >>> districts = get_available_districts(df)
-        >>> for district in districts:
-        ...     lgd = get_lgd_code(district)
+        >>> isinstance(districts, list)
+        True
+        >>> 'Northern Ireland' in districts
+        True
     """
     return sorted(df["policing_district"].unique().tolist())

--- a/src/bolster/data_sources/psni/crime_statistics.py
+++ b/src/bolster/data_sources/psni/crime_statistics.py
@@ -135,8 +135,12 @@ def parse_crime_statistics_file(
         PSNIValidationError: If file structure is unexpected
 
     Example:
-        >>> from pathlib import Path
-        >>> df = parse_crime_statistics_file(Path("crime_data.csv"))
+        >>> path = download_file(CRIME_STATISTICS_URL, cache_ttl_hours=24*7)
+        >>> df = parse_crime_statistics_file(path)
+        >>> 'crime_type' in df.columns
+        True
+        >>> len(df) > 0
+        True
     """
     file_path = Path(file_path)
 
@@ -511,18 +515,11 @@ def get_crime_trends(
 
     Example:
         >>> df = get_latest_crime_statistics()
-        >>> # Belfast violence trends
-        >>> trends = get_crime_trends(
-        ...     df,
-        ...     crime_type="Violence with injury (including homicide & death/serious injury by unlawful driving)",
-        ...     district="Belfast City"
-        ... )
-        >>>
-        >>> # Plot with pandas
-        >>> import matplotlib.pyplot as plt
-        >>> trends.set_index('date')['count'].plot()
-        >>> plt.title('Crime Trends')
-        >>> plt.show()
+        >>> trends = get_crime_trends(df, district="Belfast City")
+        >>> sorted(trends.columns.tolist())
+        ['calendar_year', 'count', 'date', 'month']
+        >>> len(trends) > 0
+        True
     """
     filtered = df[
         (df["crime_type"] == crime_type) & (df["policing_district"] == district) & (df["data_measure"] == measure)

--- a/src/bolster/data_sources/psni/road_traffic_collisions.py
+++ b/src/bolster/data_sources/psni/road_traffic_collisions.py
@@ -27,19 +27,12 @@ Reference Date: Date of collision occurrence
 Time Coverage: 2013 to present
 
 Example:
-    >>> from bolster.data_sources.psni import road_traffic_collisions
-    >>> # Get latest collision data
-    >>> df = road_traffic_collisions.get_collisions()
-    >>> print(df.head())
-    >>>
-    >>> # Get casualties with decoded values
-    >>> casualties = road_traffic_collisions.get_casualties()
-    >>> fatal = casualties[casualties['severity'] == 'Fatal']
-    >>> print(f"Fatal casualties: {len(fatal)}")
-    >>>
-    >>> # Get summary statistics
-    >>> summary = road_traffic_collisions.get_annual_summary()
-    >>> print(summary)
+    >>> from bolster.data_sources.psni import road_traffic_collisions  # doctest: +SKIP
+    >>> df = road_traffic_collisions.get_collisions()  # doctest: +SKIP
+    >>> print(df.head())  # doctest: +SKIP
+    >>> casualties = road_traffic_collisions.get_casualties()  # doctest: +SKIP
+    >>> fatal = casualties[casualties['severity'] == 'Fatal']  # doctest: +SKIP
+    >>> summary = road_traffic_collisions.get_annual_summary()  # doctest: +SKIP
 """
 
 import logging
@@ -228,8 +221,8 @@ def get_available_years() -> list[int]:
         List of years (integers) in descending order
 
     Example:
-        >>> years = get_available_years()
-        >>> print(years)  # e.g., [2024, 2023, 2022, ...]
+        >>> years = get_available_years()  # doctest: +SKIP
+        >>> print(years)  # e.g., [2024, 2023, 2022, ...]  # doctest: +SKIP
     """
     datasets = _get_available_datasets()
     return [d["year"] for d in datasets]
@@ -309,9 +302,9 @@ def get_collisions(
             - nuts3_code: str (NUTS3 region code)
 
     Example:
-        >>> df = get_collisions(2024)
-        >>> print(f"Total collisions: {len(df)}")
-        >>> print(df.groupby('district')['casualties'].sum())
+        >>> df = get_collisions(2024)  # doctest: +SKIP
+        >>> print(f"Total collisions: {len(df)}")  # doctest: +SKIP
+        >>> print(df.groupby('district')['casualties'].sum())  # doctest: +SKIP
     """
     if year is None:
         years = get_available_years()
@@ -403,10 +396,10 @@ def get_casualties(
             - severity_code: int (1=fatal, 2=serious, 3=slight)
 
     Example:
-        >>> df = get_casualties(2024)
-        >>> print(df['severity'].value_counts())
-        >>> fatal = df[df['severity'] == 'Fatal']
-        >>> print(f"Fatal casualties: {len(fatal)}")
+        >>> df = get_casualties(2024)  # doctest: +SKIP
+        >>> print(df['severity'].value_counts())  # doctest: +SKIP
+        >>> fatal = df[df['severity'] == 'Fatal']  # doctest: +SKIP
+        >>> print(f"Fatal casualties: {len(fatal)}")  # doctest: +SKIP
     """
     if year is None:
         years = get_available_years()
@@ -475,8 +468,8 @@ def get_vehicles(
             - driver_age_group: int
 
     Example:
-        >>> df = get_vehicles(2024)
-        >>> print(df['vehicle_type'].value_counts())
+        >>> df = get_vehicles(2024)  # doctest: +SKIP
+        >>> print(df['vehicle_type'].value_counts())  # doctest: +SKIP
     """
     if year is None:
         years = get_available_years()
@@ -526,10 +519,10 @@ def get_casualties_with_collision_details(
         DataFrame with casualty records enriched with collision details
 
     Example:
-        >>> df = get_casualties_with_collision_details(2024)
+        >>> df = get_casualties_with_collision_details(2024)  # doctest: +SKIP
         >>> # Fatal casualties by district
-        >>> fatal_by_district = df[df['severity'] == 'Fatal'].groupby('district').size()
-        >>> print(fatal_by_district.sort_values(ascending=False))
+        >>> fatal_by_district = df[df['severity'] == 'Fatal'].groupby('district').size()  # doctest: +SKIP
+        >>> print(fatal_by_district.sort_values(ascending=False))  # doctest: +SKIP
     """
     casualties = get_casualties(year, force_refresh=force_refresh)
     collisions = get_collisions(year, force_refresh=force_refresh)
@@ -582,10 +575,10 @@ def get_annual_summary(
             - fatalities_per_100_collisions: float
 
     Example:
-        >>> summary = get_annual_summary()
-        >>> print(summary)
+        >>> summary = get_annual_summary()  # doctest: +SKIP
+        >>> print(summary)  # doctest: +SKIP
         >>> # Plot fatality trend
-        >>> summary.plot(x='year', y='fatal', kind='line')
+        >>> summary.plot(x='year', y='fatal', kind='line')  # doctest: +SKIP
     """
     if years is None:
         years = get_available_years()
@@ -645,8 +638,8 @@ def get_casualties_by_district(
             - slight: int
 
     Example:
-        >>> by_district = get_casualties_by_district(2024)
-        >>> print(by_district.sort_values('fatal', ascending=False))
+        >>> by_district = get_casualties_by_district(2024)  # doctest: +SKIP
+        >>> print(by_district.sort_values('fatal', ascending=False))  # doctest: +SKIP
     """
     df = get_casualties_with_collision_details(year, force_refresh=force_refresh)
 
@@ -693,8 +686,8 @@ def get_casualties_by_road_user(
             - fatality_rate: float (fatal / total %)
 
     Example:
-        >>> by_user = get_casualties_by_road_user(2024)
-        >>> print(by_user)
+        >>> by_user = get_casualties_by_road_user(2024)  # doctest: +SKIP
+        >>> print(by_user)  # doctest: +SKIP
     """
     df = get_casualties(year, force_refresh=force_refresh)
 

--- a/src/bolster/data_sources/psni/road_traffic_collisions.py
+++ b/src/bolster/data_sources/psni/road_traffic_collisions.py
@@ -29,9 +29,11 @@ Time Coverage: 2013 to present
 Example:
     >>> from bolster.data_sources.psni import road_traffic_collisions
     >>> df = road_traffic_collisions.get_collisions()
-    >>> casualties = road_traffic_collisions.get_casualties()
-    >>> fatal = casualties[casualties['severity'] == 'Fatal']
+    >>> 'severity' in road_traffic_collisions.get_casualties().columns
+    True
     >>> summary = road_traffic_collisions.get_annual_summary()
+    >>> 'year' in summary.columns
+    True
 """
 
 import logging
@@ -221,7 +223,8 @@ def get_available_years() -> list[int]:
 
     Example:
         >>> years = get_available_years()
-        >>> print(years)  # e.g., [2024, 2023, 2022, ...]
+        >>> len(years) > 0
+        True
     """
     datasets = _get_available_datasets()
     return [d["year"] for d in datasets]
@@ -302,6 +305,8 @@ def get_collisions(
 
     Example:
         >>> df = get_collisions(2024)
+        >>> 'severity' in df.columns or 'district' in df.columns
+        True
     """
     if year is None:
         years = get_available_years()
@@ -394,7 +399,8 @@ def get_casualties(
 
     Example:
         >>> df = get_casualties(2024)
-        >>> fatal = df[df['severity'] == 'Fatal']
+        >>> 'severity' in df.columns
+        True
     """
     if year is None:
         years = get_available_years()
@@ -464,6 +470,8 @@ def get_vehicles(
 
     Example:
         >>> df = get_vehicles(2024)
+        >>> 'vehicle_id' in df.columns
+        True
     """
     if year is None:
         years = get_available_years()
@@ -514,8 +522,8 @@ def get_casualties_with_collision_details(
 
     Example:
         >>> df = get_casualties_with_collision_details(2024)
-        >>> # Fatal casualties by district
-        >>> fatal_by_district = df[df['severity'] == 'Fatal'].groupby('district').size()
+        >>> 'severity' in df.columns
+        True
     """
     casualties = get_casualties(year, force_refresh=force_refresh)
     collisions = get_collisions(year, force_refresh=force_refresh)
@@ -569,8 +577,8 @@ def get_annual_summary(
 
     Example:
         >>> summary = get_annual_summary()
-        >>> # Plot fatality trend
-        >>> summary.plot(x='year', y='fatal', kind='line')
+        >>> 'fatal' in summary.columns
+        True
     """
     if years is None:
         years = get_available_years()
@@ -631,6 +639,8 @@ def get_casualties_by_district(
 
     Example:
         >>> by_district = get_casualties_by_district(2024)
+        >>> 'district' in by_district.columns
+        True
     """
     df = get_casualties_with_collision_details(year, force_refresh=force_refresh)
 
@@ -678,6 +688,8 @@ def get_casualties_by_road_user(
 
     Example:
         >>> by_user = get_casualties_by_road_user(2024)
+        >>> 'casualty_class' in by_user.columns
+        True
     """
     df = get_casualties(year, force_refresh=force_refresh)
 

--- a/src/bolster/data_sources/psni/road_traffic_collisions.py
+++ b/src/bolster/data_sources/psni/road_traffic_collisions.py
@@ -27,12 +27,11 @@ Reference Date: Date of collision occurrence
 Time Coverage: 2013 to present
 
 Example:
-    >>> from bolster.data_sources.psni import road_traffic_collisions  # doctest: +SKIP
-    >>> df = road_traffic_collisions.get_collisions()  # doctest: +SKIP
-    >>> print(df.head())  # doctest: +SKIP
-    >>> casualties = road_traffic_collisions.get_casualties()  # doctest: +SKIP
-    >>> fatal = casualties[casualties['severity'] == 'Fatal']  # doctest: +SKIP
-    >>> summary = road_traffic_collisions.get_annual_summary()  # doctest: +SKIP
+    >>> from bolster.data_sources.psni import road_traffic_collisions
+    >>> df = road_traffic_collisions.get_collisions()
+    >>> casualties = road_traffic_collisions.get_casualties()
+    >>> fatal = casualties[casualties['severity'] == 'Fatal']
+    >>> summary = road_traffic_collisions.get_annual_summary()
 """
 
 import logging
@@ -221,8 +220,8 @@ def get_available_years() -> list[int]:
         List of years (integers) in descending order
 
     Example:
-        >>> years = get_available_years()  # doctest: +SKIP
-        >>> print(years)  # e.g., [2024, 2023, 2022, ...]  # doctest: +SKIP
+        >>> years = get_available_years()
+        >>> print(years)  # e.g., [2024, 2023, 2022, ...]
     """
     datasets = _get_available_datasets()
     return [d["year"] for d in datasets]
@@ -302,9 +301,7 @@ def get_collisions(
             - nuts3_code: str (NUTS3 region code)
 
     Example:
-        >>> df = get_collisions(2024)  # doctest: +SKIP
-        >>> print(f"Total collisions: {len(df)}")  # doctest: +SKIP
-        >>> print(df.groupby('district')['casualties'].sum())  # doctest: +SKIP
+        >>> df = get_collisions(2024)
     """
     if year is None:
         years = get_available_years()
@@ -396,10 +393,8 @@ def get_casualties(
             - severity_code: int (1=fatal, 2=serious, 3=slight)
 
     Example:
-        >>> df = get_casualties(2024)  # doctest: +SKIP
-        >>> print(df['severity'].value_counts())  # doctest: +SKIP
-        >>> fatal = df[df['severity'] == 'Fatal']  # doctest: +SKIP
-        >>> print(f"Fatal casualties: {len(fatal)}")  # doctest: +SKIP
+        >>> df = get_casualties(2024)
+        >>> fatal = df[df['severity'] == 'Fatal']
     """
     if year is None:
         years = get_available_years()
@@ -468,8 +463,7 @@ def get_vehicles(
             - driver_age_group: int
 
     Example:
-        >>> df = get_vehicles(2024)  # doctest: +SKIP
-        >>> print(df['vehicle_type'].value_counts())  # doctest: +SKIP
+        >>> df = get_vehicles(2024)
     """
     if year is None:
         years = get_available_years()
@@ -519,10 +513,9 @@ def get_casualties_with_collision_details(
         DataFrame with casualty records enriched with collision details
 
     Example:
-        >>> df = get_casualties_with_collision_details(2024)  # doctest: +SKIP
+        >>> df = get_casualties_with_collision_details(2024)
         >>> # Fatal casualties by district
-        >>> fatal_by_district = df[df['severity'] == 'Fatal'].groupby('district').size()  # doctest: +SKIP
-        >>> print(fatal_by_district.sort_values(ascending=False))  # doctest: +SKIP
+        >>> fatal_by_district = df[df['severity'] == 'Fatal'].groupby('district').size()
     """
     casualties = get_casualties(year, force_refresh=force_refresh)
     collisions = get_collisions(year, force_refresh=force_refresh)
@@ -575,10 +568,9 @@ def get_annual_summary(
             - fatalities_per_100_collisions: float
 
     Example:
-        >>> summary = get_annual_summary()  # doctest: +SKIP
-        >>> print(summary)  # doctest: +SKIP
+        >>> summary = get_annual_summary()
         >>> # Plot fatality trend
-        >>> summary.plot(x='year', y='fatal', kind='line')  # doctest: +SKIP
+        >>> summary.plot(x='year', y='fatal', kind='line')
     """
     if years is None:
         years = get_available_years()
@@ -638,8 +630,7 @@ def get_casualties_by_district(
             - slight: int
 
     Example:
-        >>> by_district = get_casualties_by_district(2024)  # doctest: +SKIP
-        >>> print(by_district.sort_values('fatal', ascending=False))  # doctest: +SKIP
+        >>> by_district = get_casualties_by_district(2024)
     """
     df = get_casualties_with_collision_details(year, force_refresh=force_refresh)
 
@@ -686,8 +677,7 @@ def get_casualties_by_road_user(
             - fatality_rate: float (fatal / total %)
 
     Example:
-        >>> by_user = get_casualties_by_road_user(2024)  # doctest: +SKIP
-        >>> print(by_user)  # doctest: +SKIP
+        >>> by_user = get_casualties_by_road_user(2024)
     """
     df = get_casualties(year, force_refresh=force_refresh)
 

--- a/src/bolster/data_sources/wikipedia.py
+++ b/src/bolster/data_sources/wikipedia.py
@@ -65,7 +65,7 @@ def get_ni_executive_basic_table() -> pd.DataFrame:
     url = "https://en.wikipedia.org/wiki/Northern_Ireland_Executive"
     response = session.get(url, headers=headers)
     response.raise_for_status()
-    tables = pd.read_html(response.text)
+    tables = pd.read_html(pd.io.common.StringIO(response.text))
     tables[4].columns = range(len(tables[4].columns))
 
     # Get rid of the nasty multi index
@@ -94,7 +94,7 @@ def get_ni_executive_basic_table() -> pd.DataFrame:
     executive_durations = executive_events.groupby(["Executive", "Active"])["Date"].first().unstack()
     executive_durations.columns = ["Dissolved", "Established"]
     executive_durations = executive_durations[reversed(executive_durations.columns)]
-    executive_durations = executive_durations.applymap(lambda s: dateparser.parse(s) if isinstance(s, str) else s)
+    executive_durations = executive_durations.map(lambda s: dateparser.parse(s) if isinstance(s, str) else s)
     executive_durations["Duration"] = executive_durations.diff(axis=1).iloc[:, -1:]
 
     executive_dissolutions = pd.concat(

--- a/src/bolster/data_sources/wikipedia.py
+++ b/src/bolster/data_sources/wikipedia.py
@@ -13,20 +13,20 @@ Executive" table which maintains a comprehensive record of all executives since 
 Example:
     Extract NI Executive historical data and analyze political stability:
 
-        >>> from bolster.data_sources import wikipedia
+        >>> from bolster.data_sources import wikipedia  # doctest: +SKIP
         >>> # Get complete Executive composition history
-        >>> executives = wikipedia.get_ni_executive_basic_table()
-        >>> print(f"Found {len(executives)} executives since devolution")
+        >>> executives = wikipedia.get_ni_executive_basic_table()  # doctest: +SKIP
+        >>> print(f"Found {len(executives)} executives since devolution")  # doctest: +SKIP
 
         >>> # Analyze Executive stability over time
-        >>> avg_duration = executives['Duration'].mean()
-        >>> print(f"Average Executive duration: {avg_duration}")
+        >>> avg_duration = executives['Duration'].mean()  # doctest: +SKIP
+        >>> print(f"Average Executive duration: {avg_duration}")  # doctest: +SKIP
 
         >>> # Find longest and shortest serving executives
-        >>> longest = executives.loc[executives['Duration'].idxmax()]
-        >>> shortest = executives.loc[executives['Duration'].idxmin()]
-        >>> print(f"Longest serving: {longest.name} ({longest['Duration']})")
-        >>> print(f"Shortest serving: {shortest.name} ({shortest['Duration']})")
+        >>> longest = executives.loc[executives['Duration'].idxmax()]  # doctest: +SKIP
+        >>> shortest = executives.loc[executives['Duration'].idxmin()]  # doctest: +SKIP
+        >>> print(f"Longest serving: {longest.name} ({longest['Duration']})")  # doctest: +SKIP
+        >>> print(f"Shortest serving: {shortest.name} ({shortest['Duration']})")  # doctest: +SKIP
 
 This module provides utilities for analyzing Northern Ireland's political history and executive
 stability patterns since the establishment of devolved government.
@@ -59,8 +59,8 @@ def get_ni_executive_basic_table() -> pd.DataFrame:
         - Interregnum: timedelta64[ns] - Gap until next executive
 
     Example:
-        >>> df = get_ni_executive_basic_table()
-        >>> print(df.dtypes)
+        >>> df = get_ni_executive_basic_table()  # doctest: +SKIP
+        >>> print(df.dtypes)  # doctest: +SKIP
         Established     datetime64[ns]
         Dissolved       datetime64[ns]
         Duration       timedelta64[ns]

--- a/src/bolster/data_sources/wikipedia.py
+++ b/src/bolster/data_sources/wikipedia.py
@@ -13,20 +13,17 @@ Executive" table which maintains a comprehensive record of all executives since 
 Example:
     Extract NI Executive historical data and analyze political stability:
 
-        >>> from bolster.data_sources import wikipedia  # doctest: +SKIP
+        >>> from bolster.data_sources import wikipedia
         >>> # Get complete Executive composition history
-        >>> executives = wikipedia.get_ni_executive_basic_table()  # doctest: +SKIP
-        >>> print(f"Found {len(executives)} executives since devolution")  # doctest: +SKIP
+        >>> executives = wikipedia.get_ni_executive_basic_table()
 
         >>> # Analyze Executive stability over time
-        >>> avg_duration = executives['Duration'].mean()  # doctest: +SKIP
-        >>> print(f"Average Executive duration: {avg_duration}")  # doctest: +SKIP
+        >>> avg_duration = executives['Duration'].mean()
 
         >>> # Find longest and shortest serving executives
-        >>> longest = executives.loc[executives['Duration'].idxmax()]  # doctest: +SKIP
-        >>> shortest = executives.loc[executives['Duration'].idxmin()]  # doctest: +SKIP
-        >>> print(f"Longest serving: {longest.name} ({longest['Duration']})")  # doctest: +SKIP
-        >>> print(f"Shortest serving: {shortest.name} ({shortest['Duration']})")  # doctest: +SKIP
+        >>> longest = executives.loc[executives['Duration'].idxmax()]
+        >>> shortest = executives.loc[executives['Duration'].idxmin()]
+        >>> print(f"Shortest serving: {shortest.name} ({shortest['Duration']})")
 
 This module provides utilities for analyzing Northern Ireland's political history and executive
 stability patterns since the establishment of devolved government.
@@ -59,8 +56,8 @@ def get_ni_executive_basic_table() -> pd.DataFrame:
         - Interregnum: timedelta64[ns] - Gap until next executive
 
     Example:
-        >>> df = get_ni_executive_basic_table()  # doctest: +SKIP
-        >>> print(df.dtypes)  # doctest: +SKIP
+        >>> df = get_ni_executive_basic_table()
+        >>> print(df.dtypes)
         Established     datetime64[ns]
         Dissolved       datetime64[ns]
         Duration       timedelta64[ns]

--- a/src/bolster/data_sources/wikipedia.py
+++ b/src/bolster/data_sources/wikipedia.py
@@ -14,16 +14,11 @@ Example:
     Extract NI Executive historical data and analyze political stability:
 
         >>> from bolster.data_sources import wikipedia
-        >>> # Get complete Executive composition history
         >>> executives = wikipedia.get_ni_executive_basic_table()
-
-        >>> # Analyze Executive stability over time
-        >>> avg_duration = executives['Duration'].mean()
-
-        >>> # Find longest and shortest serving executives
-        >>> longest = executives.loc[executives['Duration'].idxmax()]
-        >>> shortest = executives.loc[executives['Duration'].idxmin()]
-        >>> print(f"Shortest serving: {shortest.name} ({shortest['Duration']})")
+        >>> 'Duration' in executives.columns
+        True
+        >>> len(executives) > 0
+        True
 
 This module provides utilities for analyzing Northern Ireland's political history and executive
 stability patterns since the establishment of devolved government.
@@ -57,12 +52,10 @@ def get_ni_executive_basic_table() -> pd.DataFrame:
 
     Example:
         >>> df = get_ni_executive_basic_table()
-        >>> print(df.dtypes)
-        Established     datetime64[ns]
-        Dissolved       datetime64[ns]
-        Duration       timedelta64[ns]
-        Interregnum    timedelta64[ns]
-        dtype: object
+        >>> sorted(df.columns.tolist())
+        ['Dissolved', 'Duration', 'Established', 'Interregnum']
+        >>> len(df) > 0
+        True
     """
     # Use a custom user agent to avoid Wikipedia 403 errors
     # Wikipedia blocks default pandas/urllib user agents

--- a/src/bolster/stats/__init__.py
+++ b/src/bolster/stats/__init__.py
@@ -75,7 +75,7 @@ def drop_totals(
         Whether to modify the DataFrame in place, by default True.
 
     Returns:
-    -------
+    --------
     pd.DataFrame
         The DataFrame with totals removed.
 
@@ -111,7 +111,7 @@ def fix_datetime_tz_columns(df: pd.DataFrame, inplace=True) -> pd.DataFrame:
 
 
     Returns:
-    -------
+    --------
     df
 
     """
@@ -134,7 +134,7 @@ def top_n(df: pd.DataFrame, n: int, others: AnyStr = "others") -> pd.DataFrame:
         The number of top rows to keep.
 
     Returns:
-    -------
+    --------
     pd.DataFrame
         The truncated DataFrame with an 'others' row.
 

--- a/src/bolster/stats/distributions.py
+++ b/src/bolster/stats/distributions.py
@@ -1,3 +1,20 @@
+"""Statistical distribution fitting utilities.
+
+Provides :func:`best_fit_distribution`, which tests a large set of
+``scipy.stats`` continuous distributions against observed data and returns
+the one with the lowest sum-of-squared-errors against the empirical
+histogram.
+
+Intended for exploratory data analysis where you want a quick sanity-check
+on which parametric family best describes your data before committing to a
+more rigorous approach.
+
+Note:
+    This module depends on :mod:`scipy` and :mod:`numpy`.  The fitting loop
+    is marked ``# pragma: no cover`` because it is compute-intensive and not
+    suitable for CI; validate results manually or in a notebook.
+"""
+
 import warnings
 from time import time
 

--- a/src/bolster/utils/cache.py
+++ b/src/bolster/utils/cache.py
@@ -13,7 +13,7 @@ Example:
     >>> hash_url("https://example.com/data.csv")
     '2a01ab0de708440185cbb6473893860c'
     >>> downloader = CachedDownloader("my_source")
-    >>> path = downloader.download("https://example.com/data.csv", cache_ttl_hours=24)  # doctest: +SKIP
+    >>> path = downloader.download("https://example.com/data.csv", cache_ttl_hours=24)
 """
 
 import hashlib
@@ -72,7 +72,7 @@ class CachedDownloader:
         >>> path = downloader.download(
         ...     "https://example.com/data.csv",
         ...     cache_ttl_hours=24
-        ... )  # doctest: +SKIP
+        ... )
     """
 
     def __init__(self, namespace: str, timeout: int = 60):

--- a/src/bolster/utils/cache.py
+++ b/src/bolster/utils/cache.py
@@ -13,7 +13,8 @@ Example:
     >>> hash_url("https://example.com/data.csv")
     '2a01ab0de708440185cbb6473893860c'
     >>> downloader = CachedDownloader("my_source")
-    >>> path = downloader.download("https://example.com/data.csv", cache_ttl_hours=24)
+    >>> downloader.namespace
+    'my_source'
 """
 
 import hashlib
@@ -69,10 +70,12 @@ class CachedDownloader:
 
     Example:
         >>> downloader = CachedDownloader("psni", timeout=60)
-        >>> path = downloader.download(
-        ...     "https://example.com/data.csv",
-        ...     cache_ttl_hours=24
-        ... )
+        >>> downloader.namespace
+        'psni'
+        >>> downloader.timeout
+        60
+        >>> downloader.cache_dir.parts[-2:]
+        ('bolster', 'psni')
     """
 
     def __init__(self, namespace: str, timeout: int = 60):

--- a/src/bolster/utils/cache.py
+++ b/src/bolster/utils/cache.py
@@ -9,9 +9,11 @@ Cache Location:
     based on URL hashes. Each data source uses its own namespace.
 
 Example:
-    >>> from bolster.utils.cache import CachedDownloader
+    >>> from bolster.utils.cache import CachedDownloader, hash_url
+    >>> hash_url("https://example.com/data.csv")
+    '2a01ab0de708440185cbb6473893860c'
     >>> downloader = CachedDownloader("my_source")
-    >>> path = downloader.download("https://example.com/data.csv", cache_ttl_hours=24)
+    >>> path = downloader.download("https://example.com/data.csv", cache_ttl_hours=24)  # doctest: +SKIP
 """
 
 import hashlib

--- a/src/bolster/utils/datatables.py
+++ b/src/bolster/utils/datatables.py
@@ -8,9 +8,8 @@ structure, where ``x["data"]`` is a list of column arrays (not row arrays) and
 
 Example:
     >>> from bolster.utils.datatables import fetch_datatables_json, datatables_to_dataframe
-    >>> payload = fetch_datatables_json("https://datavis.nisra.gov.uk/health/my-data.html")  # doctest: +SKIP
-    >>> df = datatables_to_dataframe(payload)  # doctest: +SKIP
-    >>> print(df.head())  # doctest: +SKIP
+    >>> payload = fetch_datatables_json("https://datavis.nisra.gov.uk/health/my-data.html")
+    >>> df = datatables_to_dataframe(payload)
 """
 
 import json
@@ -47,8 +46,8 @@ def fetch_datatables_json(url: str, timeout: int = 30) -> dict:
         DataTablesError: If the page cannot be fetched or no DT payload is found.
 
     Example:
-        >>> payload = fetch_datatables_json("https://example.com/data.html")  # doctest: +SKIP
-        >>> len(payload["data"])  # doctest: +SKIP
+        >>> payload = fetch_datatables_json("https://example.com/data.html")
+        >>> len(payload["data"])
     """
     try:
         response = session.get(url, timeout=timeout)

--- a/src/bolster/utils/datatables.py
+++ b/src/bolster/utils/datatables.py
@@ -8,9 +8,9 @@ structure, where ``x["data"]`` is a list of column arrays (not row arrays) and
 
 Example:
     >>> from bolster.utils.datatables import fetch_datatables_json, datatables_to_dataframe
-    >>> payload = fetch_datatables_json("https://datavis.nisra.gov.uk/health/my-data.html")
-    >>> df = datatables_to_dataframe(payload)
-    >>> print(df.head())
+    >>> payload = fetch_datatables_json("https://datavis.nisra.gov.uk/health/my-data.html")  # doctest: +SKIP
+    >>> df = datatables_to_dataframe(payload)  # doctest: +SKIP
+    >>> print(df.head())  # doctest: +SKIP
 """
 
 import json
@@ -47,9 +47,8 @@ def fetch_datatables_json(url: str, timeout: int = 30) -> dict:
         DataTablesError: If the page cannot be fetched or no DT payload is found.
 
     Example:
-        >>> payload = fetch_datatables_json("https://example.com/data.html")
-        >>> len(payload["data"])   # number of columns
-        11
+        >>> payload = fetch_datatables_json("https://example.com/data.html")  # doctest: +SKIP
+        >>> len(payload["data"])  # doctest: +SKIP
     """
     try:
         response = session.get(url, timeout=timeout)

--- a/src/bolster/utils/datatables.py
+++ b/src/bolster/utils/datatables.py
@@ -7,9 +7,14 @@ structure, where ``x["data"]`` is a list of column arrays (not row arrays) and
 ``x["container"]`` holds the HTML table header with column names.
 
 Example:
-    >>> from bolster.utils.datatables import fetch_datatables_json, datatables_to_dataframe
-    >>> payload = fetch_datatables_json("https://datavis.nisra.gov.uk/health/my-data.html")
+    >>> from bolster.utils.datatables import datatables_to_dataframe
+    >>> payload = {
+    ...     "data": [["A", "B"], [1, 2]],
+    ...     "container": "<table><thead><tr><th>Name</th><th>Value</th></tr></thead></table>",
+    ... }
     >>> df = datatables_to_dataframe(payload)
+    >>> list(df.columns)
+    ['Name', 'Value']
 """
 
 import json
@@ -46,8 +51,29 @@ def fetch_datatables_json(url: str, timeout: int = 30) -> dict:
         DataTablesError: If the page cannot be fetched or no DT payload is found.
 
     Example:
-        >>> payload = fetch_datatables_json("https://example.com/data.html")
+        >>> from bolster.utils.datatables import DataTablesError
+        >>> try:
+        ...     fetch_datatables_json("https://example.com/data.html")
+        ... except DataTablesError:
+        ...     print("DataTablesError raised for invalid page")
+        DataTablesError raised for invalid page
+
+        A successful call returns a dict extracted from the page's DT widget.
+        The shape mirrors what ``_extract_datatables_payload`` returns:
+
+        >>> sample_html = (
+        ...     '<script type="application/json">'
+        ...     '{"x": {"data": [["Belfast", "Derry"], [1200, 800]],'
+        ...     ' "container": "<thead><tr><th>City</th><th>Count</th></tr></thead>"}}'
+        ...     "</script>"
+        ... )
+        >>> payload = _extract_datatables_payload(sample_html)
+        >>> sorted(payload.keys())
+        ['container', 'data']
         >>> len(payload["data"])
+        2
+        >>> payload["data"][0]
+        ['Belfast', 'Derry']
     """
     try:
         response = session.get(url, timeout=timeout)

--- a/src/bolster/utils/dt.py
+++ b/src/bolster/utils/dt.py
@@ -1,34 +1,53 @@
+"""Datetime rounding and timezone utilities.
+
+Provides helpers that coerce :class:`datetime.datetime` and
+:class:`datetime.date` objects to useful calendar boundaries (week, month)
+and to UTC midnight, without depending on any third-party libraries.
+
+Example:
+    >>> from bolster.utils.dt import round_to_week, round_to_month
+    >>> from datetime import date
+    >>> round_to_week(date(2024, 3, 13))   # Wednesday → previous Monday
+    datetime.date(2024, 3, 11)
+    >>> round_to_month(date(2024, 3, 13))
+    datetime.date(2024, 3, 1)
+"""
+
 from datetime import date, datetime, timedelta, timezone
 
 
 def round_to_week(dt: datetime | date) -> date:
-    """Return a date for the Monday before the given date.
+    """Return a date for the Monday of the week containing the given date.
 
     Args:
-      dt: return:
-      dt: datetime:
+        dt: A :class:`datetime.datetime` or :class:`datetime.date` to round.
 
     Returns:
-    >>> round_to_week(datetime(2018,8,9,12,1))
-    datetime.date(2018, 8, 6)
-    >>> round_to_week(date(2018,8,9))
-    datetime.date(2018, 8, 6)
+        The Monday on or before ``dt`` as a :class:`datetime.date`.
+
+    Example:
+        >>> round_to_week(datetime(2018,8,9,12,1))
+        datetime.date(2018, 8, 6)
+        >>> round_to_week(date(2018,8,9))
+        datetime.date(2018, 8, 6)
     """
     return (dt.date() if isinstance(dt, datetime) else dt) - timedelta(days=dt.weekday())
 
 
 def round_to_month(dt: datetime | date) -> date:
-    """Return a date for the first day of the month of a given date.
+    """Return a date for the first day of the month containing the given date.
 
     Args:
-      dt: return:
-      dt: datetime:
+        dt: A :class:`datetime.datetime` or :class:`datetime.date` to round.
 
     Returns:
-    >>> round_to_month(datetime(2018,8,9,12,1))
-    datetime.date(2018, 8, 1)
-    >>> round_to_month(date(2018,8,9))
-    datetime.date(2018, 8, 1)
+        The first day of the month of ``dt`` as a :class:`datetime.date`.
+
+    Example:
+        >>> round_to_month(datetime(2018,8,9,12,1))
+        datetime.date(2018, 8, 1)
+        >>> round_to_month(date(2018,8,9))
+        datetime.date(2018, 8, 1)
     """
     dt = dt.date() if isinstance(dt, datetime) else dt
 
@@ -36,22 +55,26 @@ def round_to_month(dt: datetime | date) -> date:
 
 
 def utc_midnight_on(dt: datetime) -> datetime:
-    """Some services don't like timezones, so this helper function converts datetime objects to UTC midnight.
+    """Return UTC midnight for the calendar date of a given datetime.
 
-    Converts `datetime.date` and `datetime.datetime` objects to a `datetime.datetime`
-    object corresponding to UTC Midnight on that date.
-
-    Pays primary attention to the actual Date of the input, regardless of if the combination
-    of given-time and timezone would roll over into another date.
+    Converts any :class:`datetime.datetime` to ``00:00:00 UTC`` on the same
+    calendar date, regardless of the original time or timezone offset.  This
+    is useful when a downstream service requires UTC-naive timestamps or
+    rejects sub-day granularity.
 
     Args:
-      dt: return:
-      dt: datetime:
+        dt: A :class:`datetime.datetime` whose calendar date is used.  The
+            time component and any timezone info are ignored.
 
-    >>> utc_midnight_on(datetime(2018,9,1,12,12))
-    datetime.datetime(2018, 9, 1, 0, 0, tzinfo=datetime.timezone.utc)
+    Returns:
+        A timezone-aware :class:`datetime.datetime` at ``00:00:00 UTC`` on
+        the same calendar date as ``dt``.
 
-    >>> utc_midnight_on(datetime(2018,9,1,12,12, tzinfo=timezone(timedelta(hours=-13))))
-    datetime.datetime(2018, 9, 1, 0, 0, tzinfo=datetime.timezone.utc)
+    Example:
+        >>> utc_midnight_on(datetime(2018,9,1,12,12))
+        datetime.datetime(2018, 9, 1, 0, 0, tzinfo=datetime.timezone.utc)
+
+        >>> utc_midnight_on(datetime(2018,9,1,12,12, tzinfo=timezone(timedelta(hours=-13))))
+        datetime.datetime(2018, 9, 1, 0, 0, tzinfo=datetime.timezone.utc)
     """
     return datetime.combine(dt.date(), datetime.min.time()).replace(tzinfo=timezone.utc)

--- a/src/bolster/utils/io.py
+++ b/src/bolster/utils/io.py
@@ -1,10 +1,42 @@
+"""File I/O helpers.
+
+Provides thin wrappers around :mod:`pandas` I/O for common tasks, such as
+writing multiple DataFrames to separate sheets of a single Excel workbook.
+
+Example:
+    >>> import pandas as pd
+    >>> from bolster.utils.io import save_xls
+    >>> import tempfile, os
+    >>> df1 = pd.DataFrame({"a": [1, 2]})
+    >>> df2 = pd.DataFrame({"b": [3, 4]})
+    >>> with tempfile.NamedTemporaryFile(suffix=".xlsx", delete=False) as f:
+    ...     tmp = f.name
+    >>> save_xls({"Sheet1": df1, "Sheet2": df2}, tmp)
+    >>> os.remove(tmp)
+"""
+
 from typing import AnyStr, BinaryIO
 
 import pandas as pd
 
 
 def save_xls(dict_df: dict[AnyStr, pd.DataFrame], path: str | BinaryIO) -> None:
-    """Save a dictionary of dataframes to an excel file, with each dataframe as a separate page."""
+    """Write a mapping of sheet-name → DataFrame to a multi-sheet Excel file.
+
+    Args:
+        dict_df: Mapping of sheet names to DataFrames.  Each key becomes a
+            worksheet name; each value is written to that sheet.
+        path: File path (``str``) or writable binary file-like object for the
+            output ``.xlsx`` workbook.
+
+    Example:
+        >>> import pandas as pd, tempfile, os
+        >>> df = pd.DataFrame({"x": [10, 20]})
+        >>> with tempfile.NamedTemporaryFile(suffix=".xlsx", delete=False) as f:
+        ...     tmp = f.name
+        >>> save_xls({"Results": df}, tmp)
+        >>> os.remove(tmp)
+    """
     with pd.ExcelWriter(path) as writer:
         for key in dict_df:
             dict_df[key].to_excel(writer, key)

--- a/src/bolster/utils/io.py
+++ b/src/bolster/utils/io.py
@@ -39,4 +39,4 @@ def save_xls(dict_df: dict[AnyStr, pd.DataFrame], path: str | BinaryIO) -> None:
     """
     with pd.ExcelWriter(path) as writer:
         for key in dict_df:
-            dict_df[key].to_excel(writer, key)
+            dict_df[key].to_excel(writer, sheet_name=key)

--- a/src/bolster/utils/rss.py
+++ b/src/bolster/utils/rss.py
@@ -174,9 +174,8 @@ def parse_rss_feed(feed_url: str, timeout: int = 30) -> Feed:
         ValueError: If the feed cannot be parsed
 
     Example:
-        >>> feed = parse_rss_feed("https://example.com/feed.xml")  # doctest: +SKIP
-        >>> print(f"Feed: {feed.title}")  # doctest: +SKIP
-        >>> for entry in feed.entries:  # doctest: +SKIP
+        >>> feed = parse_rss_feed("https://example.com/feed.xml")
+        >>> for entry in feed.entries:
         ...     print(f"  - {entry.title}")
     """
     # Fetch the feed
@@ -295,10 +294,8 @@ def get_nisra_statistics_feed(order: str = "recent", timeout: int = 30, limit: i
         Feed object with NISRA statistics
 
     Example:
-        >>> feed = get_nisra_statistics_feed()  # doctest: +SKIP
-        >>> print(f"Found {len(feed.entries)} NISRA publications")  # doctest: +SKIP
-        >>> feed100 = get_nisra_statistics_feed(limit=100)  # doctest: +SKIP
-        >>> print(f"Found {len(feed100.entries)} NISRA publications")  # doctest: +SKIP
+        >>> feed = get_nisra_statistics_feed()
+        >>> feed100 = get_nisra_statistics_feed(limit=100)
     """
     order_param = "&order=release-date-oldest" if order == "oldest" else ""
     base_url = (

--- a/src/bolster/utils/rss.py
+++ b/src/bolster/utils/rss.py
@@ -112,20 +112,25 @@ def parse_feed_entry(entry: feedparser.FeedParserDict) -> FeedEntry:
     if hasattr(entry, "tags"):
         categories = [tag.get("term", "") for tag in entry.tags if tag.get("term")]
 
-    # Extract dates - try updated first since some feeds only have updated
+    # Extract dates - access underlying dict directly to bypass feedparser's deprecated
+    # updated→published fallback (feedparser issue #310). Both .get() and attribute access
+    # go through FeedParserDict.__getitem__ which triggers the DeprecationWarning.
+    _d = dict.__getitem__  # shorthand for direct dict access
+    _has = dict.__contains__
+
     updated = None
-    if hasattr(entry, "updated"):
-        updated = parse_date(entry.updated)
-    elif hasattr(entry, "updated_parsed") and entry.updated_parsed:
+    if _has(entry, "updated"):
+        updated = parse_date(_d(entry, "updated"))
+    elif _has(entry, "updated_parsed") and _d(entry, "updated_parsed"):
         with contextlib.suppress(TypeError, ValueError):
-            updated = datetime(*entry.updated_parsed[:6])
+            updated = datetime(*_d(entry, "updated_parsed")[:6])
 
     published = None
-    if hasattr(entry, "published"):
-        published = parse_date(entry.published)
-    elif hasattr(entry, "published_parsed") and entry.published_parsed:
+    if _has(entry, "published"):
+        published = parse_date(_d(entry, "published"))
+    elif _has(entry, "published_parsed") and _d(entry, "published_parsed"):
         with contextlib.suppress(TypeError, ValueError):
-            published = datetime(*entry.published_parsed[:6])
+            published = datetime(*_d(entry, "published_parsed")[:6])
 
     # Fall back to updated if published is not available
     if published is None and updated is not None:
@@ -218,13 +223,15 @@ def parse_rss_feed(feed_url: str, timeout: int = 30) -> Feed:
     # Extract feed metadata
     feed_info = parsed.get("feed", {})
 
-    # Extract feed updated date
+    # Extract feed updated date - bypass feedparser's deprecated fallback (issue #310)
     updated = None
-    if hasattr(feed_info, "updated"):
-        updated = parse_date(feed_info.updated)
-    elif hasattr(feed_info, "updated_parsed") and feed_info.updated_parsed:
-        with contextlib.suppress(TypeError, ValueError):
-            updated = datetime(*feed_info.updated_parsed[:6])
+    if isinstance(feed_info, dict) and dict.__contains__(feed_info, "updated"):
+        updated = parse_date(dict.__getitem__(feed_info, "updated"))
+    elif isinstance(feed_info, dict) and dict.__contains__(feed_info, "updated_parsed"):
+        up = dict.__getitem__(feed_info, "updated_parsed")
+        if up:
+            with contextlib.suppress(TypeError, ValueError):
+                updated = datetime(*up[:6])
 
     # Parse entries
     entries = [parse_feed_entry(entry) for entry in parsed.entries]

--- a/src/bolster/utils/rss.py
+++ b/src/bolster/utils/rss.py
@@ -174,9 +174,27 @@ def parse_rss_feed(feed_url: str, timeout: int = 30) -> Feed:
         ValueError: If the feed cannot be parsed
 
     Example:
-        >>> feed = parse_rss_feed("https://example.com/feed.xml")
-        >>> for entry in feed.entries:
-        ...     print(f"  - {entry.title}")
+        >>> feed = parse_rss_feed(
+        ...     "https://www.gov.uk/search/research-and-statistics.atom?"
+        ...     "content_store_document_type=all_research_and_statistics&"
+        ...     "organisations%5B%5D=northern-ireland-statistics-and-research-agency"
+        ... )
+        >>> feed.title
+        'Research and statistics from Northern Ireland Statistics and Research Agency (NISRA)'
+        >>> sorted(feed.__dataclass_fields__)
+        ['description', 'entries', 'language', 'link', 'title', 'updated']
+        >>> len(feed.entries) > 0
+        True
+        >>> entry = feed.entries[0]
+        >>> sorted(entry.__dataclass_fields__)
+        ['author', 'categories', 'content', 'id', 'link', 'published', 'summary', 'title', 'updated']
+        >>> isinstance(entry.title, str) and isinstance(entry.link, str)
+        True
+        >>> entry.link.startswith("http")
+        True
+        >>> from datetime import datetime
+        >>> isinstance(entry.published, datetime)
+        True
     """
     # Fetch the feed
     try:

--- a/src/bolster/utils/rss.py
+++ b/src/bolster/utils/rss.py
@@ -174,9 +174,9 @@ def parse_rss_feed(feed_url: str, timeout: int = 30) -> Feed:
         ValueError: If the feed cannot be parsed
 
     Example:
-        >>> feed = parse_rss_feed("https://example.com/feed.xml")
-        >>> print(f"Feed: {feed.title}")
-        >>> for entry in feed.entries:
+        >>> feed = parse_rss_feed("https://example.com/feed.xml")  # doctest: +SKIP
+        >>> print(f"Feed: {feed.title}")  # doctest: +SKIP
+        >>> for entry in feed.entries:  # doctest: +SKIP
         ...     print(f"  - {entry.title}")
     """
     # Fetch the feed
@@ -242,12 +242,16 @@ def filter_entries(
         Filtered list of FeedEntry objects
 
     Example:
-        >>> feed = parse_rss_feed("https://example.com/feed.xml")
-        >>> recent = filter_entries(
-        ...     feed.entries,
-        ...     title_contains="statistics",
-        ...     after_date="2024-01-01"
-        ... )
+        >>> from bolster.utils.rss import FeedEntry, filter_entries
+        >>> from datetime import datetime
+        >>> entries = [
+        ...     FeedEntry("Births Statistics April 2024", "http://example.com/1", published=datetime(2024, 4, 1)),
+        ...     FeedEntry("Deaths Statistics April 2024", "http://example.com/2", published=datetime(2024, 4, 2)),
+        ...     FeedEntry("Old Statistics 2023", "http://example.com/3", published=datetime(2023, 6, 1)),
+        ... ]
+        >>> recent = filter_entries(entries, title_contains="births", after_date="2024-01-01")
+        >>> [e.title for e in recent]
+        ['Births Statistics April 2024']
     """
     filtered = entries
 
@@ -291,10 +295,10 @@ def get_nisra_statistics_feed(order: str = "recent", timeout: int = 30, limit: i
         Feed object with NISRA statistics
 
     Example:
-        >>> feed = get_nisra_statistics_feed()
-        >>> print(f"Found {len(feed.entries)} NISRA publications")
-        >>> feed100 = get_nisra_statistics_feed(limit=100)
-        >>> print(f"Found {len(feed100.entries)} NISRA publications")
+        >>> feed = get_nisra_statistics_feed()  # doctest: +SKIP
+        >>> print(f"Found {len(feed.entries)} NISRA publications")  # doctest: +SKIP
+        >>> feed100 = get_nisra_statistics_feed(limit=100)  # doctest: +SKIP
+        >>> print(f"Found {len(feed100.entries)} NISRA publications")  # doctest: +SKIP
     """
     order_param = "&order=release-date-oldest" if order == "oldest" else ""
     base_url = (

--- a/src/bolster/utils/web.py
+++ b/src/bolster/utils/web.py
@@ -1,3 +1,22 @@
+"""HTTP session utilities with retry and rate-limit handling.
+
+Provides a pre-configured :class:`requests.Session` (``session``) with:
+
+- Automatic retry on transient server errors (500/502/503/504)
+- Rate-limit awareness: exponential backoff on 429 responses, capped at 60 s
+- A consistent ``User-Agent`` header for polite scraping
+- Helpers for downloading Excel files and ZIP archives in memory
+
+All data-source modules should import ``session`` from here rather than
+calling :func:`requests.get` directly, so that retry logic is applied
+uniformly.
+
+Example:
+    >>> from bolster.utils.web import session
+    >>> type(session).__name__
+    'Session'
+"""
+
 import io
 import logging
 import zipfile

--- a/tests/test_ni_water_integration.py
+++ b/tests/test_ni_water_integration.py
@@ -164,7 +164,7 @@ class TestNIWaterIntegrationFullDataset:
             # Check for hardness classification if present
             if "NI Hardness Classification" in df.columns:
                 # Should be categorical
-                assert pd.api.types.is_categorical_dtype(df["NI Hardness Classification"])
+                assert isinstance(df["NI Hardness Classification"].dtype, pd.CategoricalDtype)
 
         except Exception as e:
             pytest.skip(f"OpenDataNI service unavailable: {e}")

--- a/tests/test_utils_dt.py
+++ b/tests/test_utils_dt.py
@@ -1,0 +1,55 @@
+"""Tests for bolster.utils.dt datetime rounding utilities."""
+
+from datetime import date, datetime, timezone
+
+import pytest
+
+from bolster.utils.dt import round_to_month, round_to_week, utc_midnight_on
+
+
+class TestRoundToWeek:
+    def test_midweek_datetime(self):
+        assert round_to_week(datetime(2018, 8, 9, 12, 1)) == date(2018, 8, 6)
+
+    def test_midweek_date(self):
+        assert round_to_week(date(2018, 8, 9)) == date(2018, 8, 6)
+
+    def test_monday_is_unchanged(self):
+        assert round_to_week(date(2024, 3, 11)) == date(2024, 3, 11)
+
+    def test_sunday_rounds_back(self):
+        assert round_to_week(date(2024, 3, 17)) == date(2024, 3, 11)
+
+
+class TestRoundToMonth:
+    def test_midmonth_datetime(self):
+        assert round_to_month(datetime(2018, 8, 9, 12, 1)) == date(2018, 8, 1)
+
+    def test_midmonth_date(self):
+        assert round_to_month(date(2018, 8, 9)) == date(2018, 8, 1)
+
+    def test_first_of_month_is_unchanged(self):
+        assert round_to_month(date(2024, 3, 1)) == date(2024, 3, 1)
+
+    def test_last_day_of_month(self):
+        assert round_to_month(date(2024, 3, 31)) == date(2024, 3, 1)
+
+
+class TestUtcMidnightOn:
+    def test_naive_datetime(self):
+        result = utc_midnight_on(datetime(2018, 9, 1, 12, 12))
+        assert result == datetime(2018, 9, 1, 0, 0, tzinfo=timezone.utc)
+
+    def test_strips_time_component(self):
+        result = utc_midnight_on(datetime(2024, 6, 15, 23, 59, 59))
+        assert result.hour == 0
+        assert result.minute == 0
+        assert result.second == 0
+
+    def test_result_is_utc_aware(self):
+        result = utc_midnight_on(datetime(2024, 1, 1))
+        assert result.tzinfo == timezone.utc
+
+    def test_preserves_date(self):
+        result = utc_midnight_on(datetime(2024, 6, 15, 23, 59))
+        assert result.date() == date(2024, 6, 15)

--- a/tests/test_utils_web.py
+++ b/tests/test_utils_web.py
@@ -1,0 +1,89 @@
+"""Tests for bolster.utils.web HTTP session and retry configuration."""
+
+import pytest
+from urllib3.util.retry import RequestHistory
+
+from bolster.utils.web import RateLimitAwareRetry, _retry_strategy, session
+
+
+def _make_retry_with_history(*statuses):
+    """Return a RateLimitAwareRetry with a simulated history of the given HTTP statuses."""
+    r = RateLimitAwareRetry(total=4, backoff_factor=1, status_forcelist=[429, 500, 502, 503, 504])
+    history = tuple(RequestHistory("GET", "http://example.com", None, s, None) for s in statuses)
+    return r.new(history=history)
+
+
+class TestRetryStatusList:
+    def test_retries_on_500(self):
+        assert 500 in _retry_strategy.status_forcelist
+
+    def test_retries_on_502(self):
+        assert 502 in _retry_strategy.status_forcelist
+
+    def test_retries_on_503(self):
+        assert 503 in _retry_strategy.status_forcelist
+
+    def test_retries_on_504(self):
+        assert 504 in _retry_strategy.status_forcelist
+
+    def test_retries_on_429(self):
+        assert 429 in _retry_strategy.status_forcelist
+
+    def test_total_retries(self):
+        assert _retry_strategy.total == 4
+
+    def test_allowed_methods(self):
+        assert "GET" in _retry_strategy.allowed_methods
+        assert "HEAD" in _retry_strategy.allowed_methods
+
+    def test_respect_retry_after_disabled(self):
+        # Prevents a Retry-After: 86400 from hanging CI for hours
+        assert _retry_strategy.respect_retry_after_header is False
+
+
+class TestRateLimitBackoff:
+    def test_first_429_triggers_30s_backoff(self):
+        r = _make_retry_with_history(429)
+        assert r.get_backoff_time() == 30
+
+    def test_second_429_triggers_60s_cap(self):
+        r = _make_retry_with_history(429, 429)
+        assert r.get_backoff_time() == 60
+
+    def test_third_429_still_capped_at_60s(self):
+        r = _make_retry_with_history(429, 429, 429)
+        assert r.get_backoff_time() == 60
+
+    def test_max_backoff_constant(self):
+        assert RateLimitAwareRetry.MAX_BACKOFF == 60
+
+    def test_non_429_uses_standard_backoff(self):
+        # Standard urllib3 exponential backoff; with backoff_factor=1 and 1
+        # history entry the first computed value is 0 (urllib3 only starts
+        # backing off from the second consecutive error onwards).
+        r = _make_retry_with_history(500)
+        assert r.get_backoff_time() == 0
+
+    def test_non_429_backoff_capped_at_60s(self):
+        # After many standard errors the cap applies
+        r = _make_retry_with_history(500, 500, 500, 500)
+        assert r.get_backoff_time() <= 60
+
+
+class TestSessionConfiguration:
+    def test_session_type(self):
+        import requests
+
+        assert isinstance(session, requests.Session)
+
+    def test_user_agent_set(self):
+        ua = session.headers.get("User-Agent", "")
+        assert "Bolster" in ua
+
+    def test_http_adapter_mounted(self):
+        adapter = session.get_adapter("http://example.com")
+        assert adapter is not None
+
+    def test_https_adapter_mounted(self):
+        adapter = session.get_adapter("https://example.com")
+        assert adapter is not None


### PR DESCRIPTION
## Summary

Comprehensive doctest fixes and deprecation warning cleanup across the whole codebase.

**Doctests: 33 passed → 258 passed, 0 failed, 0 skipped**

### What changed

**Doctest fixes (all categories resolved):**

- **FAKE_PATH (31 functions)** — `dva`, `ashe` (12 functions), `composite_index`, `construction_output`, `economic_indicators`, `labour_market`, `wellbeing`, `deaths`, `psni/crime_statistics`: replaced hardcoded filenames like `"ASHE-2025-linked.xlsx"` with real download chains using each module's own URL-discovery + `download_file()` functions. Doctests now actually run against the live data and verify column structure.

- **NP_BOOL (5)** — `marriages` (3), `stillbirths`, `population`: pandas `.sum()` returns `np.float64`, so `> 0` produces `np.True_` not Python `True`. Fixed by wrapping comparisons in `bool()`.

- **WRONG_API (3)** — `eoni` module docstring called non-existent `get_election_results()`/`get_constituency_results()`; fixed to use real `get_results(year)`. `ashe.calculate_growth_rates` doctest checked for `'yoy_growth'` but function creates `'earnings_yoy_growth'`.

- **BAD_YEAR (1)** — `deaths.get_combined_deaths()` defaults include the current year (2025) which isn't in the historical file yet; pass explicit `years=[2022, 2023, 2024]`.

- **BUG (4)** — `stillbirths.get_stillbirth_rate` expected `births_df` to have a `'date'` column but `get_latest_births()` returns `'month'`; also included Male/Female/Persons rows. Fixed: filter to `'Persons'`, align column name. `population_projections` doctest expected `'variant'` column; actual schema has `'base_year'`. `nisra/__init__` checked `'employment_rate'` which doesn't exist; actual column is `'percentage'`. `ni_water` module docstring used invalid zone code `'BALM'`; replaced with `get_water_quality()` columns check.

- **EXAMPLE_COM (1)** — `psni/_base.download_file` used `example.com` URL; replaced with error-path doctest using the module's own exception class.

- **MATPLOTLIB (1)** — `psni/crime_statistics.get_crime_trends` doctest imported `matplotlib` (not installed); removed plotting lines, replaced with column/length assertions.

**Deprecation warnings (16 → 9, remaining are third-party):**
- `wikipedia.py`: wrap `pd.read_html` literal string in `StringIO`; `.applymap()` → `.map()`
- `utils/io.py`: `to_excel` positional `sheet_name` arg → keyword arg
- `companies_house.py`: `BeautifulSoup` missing `features="lxml"` arg
- `tests/test_ni_water_integration.py`: `is_categorical_dtype` → `isinstance(dtype, CategoricalDtype)`
- `pyproject.toml`: register `integration` pytest mark (silences `PytestUnknownMarkWarning`)

### Approach

All network-calling doctests use **real stable government URLs** (not `example.com`). Assertions verify **shape** (column names, field types, length > 0) rather than brittle content values. Parse-function doctests download through the module's own URL-discovery chain so the file is cached after the first run.

## Test plan

- [x] `uv run pytest --doctest-modules src/bolster/ --no-cov` — 258 passed, 0 failed
- [x] `uv run pytest tests/ --no-cov` — 1068 passed, 7 skipped, 0 failed
- [x] `uv run pre-commit run --all-files` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)