### PR TITLE
feat(nisra): add NI Planning Activity Statistics module

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ The [GOV.UK NISRA statistics RSS feed](https://www.gov.uk/search/research-and-st
 | UK Gender Pay Gap Reporting | `gender_pay_gap` | ✅ |
 | Individual Wellbeing | `nisra.wellbeing` | ✅ |
 | Cancer Waiting Times | `nisra.cancer_waiting_times` | ✅ |
+| NI Planning Activity Statistics (DfI) | `nisra.planning_statistics` | ✅ |
 | Registrar General Quarterly Tables | `nisra.registrar_general` | ✅ |
 | Tourism - Hotel Occupancy | `nisra.tourism.occupancy` | ✅ |
 | Tourism - SSA Occupancy | `nisra.tourism.occupancy` | ✅ |

--- a/src/bolster/cli.py
+++ b/src/bolster/cli.py
@@ -29,6 +29,7 @@ from .data_sources.nisra import emergency_care_waiting_times as nisra_emergency
 from .data_sources.nisra import labour_market as nisra_labour_market
 from .data_sources.nisra import marriages as nisra_marriages
 from .data_sources.nisra import migration as nisra_migration
+from .data_sources.nisra import planning_statistics as nisra_planning
 from .data_sources.nisra import population as nisra_population
 from .data_sources.nisra import registrar_general as nisra_registrar_general
 from .data_sources.nisra import wellbeing as nisra_wellbeing
@@ -1344,6 +1345,7 @@ def nisra_feed(limit: int, title_filter: str, days: int, check_coverage: bool):
         "nicei": "composite-index",
         "wellbeing": "wellbeing",
         "cancer waiting": "cancer-waiting-times",
+        "planning": "planning-statistics",
     }
 
     with console.status("Fetching NISRA RSS feed..."):
@@ -4866,6 +4868,117 @@ def psni_rtc_cmd(year, data_type, by, output_format, save, force_refresh):
 
     except Exception as e:
         console.print(f"[bold red]❌ Error:[/bold red] {str(e)}", style="red")
+        raise click.Abort() from e
+
+
+@nisra.command(name="planning-statistics")
+@click.option(
+    "--dimension",
+    type=click.Choice(["ni", "council", "annual", "council-summary"], case_sensitive=False),
+    default="ni",
+    help=(
+        "Which view to retrieve: 'ni' (quarterly NI-wide, default), "
+        "'council' (per-council quarterly), 'annual' (NI financial-year totals), "
+        "'council-summary' (per-council aggregate)."
+    ),
+)
+@click.option("--financial-year", help="Filter by financial year, e.g. '2024/25'")
+@click.option(
+    "--format",
+    "output_format",
+    type=click.Choice(["csv", "json"], case_sensitive=False),
+    default="csv",
+    help="Output format (default: csv)",
+)
+@click.option("--force-refresh", is_flag=True, help="Force re-download even if cached")
+@click.option("--save", help="Save data to file (specify filename)")
+@click.option("--summary", is_flag=True, help="Show summary statistics instead of full data")
+def nisra_planning_statistics_cmd(dimension, financial_year, output_format, force_refresh, save, summary):
+    """NISRA Planning Activity Statistics (Department for Infrastructure).
+
+    Quarterly Northern Ireland planning application statistics: applications
+    received, decided, approved, withdrawn, and approval rate. NI-wide series
+    goes back to Q1 2002/03; council-area breakdowns cover recent quarters
+    across the 11 local councils.
+
+    Examples:
+        Quarterly NI-wide series (default)::
+
+            bolster nisra planning-statistics
+
+        Per-council quarterly data for the latest financial year::
+
+            bolster nisra planning-statistics --dimension council --financial-year 2024/25
+
+        Annual financial-year totals::
+
+            bolster nisra planning-statistics --dimension annual
+
+        Council summary for 2024/25::
+
+            bolster nisra planning-statistics --dimension council-summary --financial-year 2024/25
+
+        Save to file::
+
+            bolster nisra planning-statistics --save planning.csv
+
+    Source:
+        https://www.infrastructure-ni.gov.uk/articles/planning-activity-statistics
+    """
+    console = Console()
+
+    try:
+        dim = dimension.lower()
+        with console.status("[bold green]Fetching NI planning statistics..."):
+            if dim in ("ni", "annual"):
+                data = nisra_planning.get_latest_data(force_refresh=force_refresh)
+            else:
+                data = nisra_planning.get_latest_council_data(force_refresh=force_refresh)
+
+        if dim == "annual":
+            data = nisra_planning.get_annual_totals(data)
+        elif dim == "council-summary":
+            data = nisra_planning.get_council_summary(data, financial_year=financial_year)
+        elif financial_year is not None:
+            data = data[data["financial_year"] == financial_year]
+
+        if data.empty:
+            console.print("[yellow]No data found for the specified filters[/yellow]")
+            return
+
+        console.print("[green]Planning statistics fetched successfully[/green]")
+        console.print(f"[cyan]Rows: {len(data)}[/cyan]")
+
+        if summary and dim in ("ni",):
+            total_received = int(data["applications_received"].sum())
+            total_decided = int(data["applications_decided"].sum())
+            total_approved = int(data["applications_approved"].sum())
+            overall_rate = total_approved / total_decided if total_decided else 0.0
+            console.print(f"   Applications received: {total_received:,}")
+            console.print(f"   Applications decided:  {total_decided:,}")
+            console.print(f"   Applications approved: {total_approved:,}")
+            console.print(f"   Approval rate:         {overall_rate:.1%}")
+            if not save:
+                return
+
+        if save:
+            if output_format == "json" or save.endswith(".json"):
+                data.to_json(save, orient="records", date_format="iso", indent=2)
+            else:
+                data.to_csv(save, index=False)
+            console.print(f"[green]Saved to: {save}[/green]")
+            return
+
+        if output_format == "json":
+            click.echo(data.to_json(orient="records", date_format="iso", indent=2))
+        else:
+            console.print(data.to_csv(index=False), end="")
+
+    except Exception as e:
+        console.print(f"[bold red]Error:[/bold red] {str(e)}", style="red")
+        console.print("\n[yellow]Troubleshooting:[/yellow]")
+        console.print("   - Check your internet connection")
+        console.print("   - Try again with --force-refresh to bypass cache")
         raise click.Abort() from e
 
 

--- a/src/bolster/data_sources/nisra/__init__.py
+++ b/src/bolster/data_sources/nisra/__init__.py
@@ -17,6 +17,7 @@ Available modules:
     - marriages: Monthly marriage registrations
     - migration: Official and derived migration estimates (demographic components)
     - population: Annual mid-year population estimates by age, sex, and geography
+    - planning_statistics: NI Planning Activity Statistics - quarterly applications, by council
     - population_projections: Population projections by age, sex, and geography (2022-2072)
     - registrar_general: Registrar General Quarterly Tables (quarterly births, deaths, marriages, LGD breakdowns)
     - tourism: Tourism statistics including occupancy surveys, visitor stats (subpackage)
@@ -108,6 +109,7 @@ from . import (
     labour_market,
     marriages,
     migration,
+    planning_statistics,
     population,
     population_projections,
     quarterly_employment_survey,
@@ -132,6 +134,7 @@ __all__ = [
     "quarterly_employment_survey",
     "marriages",
     "migration",
+    "planning_statistics",
     "population",
     "population_projections",
     "registrar_general",

--- a/src/bolster/data_sources/nisra/planning_statistics.py
+++ b/src/bolster/data_sources/nisra/planning_statistics.py
@@ -1,0 +1,633 @@
+"""Northern Ireland Planning Activity Statistics.
+
+Quarterly and annual planning application statistics for Northern Ireland,
+published by the Department for Infrastructure (DfI). Provides counts of
+planning applications received, decided, approved and withdrawn, both
+NI-wide as a quarterly time series back to Q1 2002/03 and broken down by
+the 11 local councils.
+
+Data Source:
+    **Hub page**: https://www.infrastructure-ni.gov.uk/articles/planning-activity-statistics
+
+    The module scrapes the hub page for the latest publication, then scrapes
+    that publication page for the quarterly statistical tables Excel file.
+
+Update Frequency:
+    Quarterly (provisional) plus an annual final release after each
+    financial year ends (April-March).
+
+Geographic Coverage:
+    Northern Ireland - whole-country totals plus the 11 local council areas
+    (Antrim & Newtownabbey, Ards & North Down, Armagh City Banbridge &
+    Craigavon, Belfast, Causeway Coast & Glens, Derry City & Strabane,
+    Fermanagh & Omagh, Lisburn & Castlereagh, Mid & East Antrim, Mid Ulster,
+    Newry Mourne & Down).
+
+Time Series:
+    Q1 2002/03 onwards for the NI-wide series (sheet 1.1).
+    Recent quarters plus current/prior financial year for council-area data
+    (sheet 1.2).
+
+Example:
+    >>> from bolster.data_sources.nisra import planning_statistics
+    >>> df = planning_statistics.get_latest_data()
+    >>> 'applications_received' in df.columns
+    True
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from pathlib import Path
+
+import pandas as pd
+from bs4 import BeautifulSoup
+
+from bolster.utils.web import session
+
+from ._base import (
+    NISRADataNotFoundError,
+    NISRAValidationError,
+    download_file,
+    make_absolute_url,
+    safe_float,
+    safe_int,
+)
+
+logger = logging.getLogger(__name__)
+
+PLANNING_HUB_URL = "https://www.infrastructure-ni.gov.uk/articles/planning-activity-statistics"
+INFRA_BASE_URL = "https://www.infrastructure-ni.gov.uk"
+
+# Quarter labels are like "Q1", "Q2", etc. in sheet 1.1
+_VALID_QUARTERS = {"Q1", "Q2", "Q3", "Q4"}
+
+# Financial-year quarter to calendar (start) month
+_QUARTER_START_MONTH = {"Q1": 4, "Q2": 7, "Q3": 10, "Q4": 1}
+
+# Council date labels in sheet 1.2 ("Apr-Jun 2025" etc.)
+_COUNCIL_QUARTER_LABELS = {
+    "Apr-Jun": "Q1",
+    "Jul-Sep": "Q2",
+    "Oct-Dec": "Q3",
+    "Jan-Mar": "Q4",
+}
+
+
+def get_latest_publication_url() -> str:
+    """Scrape the planning statistics hub page for the latest publication page URL.
+
+    The hub lists publications newest-first; the first non-guidance link with
+    a "Northern Ireland planning statistics" title is the latest release
+    (provisional quarterly or final annual).
+
+    Returns:
+        URL of the latest publication page (containing the XLSX/ODS files).
+
+    Raises:
+        NISRADataNotFoundError: If the hub page cannot be fetched or no
+            publication link can be located.
+
+    Example:
+        >>> url = get_latest_publication_url()
+        >>> url.startswith("https://www.infrastructure-ni.gov.uk/publications/")
+        True
+    """
+    try:
+        response = session.get(PLANNING_HUB_URL, timeout=30)
+        response.raise_for_status()
+    except Exception as e:  # pragma: no cover - network errors hard to simulate
+        raise NISRADataNotFoundError(f"Failed to fetch planning hub page: {e}") from e
+
+    soup = BeautifulSoup(response.content, "html.parser")
+
+    for a in soup.find_all("a", href=True):
+        href = a["href"]
+        text = a.get_text(strip=True).lower()
+        if "/publications/northern-ireland-planning-statistics-" not in href.lower():
+            continue
+        if "user-guidance" in href.lower() or "background" in text:
+            continue
+        return make_absolute_url(href, INFRA_BASE_URL)
+
+    raise NISRADataNotFoundError("Could not locate latest planning statistics publication on hub page")
+
+
+def get_latest_xlsx_url(publication_url: str | None = None) -> str:
+    """Find the XLSX file URL on a planning statistics publication page.
+
+    Args:
+        publication_url: Publication page URL. If None, calls
+            :func:`get_latest_publication_url` to find the most recent.
+
+    Returns:
+        URL of the quarterly statistical tables Excel file.
+
+    Raises:
+        NISRADataNotFoundError: If the publication page has no XLSX link.
+
+    Example:
+        >>> url = get_latest_xlsx_url()
+        >>> url.endswith(".xlsx")
+        True
+    """
+    if publication_url is None:
+        publication_url = get_latest_publication_url()
+
+    try:
+        response = session.get(publication_url, timeout=30)
+        response.raise_for_status()
+    except Exception as e:  # pragma: no cover - network errors hard to simulate
+        raise NISRADataNotFoundError(f"Failed to fetch publication page {publication_url}: {e}") from e
+
+    soup = BeautifulSoup(response.content, "html.parser")
+
+    for a in soup.find_all("a", href=True):
+        href = a["href"]
+        if href.lower().endswith(".xlsx"):
+            return make_absolute_url(href, INFRA_BASE_URL)
+
+    raise NISRADataNotFoundError(f"No XLSX file found on publication page {publication_url}")
+
+
+def _parse_fy_quarter_to_date(financial_year: str, quarter: str) -> pd.Timestamp | None:
+    """Convert a UK financial year + quarter to a calendar Timestamp.
+
+    Args:
+        financial_year: Financial year string like ``"2024/25"``.
+        quarter: Quarter code (``Q1``-``Q4``). Q1 = Apr-Jun of the start year,
+            Q4 = Jan-Mar of the second year.
+
+    Returns:
+        Timestamp for the first day of the quarter, or ``None`` if either
+        input cannot be parsed.
+
+    Example:
+        >>> _parse_fy_quarter_to_date("2024/25", "Q1")
+        Timestamp('2024-04-01 00:00:00')
+        >>> _parse_fy_quarter_to_date("2024/25", "Q4")
+        Timestamp('2025-01-01 00:00:00')
+    """
+    if not isinstance(financial_year, str) or quarter not in _QUARTER_START_MONTH:
+        return None
+    m = re.match(r"^(\d{4})/\d{2}$", financial_year.strip())
+    if not m:
+        return None
+    start_year = int(m.group(1))
+    month = _QUARTER_START_MONTH[quarter]
+    year = start_year if quarter != "Q4" else start_year + 1
+    return pd.Timestamp(year=year, month=month, day=1)
+
+
+def parse_planning_applications(file_path: str | Path) -> pd.DataFrame:
+    """Parse the NI-wide quarterly applications time series (sheet ``1.1``).
+
+    Sheet 1.1 contains the quarterly headline series back to Q1 2002/03 with
+    a merged-cell Year column (forward-filled here) plus an annual total row
+    per financial year (filtered out).
+
+    Args:
+        file_path: Path to a downloaded planning statistics XLSX file.
+
+    Returns:
+        DataFrame with one row per quarter and columns:
+
+        - ``date`` (datetime): First day of the calendar quarter
+        - ``financial_year`` (str): e.g. ``"2024/25"``
+        - ``quarter`` (str): One of ``Q1``-``Q4``
+        - ``year`` (int): Calendar year of ``date``
+        - ``applications_received`` (int)
+        - ``applications_decided`` (int)
+        - ``applications_approved`` (int)
+        - ``applications_withdrawn`` (int)
+        - ``approval_rate`` (float): Proportion 0.0-1.0
+        - ``mid_year_population`` (int): NI mid-year population estimate
+          used for that financial year's per-10,000 rates
+        - ``applications_per_10k`` (float): Applications received per 10,000
+          population
+
+    Raises:
+        NISRAValidationError: If the sheet structure is unexpected.
+
+    Example:
+        >>> import bolster.data_sources.nisra.planning_statistics as ps
+        >>> path = ps.get_latest_data.__wrapped__ if False else None  # docs only
+    """
+    file_path = Path(file_path)
+    try:
+        raw = pd.read_excel(file_path, sheet_name="1.1", header=None)
+    except Exception as e:
+        raise NISRAValidationError(f"Failed to read planning sheet 1.1: {e}") from e
+
+    if raw.shape[1] < 10:
+        raise NISRAValidationError(f"Sheet 1.1 has only {raw.shape[1]} columns; expected at least 10")
+
+    # Forward-fill the merged-cell Year column from row 4 (data start) onwards
+    year_series = raw.iloc[4:, 0].ffill()
+
+    records = []
+    for i in range(4, len(raw)):
+        fy = year_series.loc[i]
+        quarter = str(raw.iloc[i, 1]).strip() if not pd.isna(raw.iloc[i, 1]) else ""
+        if quarter not in _VALID_QUARTERS:
+            # Skip year-total rows ("2002/03", "2025/26 ytd", source/notes, etc.)
+            continue
+
+        ts = _parse_fy_quarter_to_date(str(fy), quarter)
+        if ts is None:
+            continue
+
+        records.append(
+            {
+                "date": ts,
+                "financial_year": str(fy).strip(),
+                "quarter": quarter,
+                "year": ts.year,
+                "applications_received": safe_int(raw.iloc[i, 2]),
+                "mid_year_population": safe_int(raw.iloc[i, 3]),
+                "applications_per_10k": safe_float(raw.iloc[i, 5]),
+                "applications_decided": safe_int(raw.iloc[i, 6]),
+                "applications_approved": safe_int(raw.iloc[i, 7]),
+                "approval_rate": safe_float(raw.iloc[i, 8]),
+                "applications_withdrawn": safe_int(raw.iloc[i, 9]),
+            }
+        )
+
+    if not records:
+        raise NISRAValidationError("No quarterly data rows parsed from sheet 1.1")
+
+    df = pd.DataFrame.from_records(records)
+    col_order = [
+        "date",
+        "financial_year",
+        "quarter",
+        "year",
+        "applications_received",
+        "applications_decided",
+        "applications_approved",
+        "applications_withdrawn",
+        "approval_rate",
+        "mid_year_population",
+        "applications_per_10k",
+    ]
+    df = df[col_order].sort_values("date").reset_index(drop=True)
+
+    logger.info(
+        "Parsed planning sheet 1.1: %d quarters, %s %s to %s %s",
+        len(df),
+        df["quarter"].iloc[0],
+        df["financial_year"].iloc[0],
+        df["quarter"].iloc[-1],
+        df["financial_year"].iloc[-1],
+    )
+    return df
+
+
+def _parse_council_date_label(label: str) -> tuple[pd.Timestamp, str, str] | None:
+    """Parse a council-area date label like ``"Apr-Jun 2025"``.
+
+    Args:
+        label: Date label from column 0 of sheet 1.2 sub-tables.
+
+    Returns:
+        Tuple of ``(timestamp, financial_year, quarter)`` or ``None`` if the
+        label is not a parseable quarter row (skipping yearly totals,
+        ``"Year to date ..."``, notes etc.).
+    """
+    if not isinstance(label, str):
+        return None
+    label = label.strip()
+    m = re.match(r"^(Apr-Jun|Jul-Sep|Oct-Dec|Jan-Mar)\s+(\d{4})$", label)
+    if not m:
+        return None
+    period, year_str = m.group(1), m.group(2)
+    quarter = _COUNCIL_QUARTER_LABELS[period]
+    calendar_year = int(year_str)
+    month = _QUARTER_START_MONTH[quarter]
+    ts = pd.Timestamp(year=calendar_year, month=month, day=1)
+    # Map back to UK financial year (Q4 belongs to fy ending in this year)
+    start = calendar_year - 1 if quarter == "Q4" else calendar_year
+    fy = f"{start}/{str(start + 1)[-2:]}"
+    return ts, fy, quarter
+
+
+# Metric-name mapping for sheet 1.2 sub-tables (1.2.1 -> 1.2.5)
+_COUNCIL_METRIC_TABLES = {
+    "1.2.1": "applications_received",
+    "1.2.2": "applications_decided",
+    "1.2.3": "applications_approved",
+    "1.2.4": "approval_rate",
+    "1.2.5": "applications_withdrawn",
+}
+
+
+def parse_planning_by_council(file_path: str | Path) -> pd.DataFrame:
+    """Parse the council-area planning applications data (sheet ``1.2``).
+
+    Sheet 1.2 stacks five sub-tables (received / decided / approved /
+    approval-rate / withdrawn) with one row per quarter and one column per
+    of the 11 NI councils. This function unpivots all five into a tidy long
+    DataFrame.
+
+    Args:
+        file_path: Path to a downloaded planning statistics XLSX file.
+
+    Returns:
+        DataFrame with one row per (date, council) and columns:
+
+        - ``date`` (datetime), ``financial_year`` (str), ``quarter`` (str),
+          ``year`` (int)
+        - ``council`` (str): Council name
+        - ``applications_received`` (int | None)
+        - ``applications_decided`` (int | None)
+        - ``applications_approved`` (int | None)
+        - ``applications_withdrawn`` (int | None)
+        - ``approval_rate`` (float | None): Proportion 0.0-1.0
+
+    Raises:
+        NISRAValidationError: If the sheet structure is unexpected (no
+            council header rows / parseable date rows found).
+    """
+    file_path = Path(file_path)
+    try:
+        raw = pd.read_excel(file_path, sheet_name="1.2", header=None)
+    except Exception as e:
+        raise NISRAValidationError(f"Failed to read planning sheet 1.2: {e}") from e
+
+    # Locate each sub-table by its label in column 0
+    current_metric: str | None = None
+    councils: list[str] | None = None
+
+    rows: list[dict] = []
+    for i in range(len(raw)):
+        col0 = raw.iloc[i, 0]
+        if isinstance(col0, str):
+            stripped = col0.strip()
+            # Match "Table 1.2.1 - ..." style headers
+            m = re.match(r"^Table\s+(1\.2\.[1-5])\b", stripped)
+            if m:
+                current_metric = _COUNCIL_METRIC_TABLES.get(m.group(1))
+                councils = None
+                continue
+
+        # Header row immediately follows (col0 is NaN, councils across)
+        if current_metric is not None and councils is None:
+            possible_header = [str(v).strip() for v in raw.iloc[i, 1:].tolist() if isinstance(v, str)]
+            if len(possible_header) >= 11 and any("Antrim" in c for c in possible_header):
+                councils = [str(v).strip() for v in raw.iloc[i, 1:].tolist()]
+                continue
+
+        if current_metric is None or councils is None:
+            continue
+
+        parsed = _parse_council_date_label(col0 if isinstance(col0, str) else "")
+        if parsed is None:
+            continue
+        ts, fy, quarter = parsed
+
+        for col_idx, council in enumerate(councils, start=1):
+            if not council or council == "nan":
+                continue
+            val = raw.iloc[i, col_idx]
+            value = safe_float(val) if current_metric == "approval_rate" else safe_int(val)
+            rows.append(
+                {
+                    "date": ts,
+                    "financial_year": fy,
+                    "quarter": quarter,
+                    "year": ts.year,
+                    "council": council,
+                    "metric": current_metric,
+                    "value": value,
+                }
+            )
+
+    if not rows:
+        raise NISRAValidationError("No council-area rows parsed from sheet 1.2")
+
+    long_df = pd.DataFrame.from_records(rows)
+
+    # Pivot metric -> wide columns
+    df = (
+        long_df.pivot_table(
+            index=["date", "financial_year", "quarter", "year", "council"],
+            columns="metric",
+            values="value",
+            aggfunc="first",
+        )
+        .reset_index()
+        .rename_axis(columns=None)
+    )
+
+    # Ensure all expected metric columns exist (in case a release omits one)
+    for metric in _COUNCIL_METRIC_TABLES.values():
+        if metric not in df.columns:
+            df[metric] = pd.NA
+
+    col_order = [
+        "date",
+        "financial_year",
+        "quarter",
+        "year",
+        "council",
+        "applications_received",
+        "applications_decided",
+        "applications_approved",
+        "applications_withdrawn",
+        "approval_rate",
+    ]
+    df = df[col_order].sort_values(["date", "council"]).reset_index(drop=True)
+
+    logger.info("Parsed planning sheet 1.2: %d (date, council) rows", len(df))
+    return df
+
+
+def get_latest_data(force_refresh: bool = False) -> pd.DataFrame:
+    """Download and parse the NI-wide quarterly planning applications series.
+
+    Args:
+        force_refresh: If True, bypass the local cache and re-download.
+
+    Returns:
+        DataFrame from :func:`parse_planning_applications` (NI-wide
+        quarterly time series, sheet 1.1).
+
+    Raises:
+        NISRADataNotFoundError: If the latest publication or XLSX cannot be
+            located.
+        NISRAValidationError: If the downloaded file cannot be parsed.
+
+    Example:
+        >>> df = get_latest_data()
+        >>> 'applications_received' in df.columns
+        True
+    """
+    xlsx_url = get_latest_xlsx_url()
+    logger.info("Downloading planning statistics from %s", xlsx_url)
+    # Quarterly cadence - 30 day cache is comfortable
+    file_path = download_file(xlsx_url, cache_ttl_hours=24 * 30, force_refresh=force_refresh)
+    return parse_planning_applications(file_path)
+
+
+def get_latest_council_data(force_refresh: bool = False) -> pd.DataFrame:
+    """Download and parse the council-area planning applications data.
+
+    Args:
+        force_refresh: If True, bypass the local cache and re-download.
+
+    Returns:
+        DataFrame from :func:`parse_planning_by_council` (one row per
+        date, council).
+
+    Raises:
+        NISRADataNotFoundError: If the latest publication or XLSX cannot be
+            located.
+        NISRAValidationError: If the downloaded file cannot be parsed.
+
+    Example:
+        >>> df = get_latest_council_data()
+        >>> 'council' in df.columns
+        True
+    """
+    xlsx_url = get_latest_xlsx_url()
+    file_path = download_file(xlsx_url, cache_ttl_hours=24 * 30, force_refresh=force_refresh)
+    return parse_planning_by_council(file_path)
+
+
+def validate_data(df: pd.DataFrame) -> bool:
+    """Validate an NI-wide planning applications DataFrame.
+
+    Args:
+        df: DataFrame from :func:`get_latest_data` or
+            :func:`parse_planning_applications`.
+
+    Returns:
+        ``True`` if all checks pass.
+
+    Raises:
+        NISRAValidationError: If the DataFrame is empty, missing required
+            columns, has implausible values, or has too short a time series.
+
+    Example:
+        >>> df = get_latest_data()
+        >>> validate_data(df)
+        True
+    """
+    if df is None or df.empty:
+        raise NISRAValidationError("Planning DataFrame is empty")
+
+    required = {
+        "date",
+        "financial_year",
+        "quarter",
+        "year",
+        "applications_received",
+        "applications_decided",
+        "applications_approved",
+        "applications_withdrawn",
+        "approval_rate",
+    }
+    missing = required - set(df.columns)
+    if missing:
+        raise NISRAValidationError(f"Missing required columns: {sorted(missing)}")
+
+    if len(df) < 40:
+        raise NISRAValidationError(f"Too few quarters ({len(df)}); expected 40+ since 2002/03")
+
+    if not set(df["quarter"].unique()).issubset(_VALID_QUARTERS):
+        raise NISRAValidationError(f"Unexpected quarter values: {sorted(df['quarter'].unique())}")
+
+    for col in ("applications_received", "applications_decided", "applications_approved"):
+        vals = df[col].dropna()
+        if (vals < 0).any():
+            raise NISRAValidationError(f"Negative values found in {col}")
+        # NI quarterly application volumes have historically been ~2k-9k
+        if (vals > 50_000).any():
+            raise NISRAValidationError(f"Implausibly high values in {col} (>50,000 in a quarter)")
+
+    rates = df["approval_rate"].dropna()
+    if ((rates < 0) | (rates > 1.0001)).any():
+        raise NISRAValidationError("approval_rate outside the [0, 1] range")
+
+    return True
+
+
+def get_annual_totals(df: pd.DataFrame) -> pd.DataFrame:
+    """Aggregate a quarterly DataFrame to annual (financial-year) totals.
+
+    Args:
+        df: DataFrame from :func:`get_latest_data`.
+
+    Returns:
+        DataFrame with one row per financial year and columns:
+
+        - ``financial_year`` (str)
+        - ``applications_received`` (int)
+        - ``applications_decided`` (int)
+        - ``applications_approved`` (int)
+        - ``applications_withdrawn`` (int)
+        - ``approval_rate`` (float): Weighted by decisions
+          (approved / decided)
+        - ``quarters`` (int): Number of quarters aggregated (4 except for
+          the current in-progress year)
+
+    Example:
+        >>> df = get_latest_data()
+        >>> annual = get_annual_totals(df)
+        >>> 'applications_received' in annual.columns
+        True
+    """
+    grouped = df.groupby("financial_year", sort=False).agg(
+        applications_received=("applications_received", "sum"),
+        applications_decided=("applications_decided", "sum"),
+        applications_approved=("applications_approved", "sum"),
+        applications_withdrawn=("applications_withdrawn", "sum"),
+        quarters=("quarter", "count"),
+    )
+    grouped["approval_rate"] = (grouped["applications_approved"] / grouped["applications_decided"]).round(4)
+    return grouped.reset_index()[
+        [
+            "financial_year",
+            "applications_received",
+            "applications_decided",
+            "applications_approved",
+            "applications_withdrawn",
+            "approval_rate",
+            "quarters",
+        ]
+    ]
+
+
+def get_council_summary(council_df: pd.DataFrame, financial_year: str | None = None) -> pd.DataFrame:
+    """Summarise council-area data by council across all (or one) financial year.
+
+    Args:
+        council_df: DataFrame from :func:`get_latest_council_data`.
+        financial_year: Optional financial year to filter to
+            (e.g. ``"2024/25"``). If None, summarises across all available
+            quarters.
+
+    Returns:
+        DataFrame with one row per council, sorted by
+        ``applications_received`` descending.
+
+    Example:
+        >>> council_df = get_latest_council_data()
+        >>> summary = get_council_summary(council_df, financial_year='2024/25')
+        >>> 'council' in summary.columns
+        True
+    """
+    df = council_df
+    if financial_year is not None:
+        df = df[df["financial_year"] == financial_year]
+
+    grouped = df.groupby("council", sort=False).agg(
+        applications_received=("applications_received", "sum"),
+        applications_decided=("applications_decided", "sum"),
+        applications_approved=("applications_approved", "sum"),
+        applications_withdrawn=("applications_withdrawn", "sum"),
+    )
+    decided = grouped["applications_decided"].replace(0, pd.NA)
+    grouped["approval_rate"] = (grouped["applications_approved"] / decided).round(4)
+    return grouped.reset_index().sort_values("applications_received", ascending=False).reset_index(drop=True)

--- a/tests/test_nisra_planning_statistics_integrity.py
+++ b/tests/test_nisra_planning_statistics_integrity.py
@@ -1,0 +1,368 @@
+"""Integrity tests for NISRA Planning Activity Statistics module.
+
+Validates real data quality, structure and consistency for the
+NI planning statistics module (Department for Infrastructure).
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from bolster.data_sources.nisra import planning_statistics
+from bolster.data_sources.nisra._base import NISRAValidationError
+
+ELEVEN_COUNCILS = {
+    "Antrim & Newtownabbey",
+    "Ards & North Down",
+    "Armagh City, Banbridge & Craigavon",
+    "Belfast",
+    "Causeway Coast & Glens",
+    "Derry City & Strabane",
+    "Fermanagh & Omagh",
+    "Lisburn & Castlereagh",
+    "Mid & East Antrim",
+    "Mid Ulster",
+    "Newry, Mourne & Down",
+}
+
+
+class TestPlanningPublicationDiscovery:
+    """Live discovery of the latest planning statistics publication."""
+
+    @pytest.fixture(scope="class")
+    def latest_publication_url(self) -> str:
+        return planning_statistics.get_latest_publication_url()
+
+    def test_publication_url_shape(self, latest_publication_url: str):
+        assert latest_publication_url.startswith(
+            "https://www.infrastructure-ni.gov.uk/publications/"
+        )
+        assert "planning-statistics" in latest_publication_url.lower()
+
+    def test_xlsx_url_shape(self, latest_publication_url: str):
+        url = planning_statistics.get_latest_xlsx_url(latest_publication_url)
+        assert url.lower().endswith(".xlsx")
+        assert "planning" in url.lower()
+
+
+class TestPlanningNIWideIntegrity:
+    """Integrity tests for NI-wide quarterly applications (sheet 1.1)."""
+
+    @pytest.fixture(scope="class")
+    def df(self) -> pd.DataFrame:
+        return planning_statistics.get_latest_data(force_refresh=False)
+
+    def test_returns_dataframe(self, df):
+        assert isinstance(df, pd.DataFrame)
+        assert not df.empty
+
+    def test_required_columns(self, df):
+        required = {
+            "date",
+            "financial_year",
+            "quarter",
+            "year",
+            "applications_received",
+            "applications_decided",
+            "applications_approved",
+            "applications_withdrawn",
+            "approval_rate",
+            "mid_year_population",
+            "applications_per_10k",
+        }
+        assert required.issubset(set(df.columns))
+
+    def test_column_types(self, df):
+        assert pd.api.types.is_datetime64_any_dtype(df["date"])
+        assert df["quarter"].dtype == object
+        assert df["financial_year"].dtype == object
+        assert pd.api.types.is_integer_dtype(df["year"])
+
+    def test_quarter_values_valid(self, df):
+        assert set(df["quarter"].unique()) == {"Q1", "Q2", "Q3", "Q4"}
+
+    def test_history_starts_2002_03(self, df):
+        first = df.iloc[0]
+        assert first["financial_year"] == "2002/03"
+        assert first["quarter"] == "Q1"
+        assert first["date"] == pd.Timestamp("2002-04-01")
+
+    def test_chronological_order(self, df):
+        assert df["date"].is_monotonic_increasing
+
+    def test_minimum_coverage(self, df):
+        # 23+ full financial years since 2002/03 = ~90 quarters
+        assert len(df) >= 90
+
+    def test_recent_data_available(self, df):
+        latest_year = df["year"].max()
+        assert latest_year >= 2024
+
+    def test_application_counts_positive(self, df):
+        for col in ("applications_received", "applications_decided", "applications_approved"):
+            vals = df[col].dropna()
+            assert (vals >= 0).all(), f"Negative values in {col}"
+
+    def test_application_volumes_plausible(self, df):
+        # Quarterly applications received historically 2,000-9,000
+        received = df["applications_received"].dropna()
+        assert received.min() > 1_000
+        assert received.max() < 20_000
+
+    def test_approval_rate_in_range(self, df):
+        rates = df["approval_rate"].dropna()
+        assert rates.between(0, 1.0001).all()
+        # Mean approval rate has historically been ~90%+
+        assert rates.mean() > 0.80
+
+    def test_approved_le_decided(self, df):
+        sub = df.dropna(subset=["applications_approved", "applications_decided"])
+        assert (sub["applications_approved"] <= sub["applications_decided"]).all()
+
+    def test_population_plausible(self, df):
+        pop = df["mid_year_population"].dropna()
+        # NI mid-year population is ~1.7m-1.95m across the series
+        assert (pop > 1_600_000).all()
+        assert (pop < 2_100_000).all()
+
+    def test_date_aligns_with_fy_quarter(self, df):
+        for _, row in df.head(20).iterrows():
+            q = row["quarter"]
+            expected_month = {"Q1": 4, "Q2": 7, "Q3": 10, "Q4": 1}[q]
+            assert row["date"].month == expected_month
+            assert row["date"].day == 1
+
+    def test_validate_passes_on_real_data(self, df):
+        assert planning_statistics.validate_data(df) is True
+
+
+class TestPlanningCouncilIntegrity:
+    """Integrity tests for council-area data (sheet 1.2)."""
+
+    @pytest.fixture(scope="class")
+    def cdf(self) -> pd.DataFrame:
+        return planning_statistics.get_latest_council_data(force_refresh=False)
+
+    def test_required_columns(self, cdf):
+        required = {
+            "date",
+            "financial_year",
+            "quarter",
+            "year",
+            "council",
+            "applications_received",
+            "applications_decided",
+            "applications_approved",
+            "applications_withdrawn",
+            "approval_rate",
+        }
+        assert required.issubset(set(cdf.columns))
+
+    def test_all_eleven_councils_present(self, cdf):
+        councils = set(cdf["council"].unique())
+        missing = ELEVEN_COUNCILS - councils
+        assert not missing, f"Missing councils: {missing}"
+
+    def test_council_data_non_empty(self, cdf):
+        assert len(cdf) > 0
+        # At least 11 councils * 4 quarters in the latest financial year
+        assert len(cdf) >= 44
+
+    def test_council_quarter_values_valid(self, cdf):
+        assert set(cdf["quarter"].unique()).issubset({"Q1", "Q2", "Q3", "Q4"})
+
+    def test_council_received_plausible(self, cdf):
+        # Most councils receive 100-500 applications per quarter
+        # Take just the 11 named councils to avoid Strategic Planning Div / NI total
+        sub = cdf[cdf["council"].isin(ELEVEN_COUNCILS)]
+        vals = sub["applications_received"].dropna()
+        assert vals.min() >= 0
+        assert vals.max() < 2_000
+
+    def test_council_approval_rate_in_range(self, cdf):
+        rates = cdf["approval_rate"].dropna()
+        assert rates.between(0, 1.0001).all()
+
+
+class TestAnnualTotals:
+    """Tests for annual financial-year aggregation."""
+
+    @pytest.fixture(scope="class")
+    def df(self) -> pd.DataFrame:
+        return planning_statistics.get_latest_data(force_refresh=False)
+
+    def test_annual_totals_structure(self, df):
+        ann = planning_statistics.get_annual_totals(df)
+        assert "financial_year" in ann.columns
+        assert "applications_received" in ann.columns
+        assert "approval_rate" in ann.columns
+        # 2002/03 through latest in-progress year = 23+ rows
+        assert len(ann) >= 23
+
+    def test_complete_years_have_4_quarters(self, df):
+        ann = planning_statistics.get_annual_totals(df)
+        # All but the latest in-progress year should have 4 quarters
+        full = ann[ann["quarters"] == 4]
+        assert len(full) >= 22
+
+    def test_annual_received_consistent_with_quarterly(self, df):
+        ann = planning_statistics.get_annual_totals(df)
+        # 2002/03 had 29,561 applications received according to the source data
+        first = ann.iloc[0]
+        assert first["financial_year"] == "2002/03"
+        assert first["applications_received"] == df[df["financial_year"] == "2002/03"][
+            "applications_received"
+        ].sum()
+
+
+class TestCouncilSummary:
+    """Tests for council summary aggregation."""
+
+    @pytest.fixture(scope="class")
+    def cdf(self) -> pd.DataFrame:
+        return planning_statistics.get_latest_council_data(force_refresh=False)
+
+    def test_summary_default(self, cdf):
+        s = planning_statistics.get_council_summary(cdf)
+        assert "council" in s.columns
+        assert "applications_received" in s.columns
+        # Should include the 11 councils at minimum
+        assert ELEVEN_COUNCILS.issubset(set(s["council"]))
+
+    def test_summary_filtered_by_fy(self, cdf):
+        s = planning_statistics.get_council_summary(cdf, financial_year="2024/25")
+        # Belfast is consistently one of the highest-volume councils
+        belfast = s[s["council"] == "Belfast"]
+        assert len(belfast) == 1
+        assert belfast["applications_received"].iloc[0] > 0
+
+
+class TestValidationEdgeCases:
+    """Unit tests for validate_data() edge cases - no network calls."""
+
+    def _make_base_df(self) -> pd.DataFrame:
+        # Build a minimal 40-quarter valid frame
+        rows = []
+        for i in range(40):
+            year = 2002 + i // 4
+            quarter = f"Q{(i % 4) + 1}"
+            month = {"Q1": 4, "Q2": 7, "Q3": 10, "Q4": 1}[quarter]
+            cal_year = year if quarter != "Q4" else year + 1
+            rows.append(
+                {
+                    "date": pd.Timestamp(year=cal_year, month=month, day=1),
+                    "financial_year": f"{year}/{str(year + 1)[-2:]}",
+                    "quarter": quarter,
+                    "year": cal_year,
+                    "applications_received": 3000,
+                    "applications_decided": 2800,
+                    "applications_approved": 2600,
+                    "applications_withdrawn": 100,
+                    "approval_rate": 0.93,
+                    "mid_year_population": 1_800_000,
+                    "applications_per_10k": 16.6,
+                }
+            )
+        return pd.DataFrame(rows)
+
+    def test_validate_empty_dataframe(self):
+        with pytest.raises(NISRAValidationError, match="empty"):
+            planning_statistics.validate_data(pd.DataFrame())
+
+    def test_validate_none(self):
+        with pytest.raises(NISRAValidationError, match="empty"):
+            planning_statistics.validate_data(None)  # type: ignore[arg-type]
+
+    def test_validate_missing_columns(self):
+        df = self._make_base_df().drop(columns=["approval_rate"])
+        with pytest.raises(NISRAValidationError, match="Missing required columns"):
+            planning_statistics.validate_data(df)
+
+    def test_validate_too_few_rows(self):
+        df = self._make_base_df().iloc[:10].copy()
+        with pytest.raises(NISRAValidationError, match="Too few quarters"):
+            planning_statistics.validate_data(df)
+
+    def test_validate_bad_quarter_value(self):
+        df = self._make_base_df()
+        df.loc[0, "quarter"] = "Q5"
+        with pytest.raises(NISRAValidationError, match="Unexpected quarter"):
+            planning_statistics.validate_data(df)
+
+    def test_validate_negative_received(self):
+        df = self._make_base_df()
+        df.loc[0, "applications_received"] = -1
+        with pytest.raises(NISRAValidationError, match="Negative"):
+            planning_statistics.validate_data(df)
+
+    def test_validate_implausibly_high(self):
+        df = self._make_base_df()
+        df.loc[0, "applications_received"] = 999_999
+        with pytest.raises(NISRAValidationError, match="Implausibly high"):
+            planning_statistics.validate_data(df)
+
+    def test_validate_approval_rate_out_of_range(self):
+        df = self._make_base_df()
+        df.loc[0, "approval_rate"] = 2.5
+        with pytest.raises(NISRAValidationError, match="approval_rate"):
+            planning_statistics.validate_data(df)
+
+    def test_validate_passes_on_synthetic_valid_data(self):
+        assert planning_statistics.validate_data(self._make_base_df()) is True
+
+
+class TestHelperParsers:
+    """Unit tests for internal helpers - no network calls."""
+
+    def test_parse_fy_quarter_q1(self):
+        from bolster.data_sources.nisra.planning_statistics import _parse_fy_quarter_to_date
+
+        assert _parse_fy_quarter_to_date("2024/25", "Q1") == pd.Timestamp("2024-04-01")
+
+    def test_parse_fy_quarter_q4(self):
+        from bolster.data_sources.nisra.planning_statistics import _parse_fy_quarter_to_date
+
+        assert _parse_fy_quarter_to_date("2024/25", "Q4") == pd.Timestamp("2025-01-01")
+
+    def test_parse_fy_quarter_bad_year(self):
+        from bolster.data_sources.nisra.planning_statistics import _parse_fy_quarter_to_date
+
+        assert _parse_fy_quarter_to_date("not a year", "Q1") is None
+
+    def test_parse_fy_quarter_bad_quarter(self):
+        from bolster.data_sources.nisra.planning_statistics import _parse_fy_quarter_to_date
+
+        assert _parse_fy_quarter_to_date("2024/25", "Q9") is None
+
+    def test_parse_fy_quarter_non_string(self):
+        from bolster.data_sources.nisra.planning_statistics import _parse_fy_quarter_to_date
+
+        assert _parse_fy_quarter_to_date(2024, "Q1") is None  # type: ignore[arg-type]
+
+    def test_parse_council_label_valid(self):
+        from bolster.data_sources.nisra.planning_statistics import _parse_council_date_label
+
+        result = _parse_council_date_label("Apr-Jun 2025")
+        assert result is not None
+        ts, fy, q = result
+        assert ts == pd.Timestamp("2025-04-01")
+        assert fy == "2025/26"
+        assert q == "Q1"
+
+    def test_parse_council_label_q4_fy_rollover(self):
+        from bolster.data_sources.nisra.planning_statistics import _parse_council_date_label
+
+        result = _parse_council_date_label("Jan-Mar 2025")
+        assert result is not None
+        ts, fy, q = result
+        assert ts == pd.Timestamp("2025-01-01")
+        assert fy == "2024/25"
+        assert q == "Q4"
+
+    def test_parse_council_label_invalid(self):
+        from bolster.data_sources.nisra.planning_statistics import _parse_council_date_label
+
+        assert _parse_council_date_label("Year to date 2025/26") is None
+        assert _parse_council_date_label("") is None
+        assert _parse_council_date_label(None) is None  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary

Adds `bolster.data_sources.nisra.planning_statistics`, exposing Department for Infrastructure quarterly planning application statistics for Northern Ireland.

The module scrapes the [planning activity statistics hub](https://www.infrastructure-ni.gov.uk/articles/planning-activity-statistics) for the latest publication, downloads the quarterly statistical tables XLSX, and parses two complementary views:

- **NI-wide quarterly time series** (sheet 1.1): applications received / decided / approved / withdrawn, approval rate, mid-year population, per-10k rate. ~95 quarters from Q1 2002/03 to the latest provisional release.
- **Per-council breakdown** (sheet 1.2): 11 NI local councils plus NI total and Strategic Planning Division. The five stacked sub-tables (received / decided / approved / approval-rate / withdrawn) are unpivoted into a tidy long DataFrame.

Helpers added: `validate_data()`, `get_annual_totals()`, `get_council_summary()`. CLI command `bolster nisra planning-statistics` exposes four dimensions (`ni` / `council` / `annual` / `council-summary`).

## Example insights (from real data, 2025/26 Q3 release)

- **Long-term decline in volume**: NI quarterly applications received fell from 29,561 in 2002/03 to 9,716 in 2024/25 — a ~67% drop over 22 years. Approval rate has stayed broadly stable in the 90-95% range.
- **Belfast and Mid Ulster dominate volume** in 2024/25: Belfast received 1,296 applications and Mid Ulster 1,234, ahead of Newry/Mourne/Down (1,141). Together the top three councils account for ~38% of all NI applications.
- **Approval rates vary widely by council** in 2024/25: Mid Ulster has the highest approval rate (98.2%) among major councils, while Newry/Mourne/Down has the lowest (89.8%). NI-wide average is 94.5%.

## Usage

Python:

```python
from bolster.data_sources.nisra import planning_statistics

df = planning_statistics.get_latest_data()
annual = planning_statistics.get_annual_totals(df)

council_df = planning_statistics.get_latest_council_data()
summary = planning_statistics.get_council_summary(council_df, financial_year="2024/25")
```

CLI:

```bash
bolster nisra planning-statistics                                  # NI-wide quarterly CSV
bolster nisra planning-statistics --dimension annual               # Financial-year totals
bolster nisra planning-statistics --dimension council-summary \
    --financial-year 2024/25                                       # Council ranking
bolster nisra planning-statistics --save planning.csv
```

## Test plan

- [x] 45 new tests in `tests/test_nisra_planning_statistics_integrity.py` pass (live publication discovery + real-data parsing + validation edge cases + helper parsers)
- [x] Module coverage 93% (above 90% target)
- [x] Full local test suite passes (1113 passed, 7 skipped)
- [x] `pre-commit run --all-files` clean
- [x] Verify CI passes after push

🤖 Generated with [Claude Code](https://claude.com/claude-code)