### PR TITLE
chore: bump version to 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## [0.5.0] - 2026-05-01
+
+- feat(nisra): add stillbirths module and update population projections to 2024-based (#1762)
+- fix(nisra): fix population scraper broken by NISRA site restructure (#1758)
+- fix(release): use bump-my-version show to extract version after bump (#1739)
+- fix(ci): allow manual dispatch of rebase workflow to update all BEHIND PRs
+- fix(web): cap retry backoff to prevent CI hangs on blocked IPs
+- fix(web): cap retry backoff to prevent CI hangs on blocked IPs
+- fix(ci): include BEHIND PRs in auto-rebase workflow
+- feat(ashe): refactor linked-tables parsing to content-fingerprint detection (#1748)
+- feat(data): UK Gender Pay Gap reporting data source (#217) (#1741)
+- feat(ashe): implement Figures 14-18 gender earnings analysis (#1747)
+- fix(web): add tqdm progress bar to download_extract_zip (#314)
+- fix(drift-detection): bump artifact actions to Node.js 24, fix speciesName trailing punctuation
+- feat: weekly NISRA feed drift detection via TF-IDF (#1732)
+
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bolster"
-version = "0.4.0"
+version = "0.5.0"
 description = "Bolster's Brain, you've been warned"
 authors = [
     {name = "Andrew Bolster", email = "andrew.bolster@gmail.com"},
@@ -183,7 +183,7 @@ precision = 2
 
 # Configuration for bump-my-version (modern) and legacy bumpversion compatibility
 [tool.bumpversion]
-current_version = "0.4.0"
+current_version = "0.5.0"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 search = "{current_version}"

--- a/uv.lock
+++ b/uv.lock
@@ -206,7 +206,7 @@ css = [
 
 [[package]]
 name = "bolster"
-version = "0.4.0"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
Automated version bump to 0.5.0.

This PR was created manually to recover from a failed release workflow run on 2026-05-01. The `v0.5.0` tag was pushed successfully but `gh pr create --auto-merge` failed before creating the PR, leaving the release branch stranded.

Merging this PR will bring `main`'s `pyproject.toml` to `0.5.0` and make the `v0.5.0` tag reachable from `main`, which will stop the release workflow failure loop.

The root cause (`--auto-merge` killing PR creation silently) is fixed in `claude/improve-docs-structure-R9uiu`.

---
_Generated by [Claude Code](https://claude.ai/code/session_013DU8d5u9Kj6LP1MUk5BoDe)_