### PR TITLE
feat: complete CLI/README for baby names, work quality, education suspensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,11 +210,15 @@ The [GOV.UK NISRA statistics RSS feed](https://www.gov.uk/search/research-and-st
 | UK Gender Pay Gap Reporting | `gender_pay_gap` | ✅ |
 | Individual Wellbeing | `nisra.wellbeing` | ✅ |
 | Cancer Waiting Times | `nisra.cancer_waiting_times` | ✅ |
+| Child Protection Statistics | `nisra.child_protection` | ✅ |
 | NI Planning Activity Statistics (DfI) | `nisra.planning_statistics` | ✅ |
 | Registrar General Quarterly Tables | `nisra.registrar_general` | ✅ |
 | Tourism - Hotel Occupancy | `nisra.tourism.occupancy` | ✅ |
 | Tourism - SSA Occupancy | `nisra.tourism.occupancy` | ✅ |
 | Tourism - Visitor Statistics | `nisra.tourism.visitor_statistics` | ✅ |
+| Baby Names NI (annual, 1997–present) | `nisra.baby_names` | ✅ |
+| NI School Suspensions (DE) | `education_suspensions` | ✅ |
+| Work Quality NI (NISRA) | `nisra.work_quality` | ✅ |
 | Security Situation Statistics | - | Planned |
 | Road Traffic Collisions | `psni.road_traffic_collisions` | ✅ |
 | PSNI Crime Statistics | `psni.crime_statistics` | ⚠️ stale (to Dec 2021) |

--- a/src/bolster/cli.py
+++ b/src/bolster/cli.py
@@ -11,7 +11,7 @@ from rich.panel import Panel
 from rich.text import Text
 
 from . import __version__
-from .data_sources import dva, gender_pay_gap
+from .data_sources import dva, education_suspensions, gender_pay_gap
 from .data_sources.cineworld import get_cinema_listings
 from .data_sources.companies_house import get_companies_house_records_that_might_be_in_farset, query_basic_company_data
 from .data_sources.eoni import get_results as get_ni_election_results
@@ -19,8 +19,10 @@ from .data_sources.metoffice import get_uk_precipitation
 from .data_sources.ni_house_price_index import build as get_ni_house_prices
 from .data_sources.ni_water import get_postcode_to_water_supply_zone, get_water_quality_by_zone
 from .data_sources.nisra import ashe as nisra_ashe
+from .data_sources.nisra import baby_names as nisra_baby_names
 from .data_sources.nisra import births as nisra_births
 from .data_sources.nisra import cancer_waiting_times as nisra_cancer
+from .data_sources.nisra import child_protection as nisra_child_protection
 from .data_sources.nisra import composite_index as nisra_composite
 from .data_sources.nisra import construction_output as nisra_construction
 from .data_sources.nisra import deaths as nisra_deaths
@@ -35,6 +37,7 @@ from .data_sources.nisra import population as nisra_population
 from .data_sources.nisra import population_projections as nisra_projections
 from .data_sources.nisra import registrar_general as nisra_registrar_general
 from .data_sources.nisra import wellbeing as nisra_wellbeing
+from .data_sources.nisra import work_quality as nisra_work_quality
 from .data_sources.nisra.tourism import occupancy as nisra_occupancy
 from .data_sources.nisra.tourism import visitor_statistics as nisra_visitors
 from .data_sources.wikipedia import get_ni_executive_basic_table
@@ -4475,6 +4478,110 @@ def nisra_emergency_care_cmd(output_format, trust, attendance_type, year, save):
         raise click.Abort() from e
 
 
+@nisra.command(name="child-protection")
+@click.option(
+    "--measure",
+    type=click.Choice(
+        ["referrals", "cpr-trend", "investigations", "abuse-categories", "all"],
+        case_sensitive=False,
+    ),
+    default="all",
+    help="Which measure to show (default: all)",
+)
+@click.option("--year", type=int, help="Filter data for a specific year")
+@click.option(
+    "--format",
+    "output_format",
+    type=click.Choice(["csv", "json"], case_sensitive=False),
+    default="csv",
+    help="Output format (default: csv)",
+)
+@click.option("--force-refresh", is_flag=True, help="Force re-download even if cached")
+@click.option("--save", help="Save output to file (specify filename)")
+def nisra_child_protection_cmd(measure, year, output_format, force_refresh, save):
+    r"""NISRA Children's Social Care — Child Protection Statistics.
+
+    Annual statistics on child protection in Northern Ireland drawn from the
+    Children Order Return (CPR) series, published by the Department of Health.
+
+    Measures available:
+
+    \b
+        referrals         NI-wide and per-trust referral counts (2013/14–present)
+        cpr-trend         Children on the Child Protection Register by trust (2015–present)
+        investigations    CP investigations by trust (2015–present)
+        abuse-categories  Register entries by category of abuse (2015–present)
+        all               All of the above combined (default)
+
+    Examples::
+
+        bolster nisra child-protection
+        bolster nisra child-protection --measure referrals
+        bolster nisra child-protection --measure cpr-trend --year 2023
+        bolster nisra child-protection --save cp_data.csv
+
+    Data source:
+        https://www.health-ni.gov.uk/topics/childrens-services-statistics
+    """
+    console = Console()
+
+    measure_map = {
+        "referrals": ["referrals_ni_total", "referrals_by_trust"],
+        "cpr-trend": ["cpr_registrations_ni_total", "cpr_registrations_trust_snapshot"],
+        "investigations": ["investigations_ni_total", "investigations_by_trust"],
+        "abuse-categories": ["cpr_by_abuse_category"],
+    }
+
+    try:
+        with console.status("[bold green]Downloading latest child protection data..."):
+            df = nisra_child_protection.get_latest_child_protection(force_refresh=force_refresh)
+
+        # Filter by measure
+        if measure != "all":
+            codes = measure_map.get(measure, [])
+            df = df[df["measure"].isin(codes)]
+
+        # Filter by year
+        if year is not None:
+            df = df[df["year"] == year]
+            if df.empty:
+                console.print(f"[yellow]No data found for year {year}[/yellow]")
+                return
+
+        console.print(f"[green]Retrieved {len(df)} child protection records[/green]")
+        if not df.empty:
+            min_year = int(df["year"].min())
+            max_year = int(df["year"].max())
+            console.print(f"[dim]Years: {min_year}–{max_year}[/dim]")
+            console.print(f"[dim]Measures: {', '.join(sorted(df['measure'].unique()))}[/dim]")
+
+        # Save or display
+        if save:
+            try:
+                if output_format == "json" or save.endswith(".json"):
+                    df.to_json(save, orient="records", indent=2)
+                else:
+                    df.to_csv(save, index=False)
+                console.print(f"[green]Data saved to: {save}[/green]")
+                return
+            except Exception as e:
+                console.print(f"[red]Error saving file: {e}[/red]")
+                return
+
+        if output_format == "json":
+            click.echo(df.to_json(orient="records", indent=2))
+        else:
+            console.print("\n[bold]Data:[/bold]")
+            console.print(df.to_csv(index=False), end="")
+
+    except Exception as e:
+        console.print(f"[bold red]Error:[/bold red] {str(e)}", style="red")
+        console.print("\n[yellow]Troubleshooting:[/yellow]")
+        console.print("   • Check your internet connection")
+        console.print("   • Try again with --force-refresh to bypass cache")
+        raise click.Abort() from e
+
+
 @nisra.command(name="registrar-general")
 @click.option("--latest", is_flag=True, help="Get the most recent quarterly tables data")
 @click.option("--quarterly", is_flag=True, help="Show full quarterly time series")
@@ -5041,6 +5148,307 @@ def nisra_planning_statistics_cmd(dimension, financial_year, output_format, forc
 
         if output_format == "json":
             click.echo(data.to_json(orient="records", date_format="iso", indent=2))
+        else:
+            console.print(data.to_csv(index=False), end="")
+
+    except Exception as e:
+        console.print(f"[bold red]Error:[/bold red] {str(e)}", style="red")
+        console.print("\n[yellow]Troubleshooting:[/yellow]")
+        console.print("   - Check your internet connection")
+        console.print("   - Try again with --force-refresh to bypass cache")
+        raise click.Abort() from e
+
+
+@nisra.command(name="baby-names")
+@click.option("--year", type=int, default=None, help="Filter by registration year")
+@click.option(
+    "--sex",
+    type=click.Choice(["Boys", "Girls", "both"], case_sensitive=False),
+    default="both",
+    help="Filter by sex (default: both)",
+)
+@click.option("--top", "top_n", type=int, default=None, help="Show only top N names by rank")
+@click.option(
+    "--format",
+    "output_format",
+    type=click.Choice(["csv", "json"], case_sensitive=False),
+    default="csv",
+    help="Output format (default: csv)",
+)
+@click.option("--force-refresh", is_flag=True, help="Force re-download even if cached")
+@click.option("--save", help="Save data to file (specify filename)")
+def nisra_baby_names_cmd(year, sex, top_n, output_format, force_refresh, save):
+    r"""NISRA Baby Names for Northern Ireland (1997 to present).
+
+    \b
+    Full historical list of all first forenames given to babies registered in
+    Northern Ireland, with annual rank and count for every name by sex.
+
+    Examples:
+        Top 10 boys' names in 2024::
+
+            bolster nisra baby-names --year 2024 --sex Boys --top 10
+
+        All names for 2023 saved to file::
+
+            bolster nisra baby-names --year 2023 --save baby_names_2023.csv
+
+        Full dataset as JSON::
+
+            bolster nisra baby-names --format json
+
+    Source:
+        https://www.nisra.gov.uk/statistics/births/baby-names
+    """
+    from rich.console import Console
+
+    console = Console()
+
+    try:
+        with console.status("[bold green]Downloading NISRA baby names data..."):
+            data = nisra_baby_names.get_baby_names(force_refresh=force_refresh)
+
+        if year is not None:
+            data = data[data["year"] == year]
+            if data.empty:
+                console.print(f"[yellow]No data found for year {year}[/yellow]")
+                return
+
+        if sex.lower() != "both":
+            sex_title = sex.title()
+            data = data[data["sex"] == sex_title]
+            if data.empty:
+                console.print(f"[yellow]No data found for sex '{sex_title}'[/yellow]")
+                return
+
+        if top_n is not None:
+            data = data[data["rank"] <= top_n]
+
+        console.print("[green]Baby names data retrieved successfully[/green]")
+        console.print(f"[cyan]Rows: {len(data)}[/cyan]")
+        if not data.empty:
+            console.print(
+                f"[dim]Years: {data['year'].min()}–{data['year'].max()} | "
+                f"Sexes: {', '.join(sorted(data['sex'].unique()))}[/dim]"
+            )
+
+        if save:
+            try:
+                if output_format == "json" or save.endswith(".json"):
+                    data.to_json(save, orient="records", indent=2)
+                else:
+                    data.to_csv(save, index=False)
+                console.print(f"[green]Saved to: {save}[/green]")
+                return
+            except PermissionError:
+                console.print(f"[red]Error: Permission denied writing to {save}[/red]")
+                return
+            except Exception as e:
+                console.print(f"[red]Error saving file: {e}[/red]")
+                return
+
+        if output_format == "json":
+            click.echo(data.to_json(orient="records", indent=2))
+        else:
+            console.print(data.to_csv(index=False), end="")
+
+    except Exception as e:
+        console.print(f"[bold red]Error:[/bold red] {str(e)}", style="red")
+        console.print("\n[yellow]Troubleshooting:[/yellow]")
+        console.print("   - Check your internet connection")
+        console.print("   - Try again with --force-refresh to bypass cache")
+        raise click.Abort() from e
+
+
+@nisra.command(name="work-quality")
+@click.option("--indicator", default=None, help="Filter by indicator name (e.g. 'job_satisfaction')")
+@click.option("--year", type=int, default=None, help="Filter by year")
+@click.option(
+    "--format",
+    "output_format",
+    type=click.Choice(["csv", "json"], case_sensitive=False),
+    default="csv",
+    help="Output format (default: csv)",
+)
+@click.option("--force-refresh", is_flag=True, help="Force re-download even if cached")
+@click.option("--save", help="Save data to file (specify filename)")
+def nisra_work_quality_cmd(indicator, year, output_format, force_refresh, save):
+    r"""NISRA Work Quality Statistics for Northern Ireland.
+
+    \b
+    Seventeen indicators of job quality for employees aged 18 and over,
+    drawn from the Labour Force Survey (LFS) and Annual Survey of Hours
+    and Earnings (ASHE). Covers 2020 to present with breakdowns by sex,
+    age group, deprivation quintile, and skill level.
+
+    Examples:
+        All work quality indicators::
+
+            bolster nisra work-quality
+
+        Filter to job satisfaction indicator::
+
+            bolster nisra work-quality --indicator job_satisfaction
+
+        Data for 2023 saved as JSON::
+
+            bolster nisra work-quality --year 2023 --format json --save wq2023.json
+
+    Source:
+        https://www.nisra.gov.uk/statistics/labour-market-and-social-welfare/work-quality
+    """
+    from rich.console import Console
+
+    console = Console()
+
+    try:
+        with console.status("[bold green]Downloading NISRA work quality data..."):
+            data = nisra_work_quality.get_latest_work_quality(force_refresh=force_refresh)
+
+        if indicator is not None:
+            data = data[data["indicator"] == indicator]
+            if data.empty:
+                console.print(f"[yellow]No data found for indicator '{indicator}'[/yellow]")
+                all_data = nisra_work_quality.get_latest_work_quality(force_refresh=False)
+                available = all_data["indicator"].unique()
+                console.print(f"[dim]Available indicators: {', '.join(sorted(available))}[/dim]")
+                return
+
+        if year is not None:
+            data = data[data["year"] == year]
+            if data.empty:
+                console.print(f"[yellow]No data found for year {year}[/yellow]")
+                return
+
+        console.print("[green]Work quality data retrieved successfully[/green]")
+        console.print(f"[cyan]Rows: {len(data)}[/cyan]")
+        if not data.empty and "year" in data.columns:
+            console.print(f"[dim]Years: {data['year'].min()}–{data['year'].max()}[/dim]")
+
+        if save:
+            try:
+                if output_format == "json" or save.endswith(".json"):
+                    data.to_json(save, orient="records", indent=2)
+                else:
+                    data.to_csv(save, index=False)
+                console.print(f"[green]Saved to: {save}[/green]")
+                return
+            except PermissionError:
+                console.print(f"[red]Error: Permission denied writing to {save}[/red]")
+                return
+            except Exception as e:
+                console.print(f"[red]Error saving file: {e}[/red]")
+                return
+
+        if output_format == "json":
+            click.echo(data.to_json(orient="records", indent=2))
+        else:
+            console.print(data.to_csv(index=False), end="")
+
+    except Exception as e:
+        console.print(f"[bold red]Error:[/bold red] {str(e)}", style="red")
+        console.print("\n[yellow]Troubleshooting:[/yellow]")
+        console.print("   - Check your internet connection")
+        console.print("   - Try again with --force-refresh to bypass cache")
+        raise click.Abort() from e
+
+
+@cli.group(name="education")
+def education():
+    """Education statistics for Northern Ireland.
+
+    Access official education data from the Department of Education Northern
+    Ireland (DE NI), including pupil suspension and expulsion statistics.
+    """
+    pass
+
+
+@education.command(name="suspensions")
+@click.option("--year", default=None, help="Filter by academic year (e.g. '2023/24')")
+@click.option(
+    "--format",
+    "output_format",
+    type=click.Choice(["csv", "json"], case_sensitive=False),
+    default="csv",
+    help="Output format (default: csv)",
+)
+@click.option("--force-refresh", is_flag=True, help="Force re-download even if cached")
+@click.option("--save", help="Save data to file (specify filename)")
+@click.option("--summary", is_flag=True, help="Show summary statistics instead of full data")
+def education_suspensions_cmd(year, output_format, force_refresh, save, summary):
+    r"""NI Pupil Suspensions and Expulsions (Department of Education).
+
+    \b
+    Annual suspension statistics for pupils of compulsory school age in
+    Northern Ireland, covering 2011/12 to present.
+
+    Examples:
+        Full suspension time series::
+
+            bolster education suspensions
+
+        Filter to a single academic year::
+
+            bolster education suspensions --year 2023/24
+
+        Summary overview::
+
+            bolster education suspensions --summary
+
+        Save as CSV::
+
+            bolster education suspensions --save suspensions.csv
+
+    Source:
+        https://www.education-ni.gov.uk/articles/pupil-suspensions-and-expulsions
+    """
+    from rich.console import Console
+
+    console = Console()
+
+    try:
+        with console.status("[bold green]Downloading NI pupil suspensions data..."):
+            data = education_suspensions.get_latest_suspensions(force_refresh=force_refresh)
+
+        if year is not None:
+            data = data[data["academic_year"] == year]
+            if data.empty:
+                console.print(f"[yellow]No data found for academic year '{year}'[/yellow]")
+                return
+
+        console.print("[green]Pupil suspensions data retrieved successfully[/green]")
+        console.print(f"[cyan]Rows: {len(data)}[/cyan]")
+        if not data.empty:
+            console.print(f"[dim]Coverage: {data['academic_year'].iloc[0]} to {data['academic_year'].iloc[-1]}[/dim]")
+
+        if summary:
+            latest = data.iloc[-1]
+            console.print("\n[bold]Latest year:[/bold]")
+            console.print(f"   Academic year: {latest['academic_year']}")
+            console.print(f"   Pupils suspended: {latest['pupils_suspended']:,}")
+            pct = latest["pct_pupils_suspended"]
+            if pct is not None and not pd.isna(pct):
+                console.print(f"   Percentage suspended: {pct:.1%}")
+            if not save:
+                return
+
+        if save:
+            try:
+                if output_format == "json" or save.endswith(".json"):
+                    data.to_json(save, orient="records", indent=2)
+                else:
+                    data.to_csv(save, index=False)
+                console.print(f"[green]Saved to: {save}[/green]")
+                return
+            except PermissionError:
+                console.print(f"[red]Error: Permission denied writing to {save}[/red]")
+                return
+            except Exception as e:
+                console.print(f"[red]Error saving file: {e}[/red]")
+                return
+
+        if output_format == "json":
+            click.echo(data.to_json(orient="records", indent=2))
         else:
             console.print(data.to_csv(index=False), end="")
 

--- a/src/bolster/data_sources/education_suspensions.py
+++ b/src/bolster/data_sources/education_suspensions.py
@@ -1,0 +1,383 @@
+"""Pupil Suspensions and Expulsions in Northern Ireland.
+
+Provides access to annual suspension and expulsion statistics for pupils of
+compulsory school age in Northern Ireland, published by the Department of
+Education Northern Ireland (DE NI).
+
+Data covers pupil suspensions broken down by:
+- Trend over time (Table 1, from 2011/12 to present)
+- School type (Primary, Non Grammar, Grammar, Special) (Table 2)
+- School management type (Controlled, Voluntary, etc.) (Table 3)
+- Number of suspension occasions (Once, Twice, Three or more) (Table 4)
+- Suspension duration (Table 5)
+- Key Stage (Foundation/KS1, KS2, KS3, KS4) (Table 6)
+- Pupil characteristics (sex, age, ethnicity, SEN, religion) (Table 7)
+- Education Authority Region (Table 8)
+- Reason for suspension (Table 9)
+
+Data Source:
+    **Stable Entry Point**: https://www.education-ni.gov.uk/articles/pupil-suspensions-and-expulsions
+
+    The module scrapes the articles page to find the latest publication link,
+    then scrapes the publication page for the Excel data file URL.
+
+Update Frequency: Annual
+Geographic Coverage: Northern Ireland
+Reference Period: 2011/12 – present
+
+Example:
+    >>> from bolster.data_sources.education_suspensions import get_latest_suspensions
+    >>> df = get_latest_suspensions()
+    >>> 'academic_year' in df.columns
+    True
+"""
+
+import hashlib
+import logging
+from pathlib import Path
+from urllib.parse import urljoin
+
+import bs4
+import pandas as pd
+
+from bolster.utils.web import session
+
+logger = logging.getLogger(__name__)
+
+# Stable entry point – lists all annual publications
+ARTICLES_URL = "https://www.education-ni.gov.uk/articles/pupil-suspensions-and-expulsions"
+BASE_URL = "https://www.education-ni.gov.uk"
+
+# Cache directory for downloaded files (annual data – 7 day TTL is ample)
+CACHE_DIR = Path.home() / ".cache" / "bolster" / "education_suspensions"
+CACHE_DIR.mkdir(parents=True, exist_ok=True)
+
+_CACHE_TTL_HOURS = 24 * 7  # 1 week
+
+
+# ---------------------------------------------------------------------------
+# Errors
+# ---------------------------------------------------------------------------
+
+
+class EducationSuspensionsError(Exception):
+    """Base exception for education suspensions data errors."""
+
+
+class EducationSuspensionsNotFoundError(EducationSuspensionsError):
+    """Raised when the data file or publication page cannot be found."""
+
+
+class EducationSuspensionsParseError(EducationSuspensionsError):
+    """Raised when parsing the data file fails in an unexpected way."""
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _hash_url(url: str) -> str:
+    return hashlib.md5(url.encode()).hexdigest()
+
+
+def _cached_file(url: str) -> Path | None:
+    """Return path to a cached copy of *url* if it exists and is fresh."""
+    url_hash = _hash_url(url)
+    ext = Path(url.split("?")[0]).suffix or ".xlsx"
+    cache_path = CACHE_DIR / f"{url_hash}{ext}"
+    if cache_path.exists():
+        from datetime import datetime
+
+        age_hours = (datetime.now() - datetime.fromtimestamp(cache_path.stat().st_mtime)).total_seconds() / 3600
+        if age_hours < _CACHE_TTL_HOURS:
+            logger.debug("Using cached file: %s", cache_path)
+            return cache_path
+    return None
+
+
+def _download_file(url: str, force_refresh: bool = False) -> Path:
+    """Download *url* to the local cache, returning the cache path."""
+    if not force_refresh:
+        cached = _cached_file(url)
+        if cached:
+            return cached
+
+    url_hash = _hash_url(url)
+    ext = Path(url.split("?")[0]).suffix or ".xlsx"
+    cache_path = CACHE_DIR / f"{url_hash}{ext}"
+
+    try:
+        logger.info("Downloading %s", url)
+        response = session.get(url, timeout=60)
+        response.raise_for_status()
+        cache_path.write_bytes(response.content)
+        logger.info("Saved to %s", cache_path)
+        return cache_path
+    except Exception as exc:
+        raise EducationSuspensionsNotFoundError(f"Failed to download {url}: {exc}") from exc
+
+
+def _extract_data_rows(ws_rows: list[tuple], header_row_idx: int) -> pd.DataFrame:
+    """Build a DataFrame from raw worksheet rows given the 0-based header row index."""
+    header = ws_rows[header_row_idx]
+    data = ws_rows[header_row_idx + 1 :]
+    df = pd.DataFrame(data, columns=header)
+    # Drop fully-None columns and fully-None rows
+    df = df.dropna(axis=1, how="all").dropna(axis=0, how="all")
+    # The first column of every table is None (blank leading column in Excel)
+    if df.columns[0] is None:
+        df = df.iloc[:, 1:]
+    return df.reset_index(drop=True)
+
+
+# ---------------------------------------------------------------------------
+# Public: URL discovery
+# ---------------------------------------------------------------------------
+
+
+def get_suspensions_publication_url() -> str:
+    """Scrape education-ni.gov.uk to find the latest suspensions XLSX URL.
+
+    The function follows a two-step chain:
+    1. Fetches the stable articles page and extracts the most recent
+       publications link for pupil suspensions/expulsions.
+    2. Fetches that publication page and extracts the XLSX download link.
+
+    Returns:
+        Absolute URL of the latest suspensions XLSX file.
+
+    Raises:
+        EducationSuspensionsNotFoundError: If the publication or XLSX link
+            cannot be found.
+    """
+    # Step 1 – find the most recent publication page
+    try:
+        resp = session.get(ARTICLES_URL, timeout=30)
+        resp.raise_for_status()
+    except Exception as exc:
+        raise EducationSuspensionsNotFoundError(f"Failed to fetch articles page {ARTICLES_URL}: {exc}") from exc
+
+    soup = bs4.BeautifulSoup(resp.content, "html.parser")
+    pub_href = None
+    for a in soup.find_all("a", href=True):
+        href = a["href"]
+        if "suspension" in href.lower() and "/publications/" in href:
+            pub_href = href
+            break  # first match is the most recent
+
+    if not pub_href:
+        raise EducationSuspensionsNotFoundError(f"Could not find a suspensions publication link on {ARTICLES_URL}")
+
+    pub_url = urljoin(BASE_URL, pub_href)
+    logger.info("Found publication page: %s", pub_url)
+
+    # Step 2 – find the XLSX on that publication page
+    try:
+        resp2 = session.get(pub_url, timeout=30)
+        resp2.raise_for_status()
+    except Exception as exc:
+        raise EducationSuspensionsNotFoundError(f"Failed to fetch publication page {pub_url}: {exc}") from exc
+
+    soup2 = bs4.BeautifulSoup(resp2.content, "html.parser")
+    for a in soup2.find_all("a", href=True):
+        href = a["href"]
+        if href.lower().endswith(".xlsx") or href.lower().endswith(".xls"):
+            xlsx_url = href if href.startswith("http") else urljoin(BASE_URL, href)
+            logger.info("Found XLSX URL: %s", xlsx_url)
+            return xlsx_url
+
+    raise EducationSuspensionsNotFoundError(f"Could not find XLSX link on publication page {pub_url}")
+
+
+# ---------------------------------------------------------------------------
+# Public: Parsing
+# ---------------------------------------------------------------------------
+
+
+def parse_suspensions_file(file_path: str | Path) -> pd.DataFrame:
+    """Parse the DE NI suspensions XLSX file into a tidy DataFrame.
+
+    Reads Table 1 (annual trend) and produces one row per academic year
+    with standardised column names.  Table 1 is the only table with a
+    multi-year time series; the remaining tables are single-year snapshots
+    and are intentionally not included in the tidy output (use
+    :func:`parse_all_tables` for those).
+
+    Args:
+        file_path: Path to the downloaded XLSX file.
+
+    Returns:
+        DataFrame with columns:
+            - ``academic_year``: Academic year string, e.g. ``"2024/25"``
+            - ``pupils_suspended``: Number of pupils suspended (int)
+            - ``pct_pupils_suspended``: Percentage of all pupils suspended (float, 0–1)
+
+    Raises:
+        EducationSuspensionsParseError: If the file cannot be parsed.
+    """
+    try:
+        wb_dict = pd.read_excel(file_path, sheet_name=None, header=None)
+    except Exception as exc:
+        raise EducationSuspensionsParseError(f"Failed to read Excel file {file_path}: {exc}") from exc
+
+    if "Table 1" not in wb_dict:
+        raise EducationSuspensionsParseError("Expected sheet 'Table 1' not found in workbook")
+
+    raw = wb_dict["Table 1"]
+
+    # Locate header row: the row that contains 'Year' in column B (index 1)
+    header_row = None
+    for i, row in raw.iterrows():
+        if str(row.iloc[1]).strip() == "Year":
+            header_row = i
+            break
+
+    if header_row is None:
+        raise EducationSuspensionsParseError("Could not locate header row in Table 1")
+
+    # Slice from header row onwards
+    df = raw.iloc[header_row:].copy()
+    df.columns = df.iloc[0]
+    df = df.iloc[1:].reset_index(drop=True)
+
+    # Keep only columns B (Year) and C (pupils suspended) and D (percentage)
+    # The Excel has a blank leading column A, so after reset our useful columns
+    # are at positions 1, 2, 3 (0-based).
+    df = df.iloc[:, 1:4].copy()
+    df.columns = ["academic_year", "pupils_suspended", "pct_pupils_suspended"]
+
+    # Drop summary/footer rows (non-year values in academic_year column)
+    df = df[df["academic_year"].notna()].copy()
+    df = df[df["academic_year"].astype(str).str.match(r"^\d{4}/\d{2}$")].copy()
+
+    # Coerce types
+    df["academic_year"] = df["academic_year"].astype(str)
+    df["pupils_suspended"] = pd.to_numeric(df["pupils_suspended"], errors="coerce").astype("Int64")
+    df["pct_pupils_suspended"] = pd.to_numeric(df["pct_pupils_suspended"], errors="coerce")
+
+    return df.reset_index(drop=True)
+
+
+def parse_all_tables(file_path: str | Path) -> dict[str, pd.DataFrame]:
+    """Parse all tables from the DE NI suspensions XLSX into a dict of DataFrames.
+
+    Each table is lightly cleaned (blank leading column removed, empty rows/cols
+    dropped) but otherwise returned in its natural structure.
+
+    Args:
+        file_path: Path to the downloaded XLSX file.
+
+    Returns:
+        Dictionary mapping sheet names to DataFrames.
+
+    Raises:
+        EducationSuspensionsParseError: If the file cannot be read.
+    """
+    try:
+        wb_dict = pd.read_excel(file_path, sheet_name=None, header=None)
+    except Exception as exc:
+        raise EducationSuspensionsParseError(f"Failed to read Excel file {file_path}: {exc}") from exc
+
+    result: dict[str, pd.DataFrame] = {}
+    for sheet_name, raw_df in wb_dict.items():
+        if sheet_name == "Table of contents":
+            continue
+        # Locate header row (first row after the title rows, identified by
+        # a non-None value in column B that is a string)
+        header_row = None
+        for i, row in raw_df.iterrows():
+            val = row.iloc[1]
+            if val is not None and isinstance(val, str) and val.strip() and not val.strip().startswith("Table"):
+                header_row = i
+                break
+        if header_row is None:
+            result[sheet_name] = raw_df
+            continue
+
+        df = raw_df.iloc[header_row:].copy()
+        df.columns = df.iloc[0]
+        df = df.iloc[1:].reset_index(drop=True)
+        # Drop blank leading column
+        if df.columns[0] is None:
+            df = df.iloc[:, 1:]
+        # Drop fully None columns and rows, and rows after the first total/source row
+        df = df.dropna(axis=1, how="all").dropna(axis=0, how="all")
+        # Truncate at rows where all data columns are None (footer notes)
+        first_col = df.columns[0]
+        footer_mask = df[first_col].isna() | df[first_col].astype(str).str.startswith("Source")
+        if footer_mask.any():
+            first_footer = footer_mask.idxmax()
+            df = df.loc[: first_footer - 1]
+        result[sheet_name] = df.reset_index(drop=True)
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Public: High-level entry points
+# ---------------------------------------------------------------------------
+
+
+def get_latest_suspensions(force_refresh: bool = False) -> pd.DataFrame:
+    """Download and return the latest NI pupil suspensions time-series data.
+
+    This is the main entry point.  Returns Table 1 (annual trend) parsed
+    into a tidy DataFrame via :func:`parse_suspensions_file`.
+
+    Args:
+        force_refresh: If ``True``, bypass the local cache and re-download.
+
+    Returns:
+        DataFrame with columns ``academic_year``, ``pupils_suspended``,
+        ``pct_pupils_suspended``.
+
+    Raises:
+        EducationSuspensionsNotFoundError: If the source cannot be located.
+        EducationSuspensionsParseError: If the file cannot be parsed.
+
+    Example:
+        >>> df = get_latest_suspensions()
+        >>> 'academic_year' in df.columns
+        True
+    """
+    xlsx_url = get_suspensions_publication_url()
+    file_path = _download_file(xlsx_url, force_refresh=force_refresh)
+    return parse_suspensions_file(file_path)
+
+
+def validate_suspensions_data(df: pd.DataFrame) -> bool:
+    """Validate the structure and basic integrity of a suspensions DataFrame.
+
+    Checks performed:
+    - Required columns present
+    - At least one row of data
+    - ``pupils_suspended`` values are non-negative
+    - ``pct_pupils_suspended`` values are in [0, 1]
+
+    Args:
+        df: DataFrame as returned by :func:`parse_suspensions_file` or
+            :func:`get_latest_suspensions`.
+
+    Returns:
+        ``True`` if the data passes all checks.
+
+    Raises:
+        ValueError: If any check fails, with a descriptive message.
+    """
+    required = {"academic_year", "pupils_suspended", "pct_pupils_suspended"}
+    missing = required - set(df.columns)
+    if missing:
+        raise ValueError(f"Missing required columns: {missing}")
+
+    if len(df) == 0:
+        raise ValueError("DataFrame is empty")
+
+    if (df["pupils_suspended"].dropna() < 0).any():
+        raise ValueError("pupils_suspended contains negative values")
+
+    pct = df["pct_pupils_suspended"].dropna()
+    if (pct < 0).any() or (pct > 1).any():
+        raise ValueError("pct_pupils_suspended values outside [0, 1]")
+
+    return True

--- a/src/bolster/data_sources/nisra/__init__.py
+++ b/src/bolster/data_sources/nisra/__init__.py
@@ -8,6 +8,7 @@ Available modules:
     - ashe: Annual Survey of Hours and Earnings (employee earnings statistics)
     - births: Monthly birth registrations by registration and occurrence date
     - cancer_waiting_times: Cancer treatment waiting times (14-day, 31-day, 62-day targets)
+    - child_protection: Children's Social Care child protection statistics (referrals, CPR, investigations)
     - emergency_care_waiting_times: Emergency care (A&E) waiting times against the 4-hour target
     - composite_index: Northern Ireland Composite Economic Index (experimental quarterly economic indicator)
     - construction_output: Quarterly construction output statistics (all work, new work, repair & maintenance)
@@ -21,8 +22,10 @@ Available modules:
     - planning_statistics: NI Planning Activity Statistics - quarterly applications, by council
     - population_projections: Population projections by age, sex, and geography (2022-2072)
     - registrar_general: Registrar General Quarterly Tables (quarterly births, deaths, marriages, LGD breakdowns)
+    - baby_names: Annual baby name registrations (1997–present) by sex and rank
     - tourism: Tourism statistics including occupancy surveys, visitor stats (subpackage)
     - wellbeing: Individual wellbeing statistics (life satisfaction, happiness, anxiety, loneliness)
+    - work_quality: Work Quality NI — seventeen indicators of job quality for employees
 
 Examples:
     >>> from bolster.data_sources.nisra import ashe
@@ -94,12 +97,19 @@ Examples:
     >>> df = wellbeing.get_latest_personal_wellbeing()
     >>> 'life_satisfaction' in df.columns
     True
+
+    >>> from bolster.data_sources.nisra import child_protection as cp
+    >>> cp_df = cp.get_latest_child_protection()
+    >>> 'measure' in cp_df.columns
+    True
 """
 
 from . import (
     ashe,
+    baby_names,
     births,
     cancer_waiting_times,
+    child_protection,
     composite_index,
     construction_output,
     deaths,
@@ -117,12 +127,15 @@ from . import (
     stillbirths,
     tourism,
     wellbeing,
+    work_quality,
 )
 
 __all__ = [
     "ashe",
+    "baby_names",
     "births",
     "cancer_waiting_times",
+    "child_protection",
     "composite_index",
     "construction_output",
     "deaths",
@@ -140,4 +153,5 @@ __all__ = [
     "stillbirths",
     "tourism",
     "wellbeing",
+    "work_quality",
 ]

--- a/src/bolster/data_sources/nisra/baby_names.py
+++ b/src/bolster/data_sources/nisra/baby_names.py
@@ -1,0 +1,413 @@
+"""NISRA Baby Names Northern Ireland Data Source.
+
+Provides access to baby name statistics for Northern Ireland from the Northern Ireland
+Statistics and Research Agency (NISRA), including:
+- Full historical list of all first forenames given to babies registered in NI (1997–present)
+- Annual rank and count for every name, by sex (Boys/Girls)
+
+The module uses the Full Name List file which contains all registered names with their
+rank and count for each year from 1997 to the most recent publication year.
+
+Data Source:
+    **Statistics Page**: https://www.nisra.gov.uk/statistics/births/baby-names
+
+    The statistics page lists all Baby Names publications in reverse chronological order
+    (newest first). The module automatically scrapes this page to find the latest
+    Baby Names publication, then downloads the Full Names List Excel file from that
+    publication's detail page.
+
+    The full names list files contain complete time series from 1997 to the most recent
+    year, updated annually in April.
+
+Update Frequency: Annual (published April each year)
+Geographic Coverage: Northern Ireland (births registered in NI)
+
+Example:
+    >>> from bolster.data_sources.nisra import baby_names
+    >>> df = baby_names.get_baby_names()
+    >>> sorted(df.columns.tolist())
+    ['count', 'name', 'rank', 'sex', 'year']
+    >>> sorted(df['sex'].unique().tolist())
+    ['Boys', 'Girls']
+    >>> df['year'].min() >= 1997
+    True
+"""
+
+import logging
+import re
+from pathlib import Path
+
+import pandas as pd
+from bs4 import BeautifulSoup
+from openpyxl import load_workbook
+
+from bolster.utils.web import session
+
+from ._base import (
+    NISRADataNotFoundError,
+    NISRAValidationError,
+    download_file,
+    safe_int,
+)
+
+logger = logging.getLogger(__name__)
+
+# Statistics page listing all baby names publications
+BABY_NAMES_STATS_URL = "https://www.nisra.gov.uk/statistics/births/baby-names"
+NISRA_BASE_URL = "https://www.nisra.gov.uk"
+
+# Header row in the Full Name List Tables (1-indexed)
+_FULL_LIST_HEADER_ROW = 6
+# First data row (1-indexed)
+_FULL_LIST_DATA_START_ROW = 7
+# Columns per year block (Name, Number of Babies, Rank)
+_COLS_PER_YEAR = 3
+
+
+def get_baby_names_publication_url() -> str:
+    """Scrape NISRA to find the latest Baby Names Full Name List Excel URL.
+
+    Navigates the publication structure:
+    1. Scrapes the baby names statistics page for the latest publication link
+    2. Follows link to the publication detail page
+    3. Finds the Full Names List Excel file link
+
+    Returns:
+        URL of the latest Full Name List Excel file
+
+    Raises:
+        NISRADataNotFoundError: If publication or file not found
+    """
+    try:
+        response = session.get(BABY_NAMES_STATS_URL, timeout=30)
+        response.raise_for_status()
+    except Exception as e:
+        raise NISRADataNotFoundError(f"Failed to fetch baby names statistics page: {e}") from e
+
+    soup = BeautifulSoup(response.content, "html.parser")
+
+    # Find the most recent "Baby Names YYYY" publication link (first match = latest)
+    pub_link = None
+    pub_year = None
+    for link in soup.find_all("a", href=True):
+        href = link["href"]
+        text = link.get_text(strip=True)
+        # Match links like /publications/baby-names-2025
+        if re.search(r"/publications/baby-names-\d{4}", href):
+            # Extract year from href
+            m = re.search(r"baby-names-(\d{4})", href)
+            year = int(m.group(1)) if m else 0
+            if pub_year is None or year > pub_year:
+                pub_year = year
+                pub_link = href
+                logger.info(f"Found Baby Names publication: {text.strip()!r} ({href})")
+
+    if not pub_link:
+        raise NISRADataNotFoundError("Could not find Baby Names publication link on statistics page")
+
+    # Make absolute URL
+    if pub_link.startswith("/"):
+        pub_link = f"{NISRA_BASE_URL}{pub_link}"
+
+    # Fetch the publication detail page
+    try:
+        pub_response = session.get(pub_link, timeout=30)
+        pub_response.raise_for_status()
+    except Exception as e:
+        raise NISRADataNotFoundError(f"Failed to fetch publication page {pub_link}: {e}") from e
+
+    pub_soup = BeautifulSoup(pub_response.content, "html.parser")
+
+    # Find the "Full Names List" Excel file link
+    # Link text is like "Full Names List, 1997 to 2025 TablesMicrosoft Excel ..."
+    excel_url = None
+    for link in pub_soup.find_all("a", href=True):
+        href = link["href"]
+        text = link.get_text(strip=True)
+        if href.lower().endswith(".xlsx") and "full" in text.lower() and "name" in text.lower():
+            excel_url = href
+            logger.info(f"Found Full Name List file: {text!r} -> {href}")
+            break
+
+    # Fallback: any xlsx link with "Full_Name_List" in the path
+    if not excel_url:
+        for link in pub_soup.find_all("a", href=True):
+            href = link["href"]
+            if href.lower().endswith(".xlsx") and "full_name_list" in href.lower():
+                excel_url = href
+                logger.info(f"Found Full Name List file (fallback): {href}")
+                break
+
+    if not excel_url:
+        raise NISRADataNotFoundError(f"Could not find Full Name List Excel file on publication page: {pub_link}")
+
+    # Make absolute URL
+    if excel_url.startswith("/"):
+        excel_url = f"{NISRA_BASE_URL}{excel_url}"
+
+    return excel_url
+
+
+def parse_baby_names_file(file_path: str | Path) -> pd.DataFrame:
+    """Parse NISRA Full Name List Excel file into long-format DataFrame.
+
+    The Full Name List Excel file contains two sheets:
+    - Table 1: Boys' names (1997 to present), wide format with 3 columns per year
+                (Name, Number of Babies, Rank), 29+ year blocks across the row
+    - Table 2: Girls' names, same structure as Table 1
+
+    Names with suppressed counts (shown as '..') are excluded (names with fewer
+    than 3 occurrences are suppressed for disclosure control).
+
+    Args:
+        file_path: Path to the Full Name List Excel file
+
+    Returns:
+        Long-format DataFrame with columns:
+
+        - year: int — registration year
+        - name: str — first forename (title case as registered)
+        - sex: str — "Boys" or "Girls"
+        - rank: int — rank within that sex and year (1 = most popular)
+        - count: int — number of babies registered with that name
+
+    Raises:
+        NISRAValidationError: If the file structure is unexpected or no data parsed
+    """
+    file_path = Path(file_path)
+    wb = load_workbook(file_path, data_only=True, read_only=True)
+
+    sheet_sex_map = {
+        "Table 1": "Boys",
+        "Table 2": "Girls",
+    }
+
+    all_records: list[dict] = []
+
+    for sheet_name, sex in sheet_sex_map.items():
+        if sheet_name not in wb.sheetnames:
+            raise NISRAValidationError(f"Expected sheet '{sheet_name}' not found. Available: {wb.sheetnames}")
+
+        ws = wb[sheet_name]
+        records = _parse_full_name_list_sheet(ws, sex)
+        all_records.extend(records)
+        logger.info(f"Parsed {len(records)} records from {sheet_name} ({sex})")
+
+    if not all_records:
+        raise NISRAValidationError("No records parsed from file — check file structure")
+
+    df = pd.DataFrame(all_records)
+    df["year"] = df["year"].astype(int)
+    df["rank"] = df["rank"].astype(int)
+    df["count"] = df["count"].astype(int)
+    df = df.sort_values(["year", "sex", "rank"]).reset_index(drop=True)
+
+    logger.info(f"Parsed {len(df)} total records covering {df['year'].min()}–{df['year'].max()}")
+    return df
+
+
+def _parse_full_name_list_sheet(ws, sex: str) -> list[dict]:
+    """Parse a single sex table (Table 1 or Table 2) from the Full Name List workbook.
+
+    The sheet layout is:
+    - Rows 1–5: Cover notes / metadata
+    - Row 6: Headers — "YYYY Name", "Number of Babies", "Rank", repeated for each year
+    - Row 7+: Data — one name per row position, repeated for each year block
+
+    Each year occupies exactly 3 columns. Years run left-to-right in chronological order.
+    Names within each year block are sorted by rank (ascending).
+
+    Args:
+        ws: openpyxl worksheet (read_only)
+        sex: "Boys" or "Girls"
+
+    Returns:
+        List of record dicts with keys: year, name, sex, rank, count
+    """
+    # Read header row to extract years
+    headers = list(ws.iter_rows(min_row=_FULL_LIST_HEADER_ROW, max_row=_FULL_LIST_HEADER_ROW, values_only=True))[0]
+
+    # Build list of (col_index, year) for each year block
+    year_cols: list[tuple[int, int]] = []
+    for col_idx in range(0, len(headers), _COLS_PER_YEAR):
+        cell_val = headers[col_idx]
+        if cell_val is None:
+            break
+        # Header format: "1997 Name", "1998 Name", etc.
+        m = re.match(r"(\d{4})\s+Name", str(cell_val).strip())
+        if m:
+            year = int(m.group(1))
+            year_cols.append((col_idx, year))
+
+    if not year_cols:
+        raise NISRAValidationError(f"Could not parse year columns from header row in sheet for {sex}")
+
+    logger.debug(f"{sex}: Found {len(year_cols)} year columns, {year_cols[0][1]}–{year_cols[-1][1]}")
+
+    records: list[dict] = []
+
+    # Read all data rows at once
+    for row in ws.iter_rows(min_row=_FULL_LIST_DATA_START_ROW, values_only=True):
+        # Skip completely empty rows
+        if all(v is None for v in row):
+            continue
+
+        for col_idx, year in year_cols:
+            # Each year block: [Name, Number of Babies, Rank]
+            if col_idx + 2 >= len(row):
+                continue
+
+            name = row[col_idx]
+            count_val = row[col_idx + 1]
+            rank_val = row[col_idx + 2]
+
+            # Skip suppressed ('..' placeholder) or missing values
+            if name is None or str(name).strip() in ("", "..", "-", "Contents"):
+                continue
+            if count_val is None or str(count_val).strip() in ("", "..", "-"):
+                continue
+            if rank_val is None or str(rank_val).strip() in ("", "..", "-"):
+                continue
+
+            count = safe_int(count_val)
+            rank = safe_int(rank_val)
+
+            if count is None or rank is None:
+                continue
+
+            records.append(
+                {
+                    "year": year,
+                    "name": str(name).strip(),
+                    "sex": sex,
+                    "rank": rank,
+                    "count": count,
+                }
+            )
+
+    return records
+
+
+def get_baby_names(force_refresh: bool = False) -> pd.DataFrame:
+    """Get the full historical Baby Names series for Northern Ireland (1997–present).
+
+    Automatically discovers and downloads the most recent Full Name List publication
+    from the NISRA website, which contains the complete historical series from 1997.
+
+    Args:
+        force_refresh: If True, bypass cache and download fresh data
+
+    Returns:
+        Long-format DataFrame with columns:
+
+        - year: int — registration year (1997–present)
+        - name: str — first forename as registered
+        - sex: str — "Boys" or "Girls"
+        - rank: int — rank within sex and year (1 = most popular)
+        - count: int — number of babies with that name
+
+    Raises:
+        NISRADataNotFoundError: If the latest publication cannot be found
+        NISRAValidationError: If the file structure is unexpected
+
+    Example:
+        >>> df = get_baby_names()
+        >>> sorted(df.columns.tolist())
+        ['count', 'name', 'rank', 'sex', 'year']
+        >>> df['year'].min() >= 1997
+        True
+        >>> sorted(df['sex'].unique().tolist())
+        ['Boys', 'Girls']
+        >>> df[df['year'] == df['year'].max()].nsmallest(1, 'rank')['name'].iloc[0] is not None
+        True
+    """
+    excel_url = get_baby_names_publication_url()
+    logger.info(f"Downloading baby names data from: {excel_url}")
+
+    # Cache for 180 days — published once per year in April
+    file_path = download_file(excel_url, cache_ttl_hours=180 * 24, force_refresh=force_refresh)
+
+    return parse_baby_names_file(file_path)
+
+
+def validate_baby_names(df: pd.DataFrame) -> bool:
+    """Validate a baby names DataFrame for structural and data integrity.
+
+    Checks:
+    - Required columns are present
+    - No null values in any column
+    - Both sexes present ("Boys" and "Girls")
+    - Year range starts at or before 1999 (data should go back to 1997)
+    - Rank starts at 1 for at least one year/sex combination
+    - All counts are positive (> 0)
+    - No negative ranks or counts
+
+    Args:
+        df: DataFrame to validate (from parse_baby_names_file or get_baby_names)
+
+    Returns:
+        True if validation passes
+
+    Raises:
+        NISRAValidationError: If any validation check fails, with descriptive message
+
+    Example:
+        >>> import pandas as pd
+        >>> valid_df = pd.DataFrame({
+        ...     'year': [2020, 2020], 'name': ['Noah', 'Jack'],
+        ...     'sex': ['Boys', 'Boys'], 'rank': [1, 2], 'count': [100, 90]
+        ... })
+        >>> validate_baby_names(valid_df)
+        True
+    """
+    required_columns = {"year", "name", "sex", "rank", "count"}
+
+    # Check empty DataFrame
+    if df is None or df.empty:
+        raise NISRAValidationError("DataFrame is empty")
+
+    # Check required columns
+    missing_cols = required_columns - set(df.columns)
+    if missing_cols:
+        raise NISRAValidationError(f"Missing required columns: {missing_cols}")
+
+    # Check for null values
+    null_counts = df[list(required_columns)].isnull().sum()
+    cols_with_nulls = null_counts[null_counts > 0]
+    if not cols_with_nulls.empty:
+        raise NISRAValidationError(f"Columns with null values: {cols_with_nulls.to_dict()}")
+
+    # Check both sexes present
+    actual_sexes = set(df["sex"].unique())
+    if "Boys" not in actual_sexes:
+        raise NISRAValidationError(f"Missing 'Boys' sex category. Found: {actual_sexes}")
+    if "Girls" not in actual_sexes:
+        raise NISRAValidationError(f"Missing 'Girls' sex category. Found: {actual_sexes}")
+
+    # Check year range
+    min_year = df["year"].min()
+    if min_year > 1999:
+        raise NISRAValidationError(
+            f"Year range starts at {min_year} — expected data back to at least 1999 (ideally 1997)"
+        )
+
+    # Check no non-positive counts (before checking rank range)
+    bad_counts = (df["count"] <= 0).sum()
+    if bad_counts > 0:
+        raise NISRAValidationError(f"{bad_counts} rows have non-positive count values")
+
+    # Check no non-positive ranks (before checking min_rank == 1)
+    bad_ranks = (df["rank"] <= 0).sum()
+    if bad_ranks > 0:
+        raise NISRAValidationError(f"{bad_ranks} rows have non-positive rank values")
+
+    # Check rank starts at 1
+    min_rank = df["rank"].min()
+    if min_rank != 1:
+        raise NISRAValidationError(f"Minimum rank is {min_rank} — expected 1")
+
+    logger.info(
+        f"Validation passed: {len(df):,} records, years {df['year'].min()}–{df['year'].max()}, "
+        f"sexes: {sorted(actual_sexes)}"
+    )
+    return True

--- a/src/bolster/data_sources/nisra/work_quality.py
+++ b/src/bolster/data_sources/nisra/work_quality.py
@@ -1,0 +1,478 @@
+"""NISRA Work Quality in Northern Ireland Module.
+
+This module provides access to Work Quality statistics for Northern Ireland,
+covering seventeen indicators of job quality for employees aged 18 and over.
+
+The publication draws on two main sources:
+- Labour Force Survey (LFS): subjective and contractual indicators
+- Annual Survey of Hours and Earnings (ASHE): earnings-based indicator
+
+Work quality indicators covered:
+    1.  Real Living Wage: proportion earning above the Real Living Wage
+    2.  Zero-hours contracts: proportion not on zero-hours contracts
+    3.  Secure employment: permanent or preferred temporary contracts
+    4.  Job satisfaction: satisfied or very satisfied with job
+    5.  Career progression: opportunities for career progression
+    6.  Decision making: involvement in workplace decisions
+    7.  Meaningful work: performing work perceived as meaningful
+    8.  Flexible work: access to flexible working arrangements
+    9.  Line manager support: positive line manager relationship
+    10. Bullying & harassment: not bullied or harassed at work
+    11. Skills match: has the skills required for current duties
+    12. Workplace accidents: no accident reported at work
+    13. Underemployment: employees who are underemployed
+    14. Overemployment: employees who are overemployed
+    15. Trade union membership: member of a trade union
+    16. Training participation: participated in training (last 13 weeks)
+    17. Overtime working: reported working overtime
+
+Data Source: NISRA Labour Market and Social Welfare statistics.
+    Index page: https://www.nisra.gov.uk/statistics/labour-market-and-social-welfare/work-quality
+
+Update Frequency: Annual (published in spring for the preceding calendar year).
+
+Data Coverage:
+    - Most indicators: 2020 to present (calendar year)
+    - Line manager support, bullying & harassment, skills match: 2022 to present
+      (reported as rolling 12-month periods, e.g., "July 2024 to June 2025")
+
+Breakdowns available per indicator:
+    - Overall (NI)
+    - By sex (Male / Female)
+    - By age group (18-39 / 40 and over)
+    - By deprivation quintile (most deprived / least deprived)
+    - By skill level (low skilled / high skilled)
+
+Examples:
+    >>> from bolster.data_sources.nisra import work_quality
+    >>> df = work_quality.get_latest_work_quality()
+    >>> 'indicator' in df.columns
+    True
+    >>> 'value' in df.columns
+    True
+    >>> url, year = work_quality.get_work_quality_publication_url()
+    >>> url.startswith('https://')
+    True
+    >>> year >= 2025
+    True
+
+Publication Details:
+    - Frequency: Annual
+    - Published by: NISRA
+    - Coverage: Employees aged 18 and over in Northern Ireland
+    - Source surveys: Labour Force Survey (LFS) and ASHE
+"""
+
+import logging
+import re
+from pathlib import Path
+
+import openpyxl
+import pandas as pd
+
+from bolster.utils.web import session
+
+from ._base import NISRADataNotFoundError, NISRAValidationError, download_file
+
+logger = logging.getLogger(__name__)
+
+# Stable index page listing all work quality publications
+WORK_QUALITY_INDEX_URL = "https://www.nisra.gov.uk/statistics/labour-market-and-social-welfare/work-quality"
+NISRA_BASE_URL = "https://www.nisra.gov.uk"
+
+# All 17 indicator sheet names and their canonical indicator names
+_INDICATOR_SHEETS: dict[str, str] = {
+    "Table_1.1": "real_living_wage",
+    "Table_1.2": "no_zero_hours_contract",
+    "Table_1.3": "secure_employment",
+    "Table_1.4": "job_satisfaction",
+    "Table_1.5": "career_progression",
+    "Table_1.6": "decision_making",
+    "Table_1.7": "meaningful_work",
+    "Table_1.8": "flexible_work",
+    "Table_1.9": "line_manager_support",
+    "Table_1.10": "no_bullying_harassment",
+    "Table_1.11": "skills_match",
+    "Table_1.12": "no_workplace_accident",
+    "Table_1.13": "underemployed",
+    "Table_1.14": "overemployed",
+    "Table_1.15": "trade_union_member",
+    "Table_1.16": "recent_training",
+    "Table_1.17": "working_overtime",
+}
+
+# Row-type label for the overall NI figure (sub-table 'a')
+_OVERALL_TABLE_SUFFIX = "a"
+
+
+def get_work_quality_publication_url() -> tuple[str, int]:
+    """Get the URL of the latest Work Quality Excel file and publication year.
+
+    Scrapes the NISRA work quality index page to discover the most recent
+    publication link, then follows to the publication page to find the Excel file.
+
+    Returns:
+        Tuple of (excel_url, year) e.g.
+        ("https://www.nisra.gov.uk/system/files/.../work-quality-2025.xlsx", 2025)
+
+    Raises:
+        NISRADataNotFoundError: If unable to find the publication or Excel file
+
+    Example:
+        >>> url, year = get_work_quality_publication_url()
+        >>> url.startswith('https://')
+        True
+        >>> year >= 2025
+        True
+    """
+    from bs4 import BeautifulSoup
+
+    logger.info("Fetching Work Quality publication URL from index page...")
+
+    try:
+        response = session.get(WORK_QUALITY_INDEX_URL, timeout=30)
+        response.raise_for_status()
+    except Exception as e:
+        raise NISRADataNotFoundError(f"Failed to fetch Work Quality index page: {e}") from e
+
+    soup = BeautifulSoup(response.content, "html.parser")
+
+    # Collect all links whose text matches "Work Quality in Northern Ireland YYYY"
+    publications: list[tuple[int, str]] = []
+    for a_tag in soup.find_all("a", href=True):
+        text = a_tag.get_text(strip=True)
+        href = a_tag["href"]
+        match = re.search(r"Work Quality in Northern Ireland\s+(\d{4})", text, re.IGNORECASE)
+        if match:
+            year = int(match.group(1))
+            pub_url = href if href.startswith("http") else f"{NISRA_BASE_URL}{href}"
+            publications.append((year, pub_url))
+            logger.debug(f"Found publication: {year} → {pub_url}")
+
+    if not publications:
+        raise NISRADataNotFoundError(
+            f"Could not find any Work Quality publication links on the index page. Check: {WORK_QUALITY_INDEX_URL}"
+        )
+
+    # Use the most recent publication
+    publications.sort(key=lambda x: x[0], reverse=True)
+    latest_year, pub_url = publications[0]
+    logger.info(f"Latest Work Quality publication: {latest_year} at {pub_url}")
+
+    # Follow to the publication page and find the Excel file
+    try:
+        pub_response = session.get(pub_url, timeout=30)
+        pub_response.raise_for_status()
+    except Exception as e:
+        raise NISRADataNotFoundError(f"Failed to fetch Work Quality publication page {pub_url}: {e}") from e
+
+    pub_soup = BeautifulSoup(pub_response.content, "html.parser")
+
+    excel_url: str | None = None
+    for a_tag in pub_soup.find_all("a", href=True):
+        href = a_tag["href"]
+        if ".xlsx" in href.lower() and "work-quality" in href.lower():
+            excel_url = href if href.startswith("http") else f"{NISRA_BASE_URL}{href}"
+            break
+
+    if excel_url is None:
+        # Fallback: any .xlsx link on the publication page
+        for a_tag in pub_soup.find_all("a", href=True):
+            href = a_tag["href"]
+            if ".xlsx" in href.lower():
+                excel_url = href if href.startswith("http") else f"{NISRA_BASE_URL}{href}"
+                logger.warning(f"Using fallback Excel link (no 'work-quality' in path): {excel_url}")
+                break
+
+    if excel_url is None:
+        raise NISRADataNotFoundError(f"Could not find Excel file on Work Quality publication page: {pub_url}")
+
+    logger.info(f"Found Work Quality Excel URL: {excel_url}")
+    return excel_url, latest_year
+
+
+def _normalise_year_label(raw: str | int | float) -> str | None:
+    """Normalise a raw year cell value to a compact string label.
+
+    Accepts integer years (2020), float years (2025.0), and period strings
+    ("July 2024 to June 2025").  Returns None for blank / unsupported values.
+
+    Args:
+        raw: The raw cell value from the Excel sheet.
+
+    Returns:
+        Normalised label (e.g. "2025" or "July 2024 to June 2025") or None.
+
+    Example:
+        >>> _normalise_year_label(2025)
+        '2025'
+        >>> _normalise_year_label(2025.0)
+        '2025'
+        >>> _normalise_year_label('July 2024 to June 2025')
+        'July 2024 to June 2025'
+        >>> _normalise_year_label(None) is None
+        True
+    """
+    if raw is None:
+        return None
+    if isinstance(raw, int | float):
+        try:
+            return str(int(raw))
+        except (ValueError, TypeError):
+            return None
+    raw_str = str(raw).strip()
+    if not raw_str or raw_str.lower() in ("none", "nan", "year"):
+        return None
+    return raw_str
+
+
+def _extract_year_int(label: str) -> int:
+    """Extract the latest calendar year from a year label.
+
+    For plain year strings ("2025") returns 2025.
+    For period strings ("July 2024 to June 2025") returns 2025 (end year).
+
+    Args:
+        label: Normalised year label as returned by _normalise_year_label.
+
+    Returns:
+        Integer calendar year.
+
+    Example:
+        >>> _extract_year_int('2025')
+        2025
+        >>> _extract_year_int('July 2024 to June 2025')
+        2025
+    """
+    # Find all 4-digit years
+    years_found = [int(m) for m in re.findall(r"\b(\d{4})\b", label)]
+    if not years_found:
+        raise ValueError(f"No year found in label: {label!r}")
+    return max(years_found)
+
+
+def _parse_indicator_sheet(
+    wb: openpyxl.Workbook,
+    sheet_name: str,
+    indicator: str,
+) -> list[dict]:
+    """Parse the overall NI row (sub-table 'a') from one indicator sheet.
+
+    Each sheet contains multiple sub-tables stacked vertically.  Sub-table 'a'
+    always holds the overall NI proportions; we only extract that for the
+    canonical long-format output.
+
+    Args:
+        wb: Open openpyxl workbook (read_only=True, data_only=True).
+        sheet_name: Name of the worksheet (e.g. "Table_1.1").
+        indicator: Canonical snake_case indicator name.
+
+    Returns:
+        List of dicts with keys: indicator, year_label, year, value, geography.
+    """
+    ws = wb[sheet_name]
+    rows: list[dict] = []
+    in_overall_table = False
+
+    for row_vals in ws.iter_rows(values_only=True):
+        if not any(v is not None for v in row_vals):
+            continue
+
+        cell0 = str(row_vals[0]).strip() if row_vals[0] is not None else ""
+
+        # Detect the start of sub-table 'a' (overall NI)
+        # Pattern: "Table X.Xa: ..."  (letter 'a' suffix)
+        if re.match(r"Table\s+\d+\.\d+a\s*:", cell0, re.IGNORECASE):
+            in_overall_table = True
+            continue
+
+        # Detect start of any OTHER sub-table (b, c, d, e) — stop reading
+        if re.match(r"Table\s+\d+\.\d+[b-zA-Z]\s*:", cell0, re.IGNORECASE):
+            if in_overall_table:
+                break  # done with sub-table 'a'
+            continue
+
+        if not in_overall_table:
+            continue
+
+        # Skip the header row ("Year", "Proportion …")
+        if cell0.lower() == "year":
+            continue
+
+        # Try to parse a data row: col0 = year, col1 = value
+        year_label = _normalise_year_label(row_vals[0])
+        if year_label is None:
+            continue
+
+        raw_val = row_vals[1] if len(row_vals) > 1 else None
+        # Skip suppressed values marked [x]
+        if isinstance(raw_val, str) and "[x]" in raw_val:
+            logger.debug(f"{indicator} {year_label}: suppressed value [x]")
+            continue
+        if raw_val is None:
+            continue
+
+        try:
+            value = float(raw_val)
+        except (ValueError, TypeError):
+            logger.debug(f"{indicator} {year_label}: could not convert {raw_val!r} to float")
+            continue
+
+        try:
+            year_int = _extract_year_int(year_label)
+        except ValueError:
+            logger.debug(f"{indicator}: could not extract year from {year_label!r}")
+            continue
+
+        rows.append(
+            {
+                "indicator": indicator,
+                "year_label": year_label,
+                "year": year_int,
+                "value": value,
+                "geography": "Northern Ireland",
+            }
+        )
+
+    return rows
+
+
+def parse_work_quality_file(file_path: str | Path, year: int) -> pd.DataFrame:
+    """Parse a Work Quality Excel file into a tidy long-format DataFrame.
+
+    Extracts the overall NI proportion for each of the 17 work quality
+    indicators.  One row per (indicator, year_label) combination.
+
+    Args:
+        file_path: Path to the Work Quality Excel (.xlsx) file.
+        year: Publication year (e.g. 2025 for the 2025 publication).
+
+    Returns:
+        DataFrame with columns:
+            - indicator: str  — snake_case indicator name (e.g. "job_satisfaction")
+            - year_label: str — year as printed in the source (e.g. "2025" or
+              "July 2024 to June 2025" for rolling-period indicators)
+            - year: int       — latest calendar year in the period
+            - value: float    — proportion (percentage, 0-100)
+            - geography: str  — always "Northern Ireland" for this dataset
+
+    Raises:
+        NISRADataNotFoundError: If the file cannot be opened or no data is found.
+
+    Example:
+        >>> url, yr = get_work_quality_publication_url()
+        >>> path = download_file(url, cache_ttl_hours=90 * 24)
+        >>> df = parse_work_quality_file(path, yr)
+        >>> sorted(df.columns.tolist())
+        ['geography', 'indicator', 'value', 'year', 'year_label']
+        >>> len(df) > 0
+        True
+    """
+    logger.info(f"Parsing Work Quality file: {file_path} (publication year {year})")
+    file_path = Path(file_path)
+
+    try:
+        wb = openpyxl.load_workbook(file_path, read_only=True, data_only=True)
+    except Exception as e:
+        raise NISRADataNotFoundError(f"Cannot open Work Quality file {file_path}: {e}") from e
+
+    all_rows: list[dict] = []
+    for sheet_name, indicator in _INDICATOR_SHEETS.items():
+        if sheet_name not in wb.sheetnames:
+            logger.warning(f"Sheet {sheet_name!r} not found in workbook — skipping {indicator}")
+            continue
+        rows = _parse_indicator_sheet(wb, sheet_name, indicator)
+        if not rows:
+            logger.warning(f"No data rows extracted from {sheet_name} ({indicator})")
+        all_rows.extend(rows)
+
+    wb.close()
+
+    if not all_rows:
+        raise NISRADataNotFoundError(f"No data extracted from Work Quality file: {file_path}")
+
+    df = pd.DataFrame(all_rows)
+    df = df.sort_values(["indicator", "year", "year_label"]).reset_index(drop=True)
+    logger.info(
+        f"Parsed {len(df)} rows across {df['indicator'].nunique()} indicators "
+        f"(years {df['year'].min()}–{df['year'].max()})"
+    )
+    return df
+
+
+def get_latest_work_quality(force_refresh: bool = False) -> pd.DataFrame:
+    """Download and parse the latest Work Quality publication.
+
+    Automatically discovers the current publication URL by scraping the NISRA
+    index page, downloads the Excel file (caching for 90 days), and returns a
+    tidy long-format DataFrame.
+
+    Args:
+        force_refresh: If True, bypass cache and re-download the file.
+
+    Returns:
+        DataFrame with columns:
+            - indicator: str  (e.g. "job_satisfaction")
+            - year_label: str (e.g. "2025" or "July 2024 to June 2025")
+            - year: int
+            - value: float    (percentage, 0-100)
+            - geography: str  ("Northern Ireland")
+
+    Raises:
+        NISRADataNotFoundError: If the publication or file cannot be found.
+
+    Example:
+        >>> df = get_latest_work_quality()
+        >>> 'indicator' in df.columns
+        True
+        >>> df['year'].max() >= 2025
+        True
+    """
+    excel_url, year = get_work_quality_publication_url()
+    file_path = download_file(excel_url, cache_ttl_hours=90 * 24, force_refresh=force_refresh)
+    return parse_work_quality_file(file_path, year)
+
+
+def validate_work_quality_data(df: pd.DataFrame) -> bool:
+    """Validate a Work Quality DataFrame for expected structure and values.
+
+    Args:
+        df: DataFrame returned by parse_work_quality_file or get_latest_work_quality.
+
+    Returns:
+        True if all checks pass.
+
+    Raises:
+        NISRAValidationError: If any validation check fails.
+
+    Example:
+        >>> df = get_latest_work_quality()
+        >>> validate_work_quality_data(df)
+        True
+    """
+    if df.empty:
+        raise NISRAValidationError("DataFrame is empty")
+
+    required_columns = {"indicator", "year_label", "year", "value", "geography"}
+    missing = required_columns - set(df.columns)
+    if missing:
+        raise NISRAValidationError(f"Missing required columns: {missing}")
+
+    if df["indicator"].nunique() < 10:
+        raise NISRAValidationError(f"Expected at least 10 indicators, found {df['indicator'].nunique()}")
+
+    if df["year"].max() < 2024:
+        raise NISRAValidationError(f"No recent data found — latest year is {df['year'].max()}")
+
+    out_of_range = df[(df["value"] < 0) | (df["value"] > 100)]
+    if not out_of_range.empty:
+        raise NISRAValidationError(f"Values outside valid percentage range [0, 100]:\n{out_of_range}")
+
+    if df["geography"].nunique() != 1 or df["geography"].iloc[0] != "Northern Ireland":
+        raise NISRAValidationError(f"Unexpected geography values: {df['geography'].unique().tolist()}")
+
+    logger.info(
+        f"Work Quality data validation passed: {len(df)} rows, "
+        f"{df['indicator'].nunique()} indicators, years {df['year'].min()}–{df['year'].max()}"
+    )
+    return True

--- a/tests/test_education_suspensions_integrity.py
+++ b/tests/test_education_suspensions_integrity.py
@@ -1,0 +1,170 @@
+"""Data integrity tests for Education NI pupil suspensions module.
+
+All tests use real data fetched from education-ni.gov.uk.
+No mocks – the fixture is scoped to "class" to avoid repeated downloads.
+"""
+
+import pandas as pd
+import pytest
+
+from bolster.data_sources import education_suspensions as edu
+
+pytestmark = pytest.mark.network
+
+
+# ---------------------------------------------------------------------------
+# URL discovery
+# ---------------------------------------------------------------------------
+
+
+class TestPublicationURLDiscovery:
+    """Tests for XLSX URL discovery from education-ni.gov.uk."""
+
+    def test_url_is_string(self):
+        """get_suspensions_publication_url should return a non-empty string."""
+        url = edu.get_suspensions_publication_url()
+        assert isinstance(url, str)
+        assert len(url) > 0
+
+    def test_url_is_xlsx(self):
+        """Discovered URL must point to an XLSX file."""
+        url = edu.get_suspensions_publication_url()
+        assert url.lower().endswith(".xlsx") or url.lower().endswith(".xls")
+
+    def test_url_is_education_ni(self):
+        """Discovered URL should come from education-ni.gov.uk."""
+        url = edu.get_suspensions_publication_url()
+        assert "education-ni.gov.uk" in url
+
+    def test_invalid_base_raises(self):
+        """Passing a bad URL should raise EducationSuspensionsNotFoundError."""
+        # Patch the module-level constant temporarily
+        original = edu.ARTICLES_URL
+        edu.ARTICLES_URL = "https://example.com/nonexistent-page-xyz"
+        try:
+            with pytest.raises(edu.EducationSuspensionsNotFoundError):
+                edu.get_suspensions_publication_url()
+        finally:
+            edu.ARTICLES_URL = original
+
+
+# ---------------------------------------------------------------------------
+# Data integrity
+# ---------------------------------------------------------------------------
+
+
+class TestSuspensionsDataIntegrity:
+    """Tests for structural and statistical integrity of the tidy DataFrame."""
+
+    @pytest.fixture(scope="class")
+    def latest_data(self) -> pd.DataFrame:
+        """Fetch the latest suspensions data once for all tests in this class."""
+        return edu.get_latest_suspensions()
+
+    def test_returns_dataframe(self, latest_data):
+        """get_latest_suspensions should return a pandas DataFrame."""
+        assert isinstance(latest_data, pd.DataFrame)
+
+    def test_required_columns_present(self, latest_data):
+        """All required columns must be present."""
+        for col in ("academic_year", "pupils_suspended", "pct_pupils_suspended"):
+            assert col in latest_data.columns, f"Missing column: {col}"
+
+    def test_not_empty(self, latest_data):
+        """Dataset must contain at least one row."""
+        assert len(latest_data) > 0
+
+    def test_non_negative_counts(self, latest_data):
+        """All pupils_suspended values must be non-negative."""
+        assert (latest_data["pupils_suspended"].dropna() >= 0).all()
+
+    def test_percentage_in_range(self, latest_data):
+        """pct_pupils_suspended must be in [0, 1]."""
+        pct = latest_data["pct_pupils_suspended"].dropna()
+        assert (pct >= 0).all()
+        assert (pct <= 1).all()
+
+    def test_academic_year_format(self, latest_data):
+        """academic_year column should match YYYY/YY pattern."""
+        import re
+
+        pattern = re.compile(r"^\d{4}/\d{2}$")
+        for year in latest_data["academic_year"]:
+            assert pattern.match(str(year)), f"Unexpected academic_year format: {year}"
+
+    def test_recent_year_present(self, latest_data):
+        """Dataset must include at least 2023/24 or later."""
+        years = list(latest_data["academic_year"])
+        recent = [y for y in years if y >= "2023/24"]
+        assert len(recent) > 0, f"No recent year >= 2023/24 found; years = {years}"
+
+    def test_historical_coverage(self, latest_data):
+        """Dataset should start from at least 2011/12 (first year of series)."""
+        years = list(latest_data["academic_year"])
+        assert "2011/12" in years, "Expected 2011/12 as start of series"
+
+    def test_minimum_row_count(self, latest_data):
+        """Should have at least 10 rows (2011/12 through 2021/22 minimum)."""
+        assert len(latest_data) >= 10
+
+    def test_pupils_suspended_magnitude(self, latest_data):
+        """Suspension counts should be in a plausible range (100–15,000)."""
+        counts = latest_data["pupils_suspended"].dropna()
+        assert counts.min() >= 100, f"Min count too low: {counts.min()}"
+        assert counts.max() <= 15_000, f"Max count too high: {counts.max()}"
+
+
+# ---------------------------------------------------------------------------
+# Validation function
+# ---------------------------------------------------------------------------
+
+
+class TestValidation:
+    """Unit tests for validate_suspensions_data — no network calls needed."""
+
+    def test_validate_passes_good_data(self):
+        """validate_suspensions_data should return True for valid data."""
+        df = pd.DataFrame(
+            {
+                "academic_year": ["2023/24", "2024/25"],
+                "pupils_suspended": [4500, 4756],
+                "pct_pupils_suspended": [0.015, 0.016],
+            }
+        )
+        assert edu.validate_suspensions_data(df) is True
+
+    def test_validate_rejects_empty_dataframe(self):
+        """validate_suspensions_data should raise ValueError for empty data."""
+        df = pd.DataFrame(columns=["academic_year", "pupils_suspended", "pct_pupils_suspended"])
+        with pytest.raises(ValueError, match="empty"):
+            edu.validate_suspensions_data(df)
+
+    def test_validate_rejects_missing_column(self):
+        """validate_suspensions_data should raise ValueError when columns are missing."""
+        df = pd.DataFrame({"academic_year": ["2024/25"], "pupils_suspended": [4756]})
+        with pytest.raises(ValueError, match="Missing required columns"):
+            edu.validate_suspensions_data(df)
+
+    def test_validate_rejects_negative_counts(self):
+        """validate_suspensions_data should raise ValueError for negative counts."""
+        df = pd.DataFrame(
+            {
+                "academic_year": ["2024/25"],
+                "pupils_suspended": [-1],
+                "pct_pupils_suspended": [0.01],
+            }
+        )
+        with pytest.raises(ValueError, match="negative"):
+            edu.validate_suspensions_data(df)
+
+    def test_validate_rejects_pct_out_of_range(self):
+        """validate_suspensions_data should raise ValueError when percentage > 1."""
+        df = pd.DataFrame(
+            {
+                "academic_year": ["2024/25"],
+                "pupils_suspended": [4756],
+                "pct_pupils_suspended": [1.5],
+            }
+        )
+        with pytest.raises(ValueError, match="outside"):
+            edu.validate_suspensions_data(df)

--- a/tests/test_nisra_baby_names_integrity.py
+++ b/tests/test_nisra_baby_names_integrity.py
@@ -1,0 +1,228 @@
+"""Data integrity tests for NISRA Baby Names Northern Ireland statistics.
+
+These tests validate that the data is internally consistent and structurally correct.
+They use real data from NISRA (no mocks) and cover the full historical series (1997–present).
+
+Key validations:
+- Required columns present with correct types
+- Both sexes present (Boys and Girls)
+- Year range starts at 1997
+- Rank starts at 1 for each sex/year
+- All counts are positive
+- Top name each year has rank 1
+- validate_baby_names() rejects bad data
+"""
+
+import pandas as pd
+import pytest
+
+from bolster.data_sources.nisra import baby_names
+from bolster.data_sources.nisra._base import NISRAValidationError
+
+
+class TestBabyNamesDataIntegrity:
+    """Test suite for validating internal consistency of NISRA baby names data."""
+
+    @pytest.fixture(scope="class")
+    def baby_names_data(self):
+        """Fetch the full historical baby names data once for the test class."""
+        return baby_names.get_baby_names(force_refresh=False)
+
+    def test_required_columns_present(self, baby_names_data):
+        """Test that all required columns are present."""
+        required = {"year", "name", "sex", "rank", "count"}
+        assert required.issubset(set(baby_names_data.columns)), (
+            f"Missing columns: {required - set(baby_names_data.columns)}"
+        )
+
+    def test_no_null_values(self, baby_names_data):
+        """Test that there are no null values in required columns."""
+        for col in ("year", "name", "sex", "rank", "count"):
+            null_count = baby_names_data[col].isnull().sum()
+            assert null_count == 0, f"Column '{col}' has {null_count} null values"
+
+    def test_both_sexes_present(self, baby_names_data):
+        """Test that both Boys and Girls are present."""
+        sexes = set(baby_names_data["sex"].unique())
+        assert "Boys" in sexes, f"'Boys' not found in sex values: {sexes}"
+        assert "Girls" in sexes, f"'Girls' not found in sex values: {sexes}"
+
+    def test_year_range_starts_at_1997(self, baby_names_data):
+        """Test that data starts at 1997 or earlier."""
+        min_year = baby_names_data["year"].min()
+        assert min_year <= 1997, f"Year range starts at {min_year}, expected 1997 or earlier"
+
+    def test_year_range_current(self, baby_names_data):
+        """Test that data covers recent years (at least up to 2020)."""
+        max_year = baby_names_data["year"].max()
+        assert max_year >= 2020, f"Year range only goes to {max_year}, expected at least 2020"
+
+    def test_rank_starts_at_one(self, baby_names_data):
+        """Test that rank 1 exists for each sex and year combination."""
+        for (year, sex), group in baby_names_data.groupby(["year", "sex"]):
+            min_rank = group["rank"].min()
+            assert min_rank == 1, f"Minimum rank for {sex} {year} is {min_rank}, expected 1"
+
+    def test_counts_positive(self, baby_names_data):
+        """Test that all count values are positive (> 0)."""
+        non_positive = (baby_names_data["count"] <= 0).sum()
+        assert non_positive == 0, f"{non_positive} rows have non-positive count values"
+
+    def test_ranks_positive(self, baby_names_data):
+        """Test that all rank values are positive (> 0)."""
+        non_positive = (baby_names_data["rank"] <= 0).sum()
+        assert non_positive == 0, f"{non_positive} rows have non-positive rank values"
+
+    def test_top_name_has_rank_one(self, baby_names_data):
+        """Test that the name with the highest count in each year/sex has rank 1.
+
+        Within each year and sex, the name with count == max(count) should have rank == 1.
+        Ties at the top are allowed but at least one rank-1 row must exist.
+        """
+        for (year, sex), group in baby_names_data.groupby(["year", "sex"]):
+            rank1_rows = group[group["rank"] == 1]
+            assert len(rank1_rows) >= 1, f"No rank-1 name found for {sex} {year}"
+
+            max_count = group["count"].max()
+            rank1_max_count = rank1_rows["count"].max()
+
+            # Rank-1 entry must have the highest (or joint-highest) count
+            assert rank1_max_count == max_count, (
+                f"{sex} {year}: rank-1 name has count {rank1_max_count} but max count is {max_count}"
+            )
+
+    def test_names_are_strings(self, baby_names_data):
+        """Test that all name values are non-empty strings."""
+        assert baby_names_data["name"].dtype == object, "name column should be string dtype"
+        empty_names = (baby_names_data["name"].str.strip() == "").sum()
+        assert empty_names == 0, f"{empty_names} rows have empty name strings"
+
+    def test_year_dtype_integer(self, baby_names_data):
+        """Test that year column contains integers."""
+        assert pd.api.types.is_integer_dtype(baby_names_data["year"]), (
+            f"year column dtype is {baby_names_data['year'].dtype}, expected integer"
+        )
+
+    def test_rank_dtype_integer(self, baby_names_data):
+        """Test that rank column contains integers."""
+        assert pd.api.types.is_integer_dtype(baby_names_data["rank"]), (
+            f"rank column dtype is {baby_names_data['rank'].dtype}, expected integer"
+        )
+
+    def test_count_dtype_integer(self, baby_names_data):
+        """Test that count column contains integers."""
+        assert pd.api.types.is_integer_dtype(baby_names_data["count"]), (
+            f"count column dtype is {baby_names_data['count'].dtype}, expected integer"
+        )
+
+    def test_historically_popular_names_present(self, baby_names_data):
+        """Test that well-known historically popular NI names appear in early years.
+
+        Matthew was the top boys' name in 1997, 1998, 1999.
+        Chloe was the top girls' name in 1997, 1998, 1999.
+        """
+        boys_1997 = baby_names_data[(baby_names_data["year"] == 1997) & (baby_names_data["sex"] == "Boys")]
+        top_boys_1997 = boys_1997[boys_1997["rank"] == 1]["name"].values
+        assert "Matthew" in top_boys_1997, f"Expected Matthew as top boys name in 1997, got: {top_boys_1997}"
+
+        girls_1997 = baby_names_data[(baby_names_data["year"] == 1997) & (baby_names_data["sex"] == "Girls")]
+        top_girls_1997 = girls_1997[girls_1997["rank"] == 1]["name"].values
+        assert "Chloe" in top_girls_1997, f"Expected Chloe as top girls name in 1997, got: {top_girls_1997}"
+
+    def test_data_volume_reasonable(self, baby_names_data):
+        """Test that the data contains a reasonable number of records.
+
+        With ~29 years and hundreds of names per year per sex, we expect tens of thousands
+        of records total.
+        """
+        assert len(baby_names_data) >= 10_000, f"Only {len(baby_names_data)} records — expected at least 10,000"
+
+    def test_validate_passes(self, baby_names_data):
+        """Test that validate_baby_names() passes on real data."""
+        assert baby_names.validate_baby_names(baby_names_data)
+
+
+class TestBabyNamesValidation:
+    """Unit tests for validate_baby_names() — no network calls needed."""
+
+    def _make_valid_df(self) -> pd.DataFrame:
+        """Create a minimal valid DataFrame for testing."""
+        return pd.DataFrame(
+            {
+                "year": [1997, 1997, 1997, 1997],
+                "name": ["Matthew", "Ryan", "Chloe", "Shannon"],
+                "sex": ["Boys", "Boys", "Girls", "Girls"],
+                "rank": [1, 2, 1, 2],
+                "count": [410, 381, 361, 313],
+            }
+        )
+
+    def test_validate_rejects_empty_dataframe(self):
+        """Test that validate_baby_names() raises on empty DataFrame."""
+        with pytest.raises(NISRAValidationError, match="empty"):
+            baby_names.validate_baby_names(pd.DataFrame())
+
+    def test_validate_rejects_none(self):
+        """Test that validate_baby_names() raises on None."""
+        with pytest.raises(NISRAValidationError, match="empty"):
+            baby_names.validate_baby_names(None)
+
+    def test_validate_rejects_missing_columns(self):
+        """Test that validate_baby_names() raises on missing required columns."""
+        df = self._make_valid_df().drop(columns=["count"])
+        with pytest.raises(NISRAValidationError, match="Missing required columns"):
+            baby_names.validate_baby_names(df)
+
+    def test_validate_rejects_missing_boys(self):
+        """Test that validate_baby_names() raises when Boys sex is absent."""
+        df = self._make_valid_df()
+        df = df[df["sex"] == "Girls"]
+        with pytest.raises(NISRAValidationError, match="Boys"):
+            baby_names.validate_baby_names(df)
+
+    def test_validate_rejects_missing_girls(self):
+        """Test that validate_baby_names() raises when Girls sex is absent."""
+        df = self._make_valid_df()
+        df = df[df["sex"] == "Boys"]
+        with pytest.raises(NISRAValidationError, match="Girls"):
+            baby_names.validate_baby_names(df)
+
+    def test_validate_rejects_negative_counts(self):
+        """Test that validate_baby_names() raises on negative count values."""
+        df = self._make_valid_df()
+        df.loc[0, "count"] = -1
+        with pytest.raises(NISRAValidationError, match="non-positive count"):
+            baby_names.validate_baby_names(df)
+
+    def test_validate_rejects_zero_counts(self):
+        """Test that validate_baby_names() raises on zero count values."""
+        df = self._make_valid_df()
+        df.loc[0, "count"] = 0
+        with pytest.raises(NISRAValidationError, match="non-positive count"):
+            baby_names.validate_baby_names(df)
+
+    def test_validate_rejects_negative_ranks(self):
+        """Test that validate_baby_names() raises on negative rank values."""
+        df = self._make_valid_df()
+        df.loc[0, "rank"] = -1
+        with pytest.raises(NISRAValidationError, match="non-positive rank"):
+            baby_names.validate_baby_names(df)
+
+    def test_validate_rejects_late_start_year(self):
+        """Test that validate_baby_names() raises when year range starts too late."""
+        df = self._make_valid_df()
+        df["year"] = 2010  # No data before 2010
+        with pytest.raises(NISRAValidationError, match="Year range"):
+            baby_names.validate_baby_names(df)
+
+    def test_validate_rejects_rank_not_starting_at_one(self):
+        """Test that validate_baby_names() raises when minimum rank is not 1."""
+        df = self._make_valid_df()
+        df["rank"] = df["rank"] + 1  # Shift all ranks up by 1
+        with pytest.raises(NISRAValidationError, match="rank"):
+            baby_names.validate_baby_names(df)
+
+    def test_validate_accepts_valid_data(self):
+        """Test that validate_baby_names() returns True for valid data."""
+        df = self._make_valid_df()
+        assert baby_names.validate_baby_names(df) is True

--- a/tests/test_nisra_work_quality_integrity.py
+++ b/tests/test_nisra_work_quality_integrity.py
@@ -1,0 +1,223 @@
+"""Data integrity tests for NISRA Work Quality in Northern Ireland statistics.
+
+These tests validate the data returned by the work_quality module against
+real data from NISRA (no mocks). They verify structural, numerical, and
+temporal correctness of the parsed output.
+
+Key validations:
+- All required columns present
+- Multiple indicators present (should be 17)
+- Values within valid percentage range (0-100)
+- Data covers expected years (2020 to present for most indicators)
+- Recent data available (2025 or later)
+- validate_work_quality_data rejects empty and malformed DataFrames
+"""
+
+import pandas as pd
+import pytest
+
+from bolster.data_sources.nisra import work_quality
+
+
+class TestWorkQualityDataIntegrity:
+    """Test suite for validating Work Quality data structure and content."""
+
+    @pytest.fixture(scope="class")
+    def latest_data(self) -> pd.DataFrame:
+        """Fetch latest work quality data once for the test class."""
+        return work_quality.get_latest_work_quality(force_refresh=False)
+
+    def test_required_columns_present(self, latest_data: pd.DataFrame) -> None:
+        """Test that all required columns are present."""
+        required = {"indicator", "year_label", "year", "value", "geography"}
+        assert required.issubset(set(latest_data.columns)), f"Missing columns: {required - set(latest_data.columns)}"
+
+    def test_dataframe_not_empty(self, latest_data: pd.DataFrame) -> None:
+        """Test that the DataFrame contains rows."""
+        assert len(latest_data) > 0, "DataFrame is empty"
+
+    def test_all_17_indicators_present(self, latest_data: pd.DataFrame) -> None:
+        """Test that all 17 work quality indicators are present."""
+        n_indicators = latest_data["indicator"].nunique()
+        assert n_indicators == 17, (
+            f"Expected 17 indicators, got {n_indicators}: {sorted(latest_data['indicator'].unique())}"
+        )
+
+    def test_known_indicators_present(self, latest_data: pd.DataFrame) -> None:
+        """Test that a selection of expected indicator names are present."""
+        expected_indicators = {
+            "real_living_wage",
+            "job_satisfaction",
+            "secure_employment",
+            "no_zero_hours_contract",
+            "trade_union_member",
+            "line_manager_support",
+            "working_overtime",
+        }
+        found = set(latest_data["indicator"].unique())
+        missing = expected_indicators - found
+        assert not missing, f"Expected indicators not found: {missing}"
+
+    def test_values_within_valid_range(self, latest_data: pd.DataFrame) -> None:
+        """Test that all values are valid percentages (0-100)."""
+        bad = latest_data[(latest_data["value"] < 0) | (latest_data["value"] > 100)]
+        assert bad.empty, f"Found {len(bad)} rows with values outside [0, 100]:\n{bad}"
+
+    def test_values_are_numeric(self, latest_data: pd.DataFrame) -> None:
+        """Test that the value column is numeric."""
+        assert pd.api.types.is_numeric_dtype(latest_data["value"]), (
+            f"'value' column is not numeric: dtype={latest_data['value'].dtype}"
+        )
+
+    def test_year_column_is_integer(self, latest_data: pd.DataFrame) -> None:
+        """Test that the year column contains integers."""
+        assert pd.api.types.is_integer_dtype(latest_data["year"]), (
+            f"'year' column is not integer: dtype={latest_data['year'].dtype}"
+        )
+
+    def test_recent_year_present(self, latest_data: pd.DataFrame) -> None:
+        """Test that data for 2025 or later is available."""
+        max_year = latest_data["year"].max()
+        assert max_year >= 2025, f"Expected data for 2025 or later, latest year is {max_year}"
+
+    def test_historical_coverage_from_2020(self, latest_data: pd.DataFrame) -> None:
+        """Test that most indicators have data going back to 2020."""
+        # The majority of indicators have 2020 as their earliest year
+        indicators_with_2020 = latest_data[latest_data["year"] == 2020]["indicator"].nunique()
+        assert indicators_with_2020 >= 10, f"Expected at least 10 indicators with 2020 data, got {indicators_with_2020}"
+
+    def test_geography_is_northern_ireland(self, latest_data: pd.DataFrame) -> None:
+        """Test that geography is always 'Northern Ireland'."""
+        geographies = latest_data["geography"].unique()
+        assert list(geographies) == ["Northern Ireland"], f"Unexpected geographies: {geographies.tolist()}"
+
+    def test_no_null_values(self, latest_data: pd.DataFrame) -> None:
+        """Test that there are no null values in required columns."""
+        for col in ("indicator", "year_label", "year", "value", "geography"):
+            null_count = latest_data[col].isna().sum()
+            assert null_count == 0, f"Column '{col}' has {null_count} null values"
+
+    def test_each_indicator_has_multiple_years(self, latest_data: pd.DataFrame) -> None:
+        """Test that every indicator has at least 2 years of data."""
+        year_counts = latest_data.groupby("indicator")["year"].nunique()
+        single_year = year_counts[year_counts < 2]
+        assert single_year.empty, f"These indicators have fewer than 2 years of data: {single_year.to_dict()}"
+
+    def test_validate_function_passes(self, latest_data: pd.DataFrame) -> None:
+        """Test that validate_work_quality_data returns True on valid data."""
+        assert work_quality.validate_work_quality_data(latest_data) is True
+
+    def test_real_living_wage_value_plausible(self, latest_data: pd.DataFrame) -> None:
+        """Test that Real Living Wage values are plausible (70-95% range)."""
+        rlw = latest_data[latest_data["indicator"] == "real_living_wage"]
+        assert not rlw.empty, "No real_living_wage rows found"
+        assert rlw["value"].between(50, 100).all(), (
+            f"Real Living Wage values out of plausible range:\n{rlw[['year_label', 'value']]}"
+        )
+
+    def test_publication_url_returns_valid_tuple(self) -> None:
+        """Test that get_work_quality_publication_url returns (url, year)."""
+        url, year = work_quality.get_work_quality_publication_url()
+        assert url.startswith("https://"), f"URL does not start with https://: {url!r}"
+        assert url.endswith(".xlsx"), f"URL does not end with .xlsx: {url!r}"
+        assert year >= 2025, f"Expected year >= 2025, got {year}"
+
+
+class TestValidation:
+    """Unit tests for validate_work_quality_data — no network calls required."""
+
+    def _minimal_df(self) -> pd.DataFrame:
+        """Return a minimal valid DataFrame for testing."""
+        return pd.DataFrame(
+            {
+                "indicator": ["job_satisfaction"] * 6
+                + ["real_living_wage"] * 6
+                + ["secure_employment"] * 6
+                + ["no_zero_hours_contract"] * 6
+                + ["trade_union_member"] * 6
+                + ["line_manager_support"] * 6
+                + ["decision_making"] * 6
+                + ["meaningful_work"] * 6
+                + ["flexible_work"] * 6
+                + ["no_bullying_harassment"] * 6,
+                "year_label": list(range(2020, 2026)) * 10,
+                "year": list(range(2020, 2026)) * 10,
+                "value": [75.0] * 60,
+                "geography": ["Northern Ireland"] * 60,
+            }
+        )
+
+    def test_validate_rejects_empty_dataframe(self) -> None:
+        """Test that an empty DataFrame raises NISRAValidationError."""
+        from bolster.data_sources.nisra._base import NISRAValidationError
+
+        with pytest.raises(NISRAValidationError, match="empty"):
+            work_quality.validate_work_quality_data(pd.DataFrame())
+
+    def test_validate_rejects_missing_columns(self) -> None:
+        """Test that a DataFrame missing required columns raises NISRAValidationError."""
+        from bolster.data_sources.nisra._base import NISRAValidationError
+
+        df = pd.DataFrame({"indicator": ["x"], "year": [2025]})
+        with pytest.raises(NISRAValidationError, match="Missing required columns"):
+            work_quality.validate_work_quality_data(df)
+
+    def test_validate_rejects_out_of_range_values(self) -> None:
+        """Test that values outside [0, 100] raise NISRAValidationError."""
+        from bolster.data_sources.nisra._base import NISRAValidationError
+
+        df = self._minimal_df()
+        df.loc[0, "value"] = -5.0
+        with pytest.raises(NISRAValidationError, match="outside valid percentage range"):
+            work_quality.validate_work_quality_data(df)
+
+    def test_validate_rejects_too_few_indicators(self) -> None:
+        """Test that fewer than 10 indicators raises NISRAValidationError."""
+        from bolster.data_sources.nisra._base import NISRAValidationError
+
+        df = pd.DataFrame(
+            {
+                "indicator": ["job_satisfaction"] * 3,
+                "year_label": ["2023", "2024", "2025"],
+                "year": [2023, 2024, 2025],
+                "value": [75.0, 76.0, 77.0],
+                "geography": ["Northern Ireland"] * 3,
+            }
+        )
+        with pytest.raises(NISRAValidationError, match="at least 10 indicators"):
+            work_quality.validate_work_quality_data(df)
+
+    def test_validate_rejects_stale_data(self) -> None:
+        """Test that data with no year >= 2024 raises NISRAValidationError."""
+        from bolster.data_sources.nisra._base import NISRAValidationError
+
+        df = self._minimal_df()
+        df["year"] = 2015  # Force all years to be old
+        df["year_label"] = "2015"
+        with pytest.raises(NISRAValidationError, match="latest year"):
+            work_quality.validate_work_quality_data(df)
+
+    def test_normalise_year_label_integer(self) -> None:
+        """Test _normalise_year_label handles integer input."""
+        assert work_quality._normalise_year_label(2025) == "2025"
+
+    def test_normalise_year_label_float(self) -> None:
+        """Test _normalise_year_label handles float input."""
+        assert work_quality._normalise_year_label(2025.0) == "2025"
+
+    def test_normalise_year_label_string(self) -> None:
+        """Test _normalise_year_label handles period string."""
+        label = "July 2024 to June 2025"
+        assert work_quality._normalise_year_label(label) == label
+
+    def test_normalise_year_label_none(self) -> None:
+        """Test _normalise_year_label returns None for None input."""
+        assert work_quality._normalise_year_label(None) is None
+
+    def test_extract_year_int_plain(self) -> None:
+        """Test _extract_year_int for plain year string."""
+        assert work_quality._extract_year_int("2025") == 2025
+
+    def test_extract_year_int_period(self) -> None:
+        """Test _extract_year_int picks the later year from a period string."""
+        assert work_quality._extract_year_int("July 2024 to June 2025") == 2025


### PR DESCRIPTION
## Summary

- Adds `bolster nisra baby-names` CLI command (--year, --sex, --top, --format, --save) for NISRA Baby Names data (1997–present), closing #1735
- Adds `bolster nisra work-quality` CLI command (--indicator, --year, --format, --save) for 17 work quality indicators, closing #1805
- Adds `bolster education suspensions` CLI command (--year, --summary, --format, --save) for DE NI pupil suspension statistics (2011/12–present), closing #1759
- Exports `nisra.baby_names` and `nisra.work_quality` from the nisra package `__init__.py`
- Adds README coverage table entries for all three new modules

## Test plan

- [ ] `uv run pytest tests/test_nisra_baby_names_integrity.py tests/test_nisra_work_quality_integrity.py tests/test_education_suspensions_integrity.py -q --no-cov` — 72 tests, all pass
- [ ] `uv run pytest tests/ -q --no-cov` — full suite passes (1221 passed, 7 skipped)
- [ ] `uv run pre-commit run --all-files` — clean
- [ ] `bolster nisra baby-names --help` shows expected options
- [ ] `bolster nisra work-quality --help` shows expected options
- [ ] `bolster education suspensions --help` shows expected options

🤖 Generated with [Claude Code](https://claude.com/claude-code)