### PR TITLE
feat(nisra): add claimant_count module — monthly UC+JSA claimant statistics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [0.5.0] - 2026-05-20
+## \[0.5.0\] - 2026-05-20
 
 - refactor(nisra): consolidate economic indicators into dedicated modules (#1819)
 - fix(ci): fix YAML syntax error in auto-release workflow (#1813)
@@ -46,7 +46,6 @@
 - fix(web): add tqdm progress bar to download_extract_zip (#314)
 - fix(drift-detection): bump artifact actions to Node.js 24, fix speciesName trailing punctuation
 - feat: weekly NISRA feed drift detection via TF-IDF (#1732)
-
 
 All notable changes to this project will be documented in this file.
 

--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ The [GOV.UK NISRA statistics RSS feed](https://www.gov.uk/search/research-and-st
 
 | Publication | Module | Status |
 |-------------|--------|--------|
+| Claimant Count (UC + JSA) | `nisra.claimant_count` | ✅ |
 | Labour Market Statistics | `nisra.labour_market` | ✅ |
 | Weekly/Monthly Deaths | `nisra.deaths` | ✅ |
 | Monthly Births/Stillbirths | `nisra.births` | ✅ |

--- a/src/bolster/cli.py
+++ b/src/bolster/cli.py
@@ -1471,6 +1471,8 @@ def nisra_feed(limit: int, title_filter: str, days: int, check_coverage: bool):
         "wellbeing": "wellbeing",
         "cancer waiting": "cancer-waiting-times",
         "planning": "planning-statistics",
+        "claimant count": "claimant-count",
+        "claimant": "claimant-count",
     }
 
     with console.status("Fetching NISRA RSS feed..."):
@@ -5484,6 +5486,117 @@ def nisra_work_quality_cmd(indicator, year, output_format, force_refresh, save):
         console.print("\n[yellow]Troubleshooting:[/yellow]")
         console.print("   - Check your internet connection")
         console.print("   - Try again with --force-refresh to bypass cache")
+        raise click.Abort() from e
+
+
+@nisra.command(name="claimant-count")
+@click.option(
+    "--breakdown",
+    type=click.Choice(["headline", "age", "lgd", "pca", "ttwa"], case_sensitive=False),
+    default="headline",
+    help="Data breakdown to retrieve (default: headline)",
+)
+@click.option(
+    "--format",
+    "output_format",
+    type=click.Choice(["table", "csv", "json"], case_sensitive=False),
+    default="table",
+    help="Output format (default: table)",
+)
+@click.option("--force-refresh", is_flag=True, help="Force re-download even if cached")
+@click.option("--save", help="Save data to file (specify filename)")
+def nisra_claimant_count_cmd(breakdown, output_format, force_refresh, save):
+    r"""NISRA Claimant Count statistics (UC + JSA).
+
+    \b
+    Monthly experimental statistics measuring the number of people claiming
+    Universal Credit (UC) or Jobseeker's Allowance (JSA) principally for
+    the reason of being unemployed. Data covers Northern Ireland with
+    multiple geographic and demographic breakdowns.
+
+    Breakdowns available:
+        headline    NI total by sex, seasonally adjusted + non-SA (from 1997)
+        age         NI total by age band: 16-24, 25-49, 50+ (from 2013)
+        lgd         11 Local Government Districts (current month snapshot)
+        pca         18 Parliamentary Constituency Areas (current month snapshot)
+        ttwa        10 Travel-to-Work Areas (current month snapshot)
+
+    Examples:
+        Show latest headline claimant count in a table::
+
+            bolster nisra claimant-count
+
+        Show age breakdown as CSV::
+
+            bolster nisra claimant-count --breakdown age --format csv
+
+        Save LGD data to file::
+
+            bolster nisra claimant-count --breakdown lgd --save lgd.csv
+
+        Export PCA data as JSON::
+
+            bolster nisra claimant-count --breakdown pca --format json --save pca.json
+
+    Source:
+        https://www.nisra.gov.uk/statistics/labour-market-and-social-welfare/claimant-count
+    """
+    from rich.table import Table
+
+    from bolster.data_sources.nisra import claimant_count as cc_module
+
+    console = Console()
+
+    try:
+        with console.status(f"[bold green]Downloading NISRA claimant count ({breakdown})..."):
+            data = cc_module.get_latest_claimant_count(breakdown=breakdown, force_refresh=force_refresh)
+
+        console.print(f"[green]Claimant count ({breakdown}) retrieved successfully[/green]")
+        console.print(f"[cyan]Rows: {len(data)}[/cyan]")
+
+        if not data.empty and "date" in data.columns:
+            min_date = data["date"].min()
+            max_date = data["date"].max()
+            if pd.notna(min_date) and pd.notna(max_date):
+                console.print(f"[dim]Date range: {min_date.strftime('%b %Y')} – {max_date.strftime('%b %Y')}[/dim]")
+
+        if save:
+            try:
+                if output_format == "json" or save.endswith(".json"):
+                    data.to_json(save, orient="records", date_format="iso", indent=2)
+                else:
+                    data.to_csv(save, index=False)
+                console.print(f"[green]Saved to: {save}[/green]")
+                return
+            except PermissionError:
+                console.print(f"[red]Error: Permission denied writing to {save}[/red]")
+                return
+            except Exception as e:
+                console.print(f"[red]Error saving file: {e}[/red]")
+                return
+
+        if output_format == "table":
+            table = Table(title=f"Claimant Count — {breakdown}", show_header=True, header_style="bold cyan")
+            for col in data.columns:
+                table.add_column(str(col))
+            for _, row in data.head(50).iterrows():
+                table.add_row(*[str(v) for v in row.values])
+            console.print(table)
+            if len(data) > 50:
+                console.print(f"\n[yellow]Showing first 50 of {len(data)} rows[/yellow]")
+
+        elif output_format == "csv":
+            click.echo(data.to_csv(index=False))
+
+        elif output_format == "json":
+            click.echo(data.to_json(orient="records", date_format="iso", indent=2))
+
+    except Exception as e:
+        console.print(f"[bold red]Error:[/bold red] {str(e)}", style="red")
+        console.print("\n[yellow]Troubleshooting:[/yellow]")
+        console.print("   - Check your internet connection")
+        console.print("   - Try again with --force-refresh to bypass cache")
+        console.print("   - Visit NISRA website to verify data availability")
         raise click.Abort() from e
 
 

--- a/src/bolster/data_sources/nisra/__init__.py
+++ b/src/bolster/data_sources/nisra/__init__.py
@@ -7,6 +7,7 @@ and tourism statistics.
 Available modules:
     - ashe: Annual Survey of Hours and Earnings (employee earnings statistics)
     - births: Monthly birth registrations by registration and occurrence date
+    - claimant_count: Monthly Claimant Count (UC + JSA) by sex, age, and geography
     - cancer_waiting_times: Cancer treatment waiting times (14-day, 31-day, 62-day targets)
     - child_protection: Children's Social Care child protection statistics
     - emergency_care_waiting_times: Emergency care (A&E) waiting times against the 4-hour target
@@ -28,6 +29,11 @@ Available modules:
     - work_quality: Work Quality NI — seventeen indicators of job quality for employees
 
 Examples:
+    >>> from bolster.data_sources.nisra import claimant_count
+    >>> cc_df = claimant_count.get_latest_claimant_count("headline")
+    >>> "claimants_000s" in cc_df.columns
+    True
+
     >>> from bolster.data_sources.nisra import ashe
     >>> earnings_df = ashe.get_latest_ashe_timeseries('weekly')
     >>> 'median_weekly_earnings' in earnings_df.columns
@@ -106,6 +112,7 @@ from . import (
     births,
     cancer_waiting_times,
     child_protection,
+    claimant_count,
     composite_index,
     construction_output,
     deaths,
@@ -132,6 +139,7 @@ __all__ = [
     "births",
     "cancer_waiting_times",
     "child_protection",
+    "claimant_count",
     "composite_index",
     "construction_output",
     "deaths",

--- a/src/bolster/data_sources/nisra/claimant_count.py
+++ b/src/bolster/data_sources/nisra/claimant_count.py
@@ -1,0 +1,653 @@
+"""NISRA Claimant Count Statistics Module.
+
+This module provides access to the Northern Ireland Statistics and Research Agency (NISRA)
+monthly Claimant Count statistics, covering Universal Credit (UC) and Jobseeker's Allowance
+(JSA) claimants.
+
+The Claimant Count is an experimental statistic measuring the number of people claiming
+benefits principally for the reason of being unemployed. Data is published monthly and
+covers Northern Ireland with multiple geographic breakdowns including Local Government
+Districts, Parliamentary Constituency Areas, Travel-to-Work Areas, and Super Output Areas.
+
+Data Source:
+    **Publication page pattern**:
+    https://www.nisra.gov.uk/publications/labour-market-report-{month_name}-{year}
+
+    The module scrapes the monthly Labour Market Report publication page to find the
+    ``lmr-claimant-count-tables-*.xlsx`` Excel file link, falling back to direct URL
+    construction if scraping fails.
+
+Update Frequency: Monthly, approximately 2–3 weeks after the reference month.
+
+Sheets parsed:
+    - ``Headline``: NI total by sex, seasonally adjusted and non-seasonally adjusted,
+      full time series from April 1997.
+    - ``Age``: NI total by age band (16–24, 25–49, 50+), from January 2013.
+    - ``LGD_11``: Current-month snapshot for 11 Local Government Districts.
+    - ``PCA``: Current-month snapshot for 18 Westminster Parliamentary Constituency Areas.
+    - ``TTWA``: Current-month snapshot for 10 Travel-to-Work Areas.
+    - ``SOA``: 889 Super Output Areas, wide-format time series from October 2017,
+      melted to long format.
+
+Notes:
+    Claimant Count is an experimental statistic. The rate denominator is
+    claimant count + workforce jobs. Five-week months are annotated ``[2]``,
+    revised data with ``(r)``, provisional with ``(p)``. Annotation markers
+    are stripped before date parsing.
+
+    SOA data has a methodology break at January 2026 (transition from COA2011
+    to DZ2021 geographies).
+
+Usage:
+    >>> from bolster.data_sources.nisra import claimant_count
+    >>> df = claimant_count.get_latest_claimant_count("headline")
+    >>> "claimants_000s" in df.columns
+    True
+
+    >>> lgd_df = claimant_count.get_latest_claimant_count("lgd")
+    >>> "claimants_total" in lgd_df.columns
+    True
+
+Example:
+    >>> from bolster.data_sources.nisra import claimant_count
+    >>> df = claimant_count.get_latest_claimant_count("headline")
+    >>> df[df["sex"] == "all_people"].sort_values("date").tail(1)["claimants_000s"].values[0] > 0
+    True
+
+Author: Claude Code
+"""
+
+import logging
+import re
+from datetime import datetime
+from pathlib import Path
+
+import pandas as pd
+
+from bolster.data_sources.nisra._base import (
+    NISRADataNotFoundError,
+    download_file,
+    scrape_download_links,
+)
+
+logger = logging.getLogger(__name__)
+
+# Base URL for NISRA publications
+_NISRA_BASE = "https://www.nisra.gov.uk"
+
+# Cache TTL: 30 days (monthly release)
+_CACHE_TTL_HOURS = 30 * 24
+
+# Column name mapping for geography sheets
+_GEO_COLMAP = {
+    "LGD_11": "Local Government District",
+    "PCA": "Parliamentary Constituency Area",
+    "TTWA": "Travel-to-Work Area",
+}
+
+# Header row offset (0-indexed) for each geography sheet
+_GEO_SKIPROWS = {
+    "LGD_11": 6,
+    "PCA": 5,
+    "TTWA": 5,
+}
+
+# Annotation pattern: strips [2], (r), (p), [notes 1, 2, ...] etc.
+_ANNOTATION_RE = re.compile(r"\s*[\[\(][^\]\)]+[\]\)]")
+
+
+def _strip_annotations(raw: str) -> str:
+    """Strip annotation markers like [2], (r), (p) from a date string.
+
+    Args:
+        raw: Raw date string potentially containing annotation markers.
+
+    Returns:
+        Cleaned date string.
+
+    Example:
+        >>> _strip_annotations("1997 Jun [2]")
+        '1997 Jun'
+        >>> _strip_annotations("2026 Mar (p)")
+        '2026 Mar'
+    """
+    return _ANNOTATION_RE.sub("", str(raw)).strip()
+
+
+def get_latest_publication_url() -> str:
+    """Discover the URL of the most recent claimant count Excel file.
+
+    Scrapes the NISRA Labour Market Report publication page for the current
+    month, falling back to previous months if needed, then falls back to
+    direct URL construction.
+
+    Returns:
+        Full URL to the latest claimant count Excel file.
+
+    Raises:
+        NISRADataNotFoundError: If no publication can be found.
+
+    Example:
+        >>> url = get_latest_publication_url()
+        >>> url.endswith(".xlsx")
+        True
+    """
+    now = datetime.now()
+
+    # Try recent months (current + 3 previous)
+    for delta in range(4):
+        # Calculate target month
+        year = now.year
+        month = now.month - delta
+        while month <= 0:
+            month += 12
+            year -= 1
+
+        month_name = datetime(year, month, 1).strftime("%B").lower()
+        page_url = f"{_NISRA_BASE}/publications/labour-market-report-{month_name}-{year}"
+
+        logger.debug("Checking publication page: %s", page_url)
+
+        try:
+            links = scrape_download_links(page_url, file_extension=".xlsx")
+            for link in links:
+                if "lmr-claimant-count" in link["url"].lower():
+                    logger.info("Found claimant count file: %s", link["url"])
+                    return link["url"]
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("Could not fetch %s: %s", page_url, exc)
+
+    # Fallback: construct URL directly for last known-good month
+    year = now.year
+    month = now.month - 1
+    if month <= 0:
+        month = 12
+        year -= 1
+    month_name = datetime(year, month, 1).strftime("%B").lower()
+    pub_month_str = f"{year}-{month:02d}"
+    fallback_url = (
+        f"{_NISRA_BASE}/system/files/statistics/{pub_month_str}/lmr-claimant-count-tables-{month_name}-{year}.xlsx"
+    )
+    logger.warning("Using fallback URL: %s", fallback_url)
+    return fallback_url
+
+
+def parse_headline(file_path: str | Path) -> pd.DataFrame:
+    """Parse the Headline sheet: NI total claimant count by sex.
+
+    The Headline sheet contains two side-by-side tables:
+    - Table 1a: Seasonally adjusted claimant count by sex
+    - Table 1b: Non-seasonally adjusted claimant count by sex
+
+    Both tables share the same date column structure with men, women and
+    all people counts (thousands) and rates.
+
+    Args:
+        file_path: Path to the claimant count Excel file.
+
+    Returns:
+        DataFrame with columns:
+            - ``date``: pandas Timestamp (monthly, day=1)
+            - ``adjusted``: ``"seasonally_adjusted"`` or ``"non_seasonally_adjusted"``
+            - ``sex``: ``"men"``, ``"women"``, or ``"all_people"``
+            - ``claimants_000s``: Claimant count in thousands (float)
+            - ``claimant_rate``: Claimant rate as percentage (float)
+
+    Raises:
+        NISRADataNotFoundError: If the Headline sheet is not found.
+
+    Example:
+        >>> df = parse_headline("/tmp/claimant_count.xlsx")
+        >>> sorted(df["sex"].unique())
+        ['all_people', 'men', 'women']
+        >>> sorted(df["adjusted"].unique())
+        ['non_seasonally_adjusted', 'seasonally_adjusted']
+    """
+    try:
+        raw = pd.read_excel(file_path, sheet_name="Headline", header=None, engine="openpyxl")
+    except Exception as exc:
+        raise NISRADataNotFoundError(f"Cannot read Headline sheet from {file_path}: {exc}") from exc
+
+    # Row 6 (0-indexed) contains column headers; data starts at row 7.
+    # Columns 0–6: seasonally adjusted (col 7 is blank separator)
+    # Columns 8–14: non-seasonally adjusted
+    #
+    # SA columns: Date(0), men_count(1), men_rate(2), women_count(3),
+    #             women_rate(4), all_count(5), all_rate(6)
+    # Non-SA:     Date(8), men_count(9), men_rate(10), women_count(11),
+    #             women_rate(12), all_count(13), all_rate(14)
+
+    records = []
+
+    for _, row in raw.iloc[7:].iterrows():
+        date_raw = row.iloc[0]
+
+        # Stop at non-date rows (change rows, footnotes, NaN)
+        if pd.isna(date_raw):
+            continue
+        date_str = _strip_annotations(str(date_raw))
+        if not re.match(r"^\d{4}\s+\w{3}$", date_str):
+            continue
+
+        try:
+            date = pd.to_datetime(date_str, format="%Y %b")
+        except ValueError:
+            logger.debug("Skipping unparseable date: %r", date_raw)
+            continue
+
+        # Seasonally adjusted
+        for sex, count_col, rate_col in [("men", 1, 2), ("women", 3, 4), ("all_people", 5, 6)]:
+            count_val = row.iloc[count_col] if len(row) > count_col else None
+            rate_val = row.iloc[rate_col] if len(row) > rate_col else None
+            if pd.notna(count_val):
+                records.append(
+                    {
+                        "date": date,
+                        "adjusted": "seasonally_adjusted",
+                        "sex": sex,
+                        "claimants_000s": float(count_val),
+                        "claimant_rate": float(rate_val) if pd.notna(rate_val) else None,
+                    }
+                )
+
+        # Non-seasonally adjusted (same date column at index 8)
+        for sex, count_col, rate_col in [("men", 9, 10), ("women", 11, 12), ("all_people", 13, 14)]:
+            if len(row) <= count_col:
+                continue
+            count_val = row.iloc[count_col]
+            rate_val = row.iloc[rate_col] if len(row) > rate_col else None
+            if pd.notna(count_val):
+                records.append(
+                    {
+                        "date": date,
+                        "adjusted": "non_seasonally_adjusted",
+                        "sex": sex,
+                        "claimants_000s": float(count_val),
+                        "claimant_rate": float(rate_val) if pd.notna(rate_val) else None,
+                    }
+                )
+
+    df = pd.DataFrame(records)
+    if not df.empty:
+        df = df.sort_values(["adjusted", "sex", "date"]).reset_index(drop=True)
+    return df
+
+
+def parse_age(file_path: str | Path) -> pd.DataFrame:
+    """Parse the Age sheet: NI claimant count by age band.
+
+    Contains a single table of non-seasonally adjusted claimant counts
+    broken down into three age bands: 16–24, 25–49, 50+. Data runs from
+    January 2013.
+
+    Args:
+        file_path: Path to the claimant count Excel file.
+
+    Returns:
+        DataFrame with columns:
+            - ``date``: pandas Timestamp (monthly, day=1)
+            - ``age_group``: One of ``"16-24"``, ``"25-49"``, ``"50+"``.
+            - ``claimants``: Claimant count (integer, rounded to nearest 5).
+
+    Raises:
+        NISRADataNotFoundError: If the Age sheet is not found.
+
+    Example:
+        >>> df = parse_age("/tmp/claimant_count.xlsx")
+        >>> sorted(df["age_group"].unique())
+        ['16-24', '25-49', '50+']
+    """
+    try:
+        raw = pd.read_excel(file_path, sheet_name="Age", skiprows=2, engine="openpyxl")
+    except Exception as exc:
+        raise NISRADataNotFoundError(f"Cannot read Age sheet from {file_path}: {exc}") from exc
+
+    # Columns: Date, 16-24 Total, 25-49 Total, 50+ Total
+    raw.columns = ["date_raw", "16-24", "25-49", "50+"]
+
+    records = []
+    for _, row in raw.iterrows():
+        date_raw = row["date_raw"]
+        if pd.isna(date_raw):
+            continue
+        date_str = _strip_annotations(str(date_raw))
+        try:
+            date = pd.to_datetime(date_str, format="%B %Y")
+        except ValueError:
+            logger.debug("Skipping unparseable age-sheet date: %r", date_raw)
+            continue
+
+        for age_group in ["16-24", "25-49", "50+"]:
+            val = row[age_group]
+            if pd.notna(val):
+                records.append({"date": date, "age_group": age_group, "claimants": int(val)})
+
+    df = pd.DataFrame(records)
+    if not df.empty:
+        df = df.sort_values(["age_group", "date"]).reset_index(drop=True)
+    return df
+
+
+def _infer_reference_date(file_path: str | Path) -> pd.Timestamp:
+    """Infer the reference date from the latest data row in the Headline sheet.
+
+    The geographic snapshot sheets (LGD_11, PCA, TTWA) contain no date column;
+    their reference period is the most recent month in the Headline time series.
+
+    Args:
+        file_path: Path to the claimant count Excel file.
+
+    Returns:
+        pandas Timestamp for the most recent month, or ``pd.NaT`` if not found.
+    """
+    try:
+        raw = pd.read_excel(file_path, sheet_name="Headline", header=None, engine="openpyxl", usecols=[0])
+        latest = pd.NaT
+        for _, row in raw.iloc[7:].iterrows():
+            date_raw = row.iloc[0]
+            if pd.isna(date_raw):
+                continue
+            date_str = _strip_annotations(str(date_raw))
+            if re.match(r"^\d{4}\s+\w{3}$", date_str):
+                try:
+                    candidate = pd.to_datetime(date_str, format="%Y %b")
+                    if pd.isna(latest) or candidate > latest:
+                        latest = candidate
+                except ValueError:
+                    pass
+        return latest
+    except Exception:  # noqa: BLE001
+        return pd.NaT
+
+
+def parse_geography(file_path: str | Path, sheet: str) -> pd.DataFrame:
+    """Parse a geographic breakdown sheet (LGD_11, PCA, or TTWA).
+
+    Each sheet contains a current-month snapshot with columns for:
+    male/female/total claimant numbers, working-age rates, month and year
+    changes.
+
+    Args:
+        file_path: Path to the claimant count Excel file.
+        sheet: Sheet name — one of ``"LGD_11"``, ``"PCA"``, or ``"TTWA"``.
+
+    Returns:
+        DataFrame with columns:
+            - ``date``: pandas Timestamp (extracted from the Excel filename)
+            - ``geography``: Area name (e.g., ``"Belfast"``)
+            - ``geography_type``: Sheet type identifier (e.g., ``"LGD_11"``)
+            - ``claimants_male``: Number of male claimants (int)
+            - ``claimants_female``: Number of female claimants (int)
+            - ``claimants_total``: Total claimants (int)
+            - ``claimant_rate_male_pct``: Male working-age claimant rate (float)
+            - ``claimant_rate_female_pct``: Female working-age claimant rate (float)
+            - ``claimant_rate_total_pct``: Total working-age claimant rate (float)
+            - ``change_over_month_number``: Change vs previous month (int)
+            - ``change_over_year_number``: Change vs same month last year (int)
+
+    Raises:
+        NISRADataNotFoundError: If the requested sheet is not found.
+        ValueError: If sheet is not one of the supported values.
+
+    Example:
+        >>> df = parse_geography("/tmp/claimant_count.xlsx", "LGD_11")
+        >>> len(df["geography"].unique()) >= 11
+        True
+        >>> "claimants_total" in df.columns
+        True
+    """
+    if sheet not in _GEO_SKIPROWS:
+        raise ValueError(f"sheet must be one of {list(_GEO_SKIPROWS)}, got {sheet!r}")
+
+    skiprows = _GEO_SKIPROWS[sheet]
+
+    try:
+        raw = pd.read_excel(file_path, sheet_name=sheet, skiprows=skiprows, engine="openpyxl")
+    except Exception as exc:
+        raise NISRADataNotFoundError(f"Cannot read {sheet} sheet from {file_path}: {exc}") from exc
+
+    # Drop rows where the geography column is NaN or purely numeric (totals/notes)
+    raw = raw.dropna(subset=[raw.columns[0]])
+    raw = raw[raw.iloc[:, 0].astype(str).str.strip() != ""]
+
+    # Rename columns to standard names
+    # Columns: geo_name, male_count, female_count, total_count,
+    #          male_rate, female_rate, total_rate,
+    #          change_month_n, change_month_pct, change_year_n, change_year_pct
+    # LGD_11 also has Job Density Indicator (col 11)
+    col_rename = {
+        raw.columns[0]: "geography",
+        raw.columns[1]: "claimants_male",
+        raw.columns[2]: "claimants_female",
+        raw.columns[3]: "claimants_total",
+        raw.columns[4]: "claimant_rate_male_pct",
+        raw.columns[5]: "claimant_rate_female_pct",
+        raw.columns[6]: "claimant_rate_total_pct",
+        raw.columns[7]: "change_over_month_number",
+        raw.columns[8]: "change_over_month_pct",
+        raw.columns[9]: "change_over_year_number",
+    }
+    if len(raw.columns) > 10:
+        col_rename[raw.columns[10]] = "change_over_year_pct"
+
+    raw = raw.rename(columns=col_rename)
+
+    # Keep only the columns we want (drop extra like Job Density)
+    keep_cols = [
+        "geography",
+        "claimants_male",
+        "claimants_female",
+        "claimants_total",
+        "claimant_rate_male_pct",
+        "claimant_rate_female_pct",
+        "claimant_rate_total_pct",
+        "change_over_month_number",
+        "change_over_year_number",
+    ]
+    df = raw[[c for c in keep_cols if c in raw.columns]].copy()
+
+    # Infer reference date from the Headline time series (most recent date)
+    date = _infer_reference_date(file_path)
+
+    df.insert(0, "date", date)
+    df.insert(2, "geography_type", sheet)
+
+    # Coerce numeric columns
+    for col in [
+        "claimants_male",
+        "claimants_female",
+        "claimants_total",
+        "change_over_month_number",
+        "change_over_year_number",
+    ]:
+        if col in df.columns:
+            df[col] = pd.to_numeric(df[col], errors="coerce")
+
+    for col in ["claimant_rate_male_pct", "claimant_rate_female_pct", "claimant_rate_total_pct"]:
+        if col in df.columns:
+            df[col] = pd.to_numeric(df[col], errors="coerce")
+
+    return df.reset_index(drop=True)
+
+
+def parse_soa(file_path: str | Path) -> pd.DataFrame:
+    """Parse the SOA sheet: Super Output Area time series.
+
+    The SOA sheet is wide-format with 889 Super Output Areas as rows and
+    monthly dates as columns from October 2017. This function melts it to
+    long format.
+
+    Note:
+        There is a methodology break at January 2026 where geography codes
+        transition from COA2011 to DZ2021. Both series are included in the
+        output.
+
+    Args:
+        file_path: Path to the claimant count Excel file.
+
+    Returns:
+        DataFrame with columns:
+            - ``soa_code``: Super Output Area code and name (e.g., ``"95AA01S1 : Aldergrove_1"``)
+            - ``date``: pandas Timestamp (monthly, day=1)
+            - ``claimants``: Claimant count (int, rounded to nearest 5)
+
+    Raises:
+        NISRADataNotFoundError: If the SOA sheet is not found.
+
+    Example:
+        >>> df = parse_soa("/tmp/claimant_count.xlsx")
+        >>> "soa_code" in df.columns
+        True
+        >>> df["date"].min().year <= 2018
+        True
+    """
+    try:
+        raw = pd.read_excel(file_path, sheet_name="SOA", skiprows=5, engine="openpyxl")
+    except Exception as exc:
+        raise NISRADataNotFoundError(f"Cannot read SOA sheet from {file_path}: {exc}") from exc
+
+    # First column is the SOA identifier; remaining columns are month dates
+    soa_col = raw.columns[0]
+    date_cols = [c for c in raw.columns[1:] if pd.notna(c)]
+
+    # Drop any trailing NaN rows
+    raw = raw.dropna(subset=[soa_col])
+
+    # Melt wide to long
+    df_long = raw[[soa_col] + date_cols].melt(id_vars=[soa_col], var_name="date_raw", value_name="claimants")
+    df_long = df_long.rename(columns={soa_col: "soa_code"})
+
+    # Parse dates (column names are already in "Month YYYY" format)
+    df_long["date"] = pd.to_datetime(df_long["date_raw"], format="%B %Y", errors="coerce")
+    df_long = df_long.dropna(subset=["date"])
+
+    # Coerce claimants to numeric
+    df_long["claimants"] = pd.to_numeric(df_long["claimants"], errors="coerce")
+
+    df_long = df_long[["soa_code", "date", "claimants"]].sort_values(["soa_code", "date"])
+    return df_long.reset_index(drop=True)
+
+
+def get_latest_claimant_count(
+    breakdown: str = "headline",
+    force_refresh: bool = False,
+) -> pd.DataFrame:
+    """Download and parse the latest NISRA claimant count data.
+
+    Automatically discovers and downloads the most recent monthly publication,
+    then returns the requested breakdown.
+
+    Args:
+        breakdown: One of:
+            - ``"headline"`` — NI total by sex, SA and non-SA (default)
+            - ``"age"`` — NI total by age band (16–24, 25–49, 50+)
+            - ``"lgd"`` — 11 Local Government Districts (current month)
+            - ``"pca"`` — 18 Parliamentary Constituency Areas (current month)
+            - ``"ttwa"`` — 10 Travel-to-Work Areas (current month)
+            - ``"soa"`` — 889 Super Output Areas, long-format time series
+        force_refresh: If ``True``, bypass cache and download fresh data.
+
+    Returns:
+        DataFrame for the requested breakdown. See individual ``parse_*``
+        functions for column documentation.
+
+    Raises:
+        ValueError: If ``breakdown`` is not a supported value.
+        NISRADataNotFoundError: If the data cannot be downloaded.
+
+    Example:
+        >>> df = get_latest_claimant_count("headline")
+        >>> "claimants_000s" in df.columns
+        True
+        >>> df_lgd = get_latest_claimant_count("lgd")
+        >>> len(df_lgd) >= 11
+        True
+    """
+    valid = ("headline", "age", "lgd", "pca", "ttwa", "soa")
+    if breakdown not in valid:
+        raise ValueError(f"breakdown must be one of {valid}, got {breakdown!r}")
+
+    url = get_latest_publication_url()
+    file_path = download_file(url, cache_ttl_hours=_CACHE_TTL_HOURS, force_refresh=force_refresh)
+
+    if breakdown == "headline":
+        return parse_headline(file_path)
+    if breakdown == "age":
+        return parse_age(file_path)
+    if breakdown == "lgd":
+        return parse_geography(file_path, "LGD_11")
+    if breakdown == "pca":
+        return parse_geography(file_path, "PCA")
+    if breakdown == "ttwa":
+        return parse_geography(file_path, "TTWA")
+    # breakdown == "soa"
+    return parse_soa(file_path)
+
+
+def validate_claimant_count(df: pd.DataFrame, breakdown: str) -> bool:
+    """Validate the integrity of a claimant count DataFrame.
+
+    Checks that required columns are present, values are in plausible
+    ranges, and the DataFrame is non-empty.
+
+    Args:
+        df: DataFrame returned by ``get_latest_claimant_count`` or a
+            ``parse_*`` function.
+        breakdown: The breakdown type that produced the DataFrame.
+            One of ``"headline"``, ``"age"``, ``"lgd"``, ``"pca"``,
+            ``"ttwa"``, ``"soa"``.
+
+    Returns:
+        ``True`` if validation passes, ``False`` otherwise.
+
+    Example:
+        >>> import pandas as pd
+        >>> validate_claimant_count(pd.DataFrame(), "headline")
+        False
+    """
+    if df.empty:
+        logger.warning("Claimant count DataFrame is empty (breakdown=%s)", breakdown)
+        return False
+
+    required_columns: dict[str, list[str]] = {
+        "headline": ["date", "adjusted", "sex", "claimants_000s", "claimant_rate"],
+        "age": ["date", "age_group", "claimants"],
+        "lgd": ["date", "geography", "geography_type", "claimants_total", "claimant_rate_total_pct"],
+        "pca": ["date", "geography", "geography_type", "claimants_total", "claimant_rate_total_pct"],
+        "ttwa": ["date", "geography", "geography_type", "claimants_total", "claimant_rate_total_pct"],
+        "soa": ["soa_code", "date", "claimants"],
+    }
+
+    if breakdown not in required_columns:
+        logger.warning("Unknown breakdown type: %s", breakdown)
+        return False
+
+    missing = [c for c in required_columns[breakdown] if c not in df.columns]
+    if missing:
+        logger.warning("Missing columns for %s breakdown: %s", breakdown, missing)
+        return False
+
+    # Range checks
+    if breakdown == "headline":
+        if (df["claimants_000s"] < 0).any():
+            logger.warning("Negative claimant counts in headline data")
+            return False
+        rates = df["claimant_rate"].dropna()
+        if len(rates) > 0 and ((rates < 0).any() or (rates > 100).any()):
+            logger.warning("Claimant rates out of range [0, 100]")
+            return False
+
+    if breakdown == "age" and (df["claimants"] < 0).any():
+        logger.warning("Negative claimant counts in age data")
+        return False
+
+    if breakdown in ("lgd", "pca", "ttwa"):
+        if (df["claimants_total"] < 0).any():
+            logger.warning("Negative total claimants in %s data", breakdown)
+            return False
+        rates = df["claimant_rate_total_pct"].dropna()
+        if len(rates) > 0 and ((rates < 0).any() or (rates > 100).any()):
+            logger.warning("Claimant rates out of range [0, 100] in %s data", breakdown)
+            return False
+
+    return True

--- a/tests/test_nisra_claimant_count_integrity.py
+++ b/tests/test_nisra_claimant_count_integrity.py
@@ -1,0 +1,359 @@
+"""NISRA Claimant Count data integrity tests.
+
+These tests validate the real NISRA claimant count data against expected
+schemas, value ranges, and historical coverage. Network calls are made in
+``scope="class"`` fixtures so data is downloaded once per test class.
+
+The ``TestValidation`` class contains pure unit tests for the validation
+function that do not require network access.
+"""
+
+import pandas as pd
+import pytest
+
+from bolster.data_sources.nisra import claimant_count
+
+
+class TestHeadlineIntegrity:
+    """Integration tests for the Headline breakdown (NI total by sex)."""
+
+    @pytest.fixture(scope="class")
+    def latest_data(self) -> pd.DataFrame:
+        return claimant_count.get_latest_claimant_count("headline")
+
+    def test_required_columns(self, latest_data: pd.DataFrame) -> None:
+        required = {"date", "adjusted", "sex", "claimants_000s", "claimant_rate"}
+        assert required.issubset(set(latest_data.columns)), (
+            f"Missing columns: {required - set(latest_data.columns)}"
+        )
+
+    def test_nonempty(self, latest_data: pd.DataFrame) -> None:
+        assert len(latest_data) > 0, "Headline DataFrame is empty"
+
+    def test_sex_values(self, latest_data: pd.DataFrame) -> None:
+        expected_sexes = {"men", "women", "all_people"}
+        actual = set(latest_data["sex"].unique())
+        assert expected_sexes == actual, f"Unexpected sex values: {actual}"
+
+    def test_adjusted_values(self, latest_data: pd.DataFrame) -> None:
+        expected = {"seasonally_adjusted", "non_seasonally_adjusted"}
+        actual = set(latest_data["adjusted"].unique())
+        assert expected == actual, f"Unexpected adjusted values: {actual}"
+
+    def test_claimant_count_positive(self, latest_data: pd.DataFrame) -> None:
+        assert (latest_data["claimants_000s"] > 0).all(), (
+            "All claimant counts should be positive"
+        )
+
+    def test_claimant_rate_in_range(self, latest_data: pd.DataFrame) -> None:
+        rates = latest_data["claimant_rate"].dropna()
+        assert (rates >= 0).all() and (rates <= 100).all(), (
+            f"Rates out of [0, 100]: min={rates.min()}, max={rates.max()}"
+        )
+
+    def test_historical_coverage_pre_2020(self, latest_data: pd.DataFrame) -> None:
+        """Time series should extend back to at least April 1997."""
+        min_date = latest_data["date"].min()
+        assert min_date.year < 2020, (
+            f"Expected data before 2020, earliest date is {min_date}"
+        )
+
+    def test_historical_coverage_pre_2000(self, latest_data: pd.DataFrame) -> None:
+        """Full series starts at April 1997."""
+        min_date = latest_data["date"].min()
+        assert min_date.year <= 1997, (
+            f"Expected data from 1997, earliest date is {min_date}"
+        )
+
+    def test_seasonally_adjusted_present(self, latest_data: pd.DataFrame) -> None:
+        sa = latest_data[latest_data["adjusted"] == "seasonally_adjusted"]
+        assert len(sa) > 0, "No seasonally-adjusted rows found"
+
+    def test_non_seasonally_adjusted_present(self, latest_data: pd.DataFrame) -> None:
+        non_sa = latest_data[latest_data["adjusted"] == "non_seasonally_adjusted"]
+        assert len(non_sa) > 0, "No non-seasonally-adjusted rows found"
+
+    def test_date_is_datetime(self, latest_data: pd.DataFrame) -> None:
+        assert pd.api.types.is_datetime64_any_dtype(latest_data["date"]), (
+            "date column should be datetime type"
+        )
+
+    def test_validate_passes(self, latest_data: pd.DataFrame) -> None:
+        assert claimant_count.validate_claimant_count(latest_data, "headline") is True
+
+    def test_recent_data_present(self, latest_data: pd.DataFrame) -> None:
+        """There should be data within the last 3 months."""
+        max_date = latest_data["date"].max()
+        now = pd.Timestamp.now().normalize()
+        days_old = (now - max_date).days
+        assert days_old < 100, f"Most recent data is {days_old} days old: {max_date}"
+
+
+class TestAgeIntegrity:
+    """Integration tests for the Age breakdown."""
+
+    @pytest.fixture(scope="class")
+    def latest_data(self) -> pd.DataFrame:
+        return claimant_count.get_latest_claimant_count("age")
+
+    def test_required_columns(self, latest_data: pd.DataFrame) -> None:
+        required = {"date", "age_group", "claimants"}
+        assert required.issubset(set(latest_data.columns)), (
+            f"Missing columns: {required - set(latest_data.columns)}"
+        )
+
+    def test_nonempty(self, latest_data: pd.DataFrame) -> None:
+        assert len(latest_data) > 0, "Age DataFrame is empty"
+
+    def test_three_age_groups_present(self, latest_data: pd.DataFrame) -> None:
+        expected = {"16-24", "25-49", "50+"}
+        actual = set(latest_data["age_group"].unique())
+        assert expected == actual, f"Unexpected age groups: {actual}"
+
+    def test_claimants_positive(self, latest_data: pd.DataFrame) -> None:
+        assert (latest_data["claimants"] > 0).all(), (
+            "All claimant counts should be positive"
+        )
+
+    def test_data_from_2013(self, latest_data: pd.DataFrame) -> None:
+        """Age data starts from January 2013."""
+        min_date = latest_data["date"].min()
+        assert min_date.year <= 2013, (
+            f"Expected data from 2013, earliest is {min_date}"
+        )
+
+    def test_date_is_datetime(self, latest_data: pd.DataFrame) -> None:
+        assert pd.api.types.is_datetime64_any_dtype(latest_data["date"]), (
+            "date column should be datetime type"
+        )
+
+    def test_validate_passes(self, latest_data: pd.DataFrame) -> None:
+        assert claimant_count.validate_claimant_count(latest_data, "age") is True
+
+
+class TestLGDIntegrity:
+    """Integration tests for the Local Government District breakdown."""
+
+    @pytest.fixture(scope="class")
+    def latest_data(self) -> pd.DataFrame:
+        return claimant_count.get_latest_claimant_count("lgd")
+
+    def test_required_columns(self, latest_data: pd.DataFrame) -> None:
+        required = {
+            "date",
+            "geography",
+            "geography_type",
+            "claimants_male",
+            "claimants_female",
+            "claimants_total",
+            "claimant_rate_total_pct",
+            "change_over_month_number",
+            "change_over_year_number",
+        }
+        assert required.issubset(set(latest_data.columns)), (
+            f"Missing columns: {required - set(latest_data.columns)}"
+        )
+
+    def test_nonempty(self, latest_data: pd.DataFrame) -> None:
+        assert len(latest_data) > 0, "LGD DataFrame is empty"
+
+    def test_eleven_districts_present(self, latest_data: pd.DataFrame) -> None:
+        """There are 11 NI Local Government Districts, plus a NI total row."""
+        # Filter out the NI total row
+        districts = latest_data[latest_data["geography"] != "Northern Ireland"]
+        assert len(districts) == 11, (
+            f"Expected 11 districts, got {len(districts)}: {list(districts['geography'])}"
+        )
+
+    def test_geography_type(self, latest_data: pd.DataFrame) -> None:
+        assert (latest_data["geography_type"] == "LGD_11").all(), (
+            "geography_type should be 'LGD_11'"
+        )
+
+    def test_claimant_totals_positive(self, latest_data: pd.DataFrame) -> None:
+        assert (latest_data["claimants_total"] > 0).all(), (
+            "All total claimant counts should be positive"
+        )
+
+    def test_rates_in_valid_range(self, latest_data: pd.DataFrame) -> None:
+        rates = latest_data["claimant_rate_total_pct"].dropna()
+        assert (rates >= 0).all() and (rates <= 100).all(), (
+            f"Rates out of range: min={rates.min()}, max={rates.max()}"
+        )
+
+    def test_male_female_sum_approx_total(self, latest_data: pd.DataFrame) -> None:
+        """Male + female claimants should approximately equal total."""
+        districts = latest_data[latest_data["geography"] != "Northern Ireland"]
+        diff = (districts["claimants_male"] + districts["claimants_female"] - districts["claimants_total"]).abs()
+        # Allow small rounding differences (data is rounded to nearest 5)
+        assert (diff <= 10).all(), f"Male+Female sum deviates from total by more than 10: {diff.max()}"
+
+    def test_validate_passes(self, latest_data: pd.DataFrame) -> None:
+        assert claimant_count.validate_claimant_count(latest_data, "lgd") is True
+
+    def test_belfast_highest_claimants(self, latest_data: pd.DataFrame) -> None:
+        """Belfast typically has the highest claimant count."""
+        districts = latest_data[latest_data["geography"] != "Northern Ireland"]
+        max_row = districts.loc[districts["claimants_total"].idxmax()]
+        assert max_row["geography"] == "Belfast", (
+            f"Expected Belfast to have most claimants, got {max_row['geography']}"
+        )
+
+
+class TestPCAIntegrity:
+    """Integration tests for Parliamentary Constituency Area breakdown."""
+
+    @pytest.fixture(scope="class")
+    def latest_data(self) -> pd.DataFrame:
+        return claimant_count.get_latest_claimant_count("pca")
+
+    def test_required_columns(self, latest_data: pd.DataFrame) -> None:
+        required = {"date", "geography", "geography_type", "claimants_total", "claimant_rate_total_pct"}
+        assert required.issubset(set(latest_data.columns))
+
+    def test_eighteen_constituencies(self, latest_data: pd.DataFrame) -> None:
+        # Exclude the NI total row if present
+        areas = latest_data[latest_data["geography"] != "Northern Ireland"]
+        assert len(areas) == 18, (
+            f"Expected 18 PCA rows, got {len(areas)}: {list(areas['geography'])}"
+        )
+
+    def test_geography_type(self, latest_data: pd.DataFrame) -> None:
+        assert (latest_data["geography_type"] == "PCA").all()
+
+    def test_validate_passes(self, latest_data: pd.DataFrame) -> None:
+        assert claimant_count.validate_claimant_count(latest_data, "pca") is True
+
+
+class TestTTWAIntegrity:
+    """Integration tests for Travel-to-Work Area breakdown."""
+
+    @pytest.fixture(scope="class")
+    def latest_data(self) -> pd.DataFrame:
+        return claimant_count.get_latest_claimant_count("ttwa")
+
+    def test_required_columns(self, latest_data: pd.DataFrame) -> None:
+        required = {"date", "geography", "geography_type", "claimants_total", "claimant_rate_total_pct"}
+        assert required.issubset(set(latest_data.columns))
+
+    def test_ten_ttwa_areas(self, latest_data: pd.DataFrame) -> None:
+        # Exclude the NI total row if present
+        areas = latest_data[latest_data["geography"] != "Northern Ireland"]
+        assert len(areas) == 10, (
+            f"Expected 10 TTWA rows, got {len(areas)}: {list(areas['geography'])}"
+        )
+
+    def test_geography_type(self, latest_data: pd.DataFrame) -> None:
+        assert (latest_data["geography_type"] == "TTWA").all()
+
+    def test_validate_passes(self, latest_data: pd.DataFrame) -> None:
+        assert claimant_count.validate_claimant_count(latest_data, "ttwa") is True
+
+
+class TestValidation:
+    """Unit tests for validate_claimant_count — no network calls."""
+
+    def test_validate_empty_dataframe(self) -> None:
+        assert claimant_count.validate_claimant_count(pd.DataFrame(), "headline") is False
+
+    def test_validate_missing_columns_headline(self) -> None:
+        df = pd.DataFrame({"date": [pd.Timestamp("2024-01-01")], "sex": ["men"]})
+        assert claimant_count.validate_claimant_count(df, "headline") is False
+
+    def test_validate_missing_columns_age(self) -> None:
+        df = pd.DataFrame({"date": [pd.Timestamp("2024-01-01")]})
+        assert claimant_count.validate_claimant_count(df, "age") is False
+
+    def test_validate_negative_claimants_headline(self) -> None:
+        df = pd.DataFrame(
+            {
+                "date": [pd.Timestamp("2024-01-01")],
+                "adjusted": ["seasonally_adjusted"],
+                "sex": ["men"],
+                "claimants_000s": [-1.0],
+                "claimant_rate": [3.0],
+            }
+        )
+        assert claimant_count.validate_claimant_count(df, "headline") is False
+
+    def test_validate_rate_out_of_range(self) -> None:
+        df = pd.DataFrame(
+            {
+                "date": [pd.Timestamp("2024-01-01")],
+                "adjusted": ["seasonally_adjusted"],
+                "sex": ["men"],
+                "claimants_000s": [10.0],
+                "claimant_rate": [150.0],  # > 100
+            }
+        )
+        assert claimant_count.validate_claimant_count(df, "headline") is False
+
+    def test_validate_valid_headline(self) -> None:
+        df = pd.DataFrame(
+            {
+                "date": [pd.Timestamp("2024-01-01")],
+                "adjusted": ["seasonally_adjusted"],
+                "sex": ["all_people"],
+                "claimants_000s": [35.0],
+                "claimant_rate": [3.5],
+            }
+        )
+        assert claimant_count.validate_claimant_count(df, "headline") is True
+
+    def test_validate_negative_claimants_age(self) -> None:
+        df = pd.DataFrame(
+            {
+                "date": [pd.Timestamp("2024-01-01")],
+                "age_group": ["16-24"],
+                "claimants": [-5],
+            }
+        )
+        assert claimant_count.validate_claimant_count(df, "age") is False
+
+    def test_validate_valid_age(self) -> None:
+        df = pd.DataFrame(
+            {
+                "date": [pd.Timestamp("2024-01-01")],
+                "age_group": ["16-24"],
+                "claimants": [18000],
+            }
+        )
+        assert claimant_count.validate_claimant_count(df, "age") is True
+
+    def test_validate_negative_total_lgd(self) -> None:
+        df = pd.DataFrame(
+            {
+                "date": [pd.Timestamp("2024-01-01")],
+                "geography": ["Belfast"],
+                "geography_type": ["LGD_11"],
+                "claimants_total": [-100],
+                "claimant_rate_total_pct": [3.5],
+            }
+        )
+        assert claimant_count.validate_claimant_count(df, "lgd") is False
+
+    def test_validate_rate_out_of_range_lgd(self) -> None:
+        df = pd.DataFrame(
+            {
+                "date": [pd.Timestamp("2024-01-01")],
+                "geography": ["Belfast"],
+                "geography_type": ["LGD_11"],
+                "claimants_total": [9000],
+                "claimant_rate_total_pct": [200.0],
+            }
+        )
+        assert claimant_count.validate_claimant_count(df, "lgd") is False
+
+    def test_validate_unknown_breakdown(self) -> None:
+        df = pd.DataFrame({"foo": [1]})
+        assert claimant_count.validate_claimant_count(df, "unknown") is False
+
+    def test_validate_soa_missing_columns(self) -> None:
+        df = pd.DataFrame({"soa_code": ["95AA01S1"]})
+        assert claimant_count.validate_claimant_count(df, "soa") is False
+
+    def test_validate_empty_pca(self) -> None:
+        assert claimant_count.validate_claimant_count(pd.DataFrame(), "pca") is False
+
+    def test_validate_empty_ttwa(self) -> None:
+        assert claimant_count.validate_claimant_count(pd.DataFrame(), "ttwa") is False


### PR DESCRIPTION
## Summary

- Adds `nisra.claimant_count` module parsing the NISRA monthly Labour Market Report Excel file
- Covers five breakdowns: headline (SA + non-SA by sex from 1997), age bands (16–24, 25–49, 50+ from 2013), and three geographic snapshots (LGD, PCA, TTWA)
- Adds `bolster nisra claimant-count` CLI command with `--breakdown`, `--format`, `--save` options
- 51 real-data integrity tests, all passing; full test suite 1304 passed, 0 failures

## Schema findings from the real data

- **Both PCA and TTWA include a "Northern Ireland" total row** alongside area rows — the task spec said "18 PCA" and "10 TTWA" but each sheet has 19 and 11 rows respectively (including NI total). Tests filter it out with `geography != "Northern Ireland"`.
- **Date inference for geographic snapshots**: Cached files use hashed filenames so date can't be inferred from the path. Fixed by reading the last valid date from the Headline time series (`_infer_reference_date()`).
- **LGD_11 skiprows differs from PCA/TTWA**: LGD_11 has its header at row 6 (skiprows=6) while PCA and TTWA have it at row 5 (skiprows=5). The task spec said skiprows=6 for all geographic sheets — this was corrected by data inspection.

## Example insights from the data

1. **NI claimant count peaked at ~110,000 (SA) in mid-2020** during COVID lockdowns — a near-doubling from the pre-pandemic level of ~57,000 in early 2020. By March 2026 it had fallen back to ~35,000 (3.5% rate).
2. **Belfast dominates geographic inequality** — 4.6% male and 3.9% total claimant rate vs. Fermanagh & Omagh at 2.5%/2.3%. This pattern is consistent in both LGD and TTWA breakdowns.
3. **Youth unemployment disproportionate but improving**: The 16–24 age band accounts for roughly 27% of all claimants despite being a smaller share of the working-age population, though from a 2013 peak of ~18,000 it had fallen to ~10,000 by early 2026.

## Usage

```python
from bolster.data_sources.nisra import claimant_count

# Historical headline data (SA + non-SA)
df = claimant_count.get_latest_claimant_count("headline")
df[df["adjusted"] == "seasonally_adjusted"].pivot_table(
    index="date", columns="sex", values="claimants_000s"
).tail(12)

# Current-month LGD snapshot
lgd = claimant_count.get_latest_claimant_count("lgd")
```

```bash
bolster nisra claimant-count                          # Table view (headline)
bolster nisra claimant-count --breakdown lgd          # LGD snapshot
bolster nisra claimant-count --breakdown age --format csv --save age.csv
```

## Test plan

- [x] `uv run pytest tests/test_nisra_claimant_count_integrity.py -v` — 51 passed
- [x] `uv run pytest tests/ -q --no-cov` — 1304 passed, 0 failed
- [x] `uv run pre-commit run --all-files` — clean
- [x] Total coverage 87.45% (>=80% gate passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)