### PR TITLE
fix(ci): exclude .claude/agents/ from mdformat

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,6 +5,7 @@ repos:
           - id: mdformat
             additional_dependencies:
                 - mdformat-ruff
+            exclude: ^\.claude/
     - repo: https://github.com/astral-sh/ruff-pre-commit
       # Ruff version.
       rev: v0.9.10


### PR DESCRIPTION
## Problem

\`mdformat\` was stripping YAML frontmatter fences (\`---\`) from Claude Code agent definition files in \`.claude/agents/\`. This broke agent discovery — Claude Code requires proper YAML frontmatter to recognise and load agent definitions.

The files were being reformatted to remove the \`---\` block on every \`pre-commit\` run, requiring manual restoration each time.

## Fix

Add \`exclude: ^\.claude/\` to the mdformat hook so it skips the agents directory entirely. The agent \`.md\` files contain structured YAML frontmatter that mdformat shouldn't touch.

## Test

\`pre-commit run --all-files\` passes clean.