### PR TITLE
fix(ci): auto-release idempotency and safer PR creation

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -218,38 +218,76 @@ jobs:
     - name: Push version bump branch, tag, and open PR
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        CHANGELOG_ENTRY: ${{ needs.analyze-changes.outputs.changelog }}
       run: |
         BRANCH="release/v${NEW_VERSION}"
+
+        # Idempotency: if the tag already exists (e.g. a previous run pushed the
+        # tag but failed before creating the PR), skip straight to PR creation.
+        if git ls-remote --exit-code origin "refs/tags/v${NEW_VERSION}" 2>/dev/null; then
+          echo "Tag v${NEW_VERSION} already exists on remote — checking for open PR"
+          EXISTING_PR=$(gh pr list --head "$BRANCH" --base main --json number --jq '.[0].number' 2>/dev/null || true)
+          if [ -n "$EXISTING_PR" ]; then
+            echo "PR #${EXISTING_PR} already open for ${BRANCH} — nothing to do"
+            exit 0
+          fi
+          echo "No PR found for ${BRANCH} — opening one now"
+          gh pr create \
+            --title "chore: bump version to ${NEW_VERSION}" \
+            --body "Automated version bump to ${NEW_VERSION} (retry — tag was already pushed in a previous run)." \
+            --label "version:skip" \
+            --base main \
+            --head "$BRANCH"
+          exit 0
+        fi
+
         git checkout -b "$BRANCH"
         git add .
         git commit -m "chore: bump version to ${NEW_VERSION}"
         git tag "v${NEW_VERSION}"
         git push origin "$BRANCH"
         git push origin "v${NEW_VERSION}"
+
+        # Write PR body to a file so that multi-line changelog content and any
+        # special shell characters are not interpreted by bash.
+        python3 - <<'PYEOF'
+        import os
+        from pathlib import Path
+
+        version = os.environ["NEW_VERSION"]
+        changelog = os.environ.get("CHANGELOG_ENTRY", "")
+
+        body = f"""Automated version bump to {version}.
+
+## Changes in this release
+
+{changelog}
+
+## Installation
+
+```bash
+pip install bolster=={version}
+```
+
+## Documentation
+
+- [Documentation](https://bolster.help)
+- [PyPI Package](https://pypi.org/project/bolster/{version}/)
+
+---
+*This PR was automatically created by the release workflow. It will be merged automatically once CI passes.*
+
+> **Note**: The `v{version}` tag has already been pushed. PyPI publishing is triggered by the tag and will proceed independently."""
+
+        Path("/tmp/pr-body.md").write_text(body)
+        PYEOF
+
+        # automerge.yml handles auto-merge for github-actions[bot] PRs;
+        # do not pass --auto-merge here as it can fail if the repo feature
+        # is not enabled, which would leave the tag pushed but no PR created.
         gh pr create \
           --title "chore: bump version to ${NEW_VERSION}" \
-          --body "Automated version bump to ${NEW_VERSION}.
-
-        ## Changes in this release
-
-        ${{ needs.analyze-changes.outputs.changelog }}
-
-        ## Installation
-
-        \`\`\`bash
-        pip install bolster==${NEW_VERSION}
-        \`\`\`
-
-        ## Documentation
-
-        - [Documentation](https://bolster.help)
-        - [PyPI Package](https://pypi.org/project/bolster/${NEW_VERSION}/)
-
-        ---
-        *This PR was automatically created by the release workflow. It will be merged automatically once CI passes.*
-
-        > **Note**: The \`v${NEW_VERSION}\` tag has already been pushed. PyPI publishing is triggered by the tag and will proceed independently." \
+          --body-file /tmp/pr-body.md \
           --label "version:skip" \
-          --auto-merge \
           --base main \
           --head "$BRANCH"


### PR DESCRIPTION
## Summary

Fixes the auto-release workflow failure loop caused by two bugs:

- **Root cause**: `gh pr create --auto-merge` failed after the tag was already pushed, leaving `release/v0.5.0` stranded with no PR. Every subsequent push to `main` then tried to re-push the existing `v0.5.0` tag and died.
- **Secondary**: Inlining `${{ needs.analyze-changes.outputs.changelog }}` directly into a bash double-quoted string is unsafe if commit messages contain `"`, `$`, or backticks.

## Changes

1. **Idempotency check**: if the tag already exists on the remote (previous run pushed it but failed before creating the PR), detect the existing branch, check for an open PR, create one if missing, then exit 0. Breaks the current failure loop and makes future partial failures self-healing.
2. **Remove `--auto-merge`**: `automerge.yml` already handles auto-merge for `github-actions[bot]` PRs via `pull_request_target`. The `--auto-merge` flag on `gh pr create` was redundant and its failure was silently killing PR creation.
3. **PR body via temp file**: changelog is written by Python into `/tmp/pr-body.md` and passed with `--body-file`, so shell-special characters in commit messages can't break the `gh pr create` invocation.

## Related

- Companion recovery PR: #1795 (merges the stranded `release/v0.5.0` branch to unblock `main`)

---
_Generated by [Claude Code](https://claude.ai/code/session_013DU8d5u9Kj6LP1MUk5BoDe)_