### PR TITLE
fix(docs): correct structural and content issues

### DIFF
--- a/docs/data_sources.rst
+++ b/docs/data_sources.rst
@@ -141,6 +141,9 @@ Annual workplace earnings data for Northern Ireland.
 Quarterly Employment Survey
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+Quarterly survey of employee jobs across the public and private sectors,
+providing estimates of employment levels broken down by industry grouping.
+
 .. code-block:: python
 
     from bolster.data_sources.nisra import quarterly_employment_survey as qes
@@ -282,10 +285,6 @@ and outcome.
     from bolster.data_sources.psni import crime_statistics
 
     df = crime_statistics.get_latest_crime_statistics()
-
-.. code-block:: console
-
-    $ bolster nisra crime-statistics   # proxied via nisra group
 
 Road Traffic Collisions
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/bolster/cli.py
+++ b/src/bolster/cli.py
@@ -2434,15 +2434,15 @@ def nisra_occupancy_cmd(latest, year, accommodation, data_type, output_format, f
     Parameters
     ----------
     accommodation : str
-        hotel : Hotels (2011-present, ~65% avg occupancy)
-        ssa : Small Service Accommodation: B&Bs, guest houses (2013-present, ~33% avg)
-        combined : Both types with accommodation_type column
+        Type of accommodation: ``hotel`` (Hotels, 2011-present, ~65% avg occupancy),
+        ``ssa`` (Small Service Accommodation: B&Bs/guest houses, 2013-present, ~33% avg),
+        or ``combined`` (both types with accommodation_type column).
     data_type : str
-        rates : Room and bed occupancy rates (0-1 scale)
-        sold : Number of rooms and beds sold monthly
+        Data to retrieve: ``rates`` (room and bed occupancy rates, 0-1 scale)
+        or ``sold`` (number of rooms and beds sold monthly).
 
-    Examples:
-    --------
+    .. rubric:: Examples
+
     Get latest hotel occupancy rates (default)::
 
         bolster nisra occupancy --latest
@@ -2475,39 +2475,43 @@ def nisra_occupancy_cmd(latest, year, accommodation, data_type, output_format, f
 
         bolster nisra occupancy --latest --save occupancy.csv
 
-    Notes:
-    -----
+    .. rubric:: Notes
+
     - Hotel data: 2011-present (~65% average room occupancy)
     - SSA data: 2013-present (~33% average room occupancy)
     - Room occupancy is typically higher than bed occupancy
     - COVID-19 Note: 2020-2021 shows dramatic impact on tourism
       (all accommodation closed March-July 2020, Oct-Dec 2020, Jan-May 2021)
 
-    Seasonal Patterns
-    -----------------
+    .. rubric:: Seasonal Patterns
+
     Summer months (June-September) are peak tourism season:
+
     - August typically has the highest occupancy (~80% hotel, ~55% SSA)
     - July-September are consistently strong
     - January-February typically have the lowest occupancy
 
-    Returns:
-    -------
-    DataFrame (rates)
-        - date: First day of month (datetime)
-        - year: Year
-        - month: Month name
-        - room_occupancy: Room occupancy rate (0-1)
-        - bed_occupancy: Bed occupancy rate (0-1)
-        - accommodation_type: (combined only) 'hotel' or 'ssa'
-    DataFrame (sold)
-        - date: First day of month (datetime)
-        - year: Year
-        - month: Month name
-        - rooms_sold: Number of rooms sold
-        - beds_sold: Number of beds sold
+    .. rubric:: Returns
 
-    Source
-    ------
+    DataFrame (rates):
+
+    - date: First day of month (datetime)
+    - year: Year
+    - month: Month name
+    - room_occupancy: Room occupancy rate (0-1)
+    - bed_occupancy: Bed occupancy rate (0-1)
+    - accommodation_type: (combined only) 'hotel' or 'ssa'
+
+    DataFrame (sold):
+
+    - date: First day of month (datetime)
+    - year: Year
+    - month: Month name
+    - rooms_sold: Number of rooms sold
+    - beds_sold: Number of beds sold
+
+    .. rubric:: Source
+
     https://www.nisra.gov.uk/statistics/tourism/occupancy-surveys
     """
     console = Console()

--- a/src/bolster/cli.py
+++ b/src/bolster/cli.py
@@ -55,7 +55,8 @@ def cli(verbose, args=None):
     Government & Politics:
         * ni-executive         NI Executive historical data
         * ni-elections         NI Assembly election results (2016-2022)
-        * nisra                NISRA statistics (deaths, labour market, crime)
+        * nisra                NISRA statistics (deaths, births, population, economic indicators)
+        * psni                 PSNI statistics (road traffic collisions)
 
     Business & Property:
         * companies-house      UK Companies House data queries
@@ -1283,9 +1284,11 @@ def nisra():
 
     Access official statistics and research publications from NISRA including:
     - Weekly death registrations with demographic breakdowns
-    - Labour market statistics (coming soon)
-    - Crime statistics (coming soon)
-    - Economic indicators (coming soon)
+    - Labour market statistics (employment, economic inactivity)
+    - Economic indicators (Index of Production, Index of Services, Construction Output, Composite Index)
+    - Population estimates, births, marriages, migration
+    - Tourism (accommodation occupancy, visitor statistics)
+    - Cancer and emergency care waiting times
 
     All data is sourced directly from NISRA publications and cached locally
     for performance. Use --force-refresh to bypass cache and download fresh data.
@@ -2439,7 +2442,7 @@ def nisra_occupancy_cmd(latest, year, accommodation, data_type, output_format, f
         sold : Number of rooms and beds sold monthly
 
     Examples:
-    ---------
+    --------
     Get latest hotel occupancy rates (default)::
 
         bolster nisra occupancy --latest
@@ -2473,7 +2476,7 @@ def nisra_occupancy_cmd(latest, year, accommodation, data_type, output_format, f
         bolster nisra occupancy --latest --save occupancy.csv
 
     Notes:
-    ------
+    -----
     - Hotel data: 2011-present (~65% average room occupancy)
     - SSA data: 2013-present (~33% average room occupancy)
     - Room occupancy is typically higher than bed occupancy
@@ -2488,7 +2491,7 @@ def nisra_occupancy_cmd(latest, year, accommodation, data_type, output_format, f
     - January-February typically have the lowest occupancy
 
     Returns:
-    --------
+    -------
     DataFrame (rates)
         - date: First day of month (datetime)
         - year: Year


### PR DESCRIPTION
## Summary

- **Remove wrong PSNI CLI command**: `bolster nisra crime-statistics` referenced in `data_sources.rst` doesn't exist — the PSNI crime stats module has a Python API but no CLI command
- **Add missing QES description**: Quarterly Employment Survey was the only NISRA section in `data_sources.rst` with no explanatory text
- **Fix nisra CLI overview**: The `nisra` group docstring had three stale "coming soon" items for modules that have been implemented; also updated the top-level `cli()` help to mention `psni` group and remove the misleading "crime" attribution to the `nisra` group
- **Fix `nisra_occupancy_cmd` docstring rendering**: Mixed NumPy/Google docstring style (NumPy `Parameters` section followed by `Examples:` with a Google-style colon) caused Napoleon to render `Examples`, `Notes`, and `Returns` as `:param:` field list entries instead of section headings; standardised to NumPy style

## Test plan

- [ ] Docs CI build passes on this PR
- [ ] Verify `autoapi/bolster/cli/index.html` renders `nisra_occupancy_cmd` Examples/Notes/Returns as proper sections (not `:param:` fields)
- [ ] Verify `data_sources.html` PSNI section no longer references the non-existent CLI command
- [ ] Verify `data_sources.html` Quarterly Employment Survey has a description

🤖 Generated with [Claude Code](https://claude.com/claude-code)