### PR TITLE
fix(composite_index): update stale URL path to /economic-output/

### DIFF
--- a/src/bolster/data_sources/nisra/composite_index.py
+++ b/src/bolster/data_sources/nisra/composite_index.py
@@ -41,7 +41,7 @@ Publication Details:
     - Frequency: Quarterly (published ~3 months after quarter end)
     - Published by: NISRA Economic & Labour Market Statistics Branch
     - Contact: economicstats@nisra.gov.uk
-    - Mother page: https://www.nisra.gov.uk/statistics/economic-output-statistics/ni-composite-economic-index
+    - Mother page: https://www.nisra.gov.uk/statistics/economic-output/ni-composite-economic-index
     - Note: NICEI is an experimental statistic subject to revision
 
 Author: Claude Code
@@ -61,7 +61,7 @@ logger = logging.getLogger(__name__)
 
 # Base URL for NICEI publications
 NICEI_BASE_URL = "https://www.nisra.gov.uk"
-NICEI_STATS_URL = "https://www.nisra.gov.uk/statistics/economic-output-statistics/ni-composite-economic-index"
+NICEI_STATS_URL = "https://www.nisra.gov.uk/statistics/economic-output/ni-composite-economic-index"
 
 
 def get_latest_nicei_publication_url() -> tuple[str, int, str]:


### PR DESCRIPTION
Closes #1804.

The NISRA URL path `/economic-output-statistics/` is stale — the current path is `/economic-output/`, consistent with what `index_of_production.py` and `index_of_services.py` already use.

Two-line change: constant definition and docstring.