### PR TITLE
feat(psni): add stop_and_search module — PSNI stop & search 2017/18–2024/25

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ The [GOV.UK NISRA statistics RSS feed](https://www.gov.uk/search/research-and-st
 | Road Traffic Collisions | `psni.road_traffic_collisions` | ✅ |
 | PSNI Crime Statistics | `psni.crime_statistics` | ⚠️ historical only (Apr 2001–Dec 2021); `get_latest` raises `PSNIDataStaleError` |
 | Police Ombudsman Complaints | `psni.police_ombudsman` | ✅ |
+| Stop & Search | `psni.stop_and_search` | ✅ |
 
 #### Infrastructure NI Publication Discovery
 

--- a/src/bolster/cli.py
+++ b/src/bolster/cli.py
@@ -5289,6 +5289,113 @@ def psni_ombudsman_cmd(breakdown, output_format, save, force_refresh):
         raise click.Abort() from e
 
 
+@psni.command(name="stop-search")
+@click.option("--year", help="Filter by financial year, e.g. '2023/24'")
+@click.option("--district", help="No district breakdown is available in this dataset (ignored with warning)")
+@click.option(
+    "--format",
+    "output_format",
+    type=click.Choice(["table", "csv", "json"], case_sensitive=False),
+    default="table",
+    help="Output format (default: table)",
+)
+@click.option("--save", help="Save data to file (specify filename)")
+@click.option("--force-refresh", is_flag=True, help="Force re-download even if cached")
+def psni_stop_search_cmd(year, district, output_format, save, force_refresh):
+    """PSNI Stop and Search Statistics (2017/18 onwards).
+
+    Retrieves individual stop and search records for Northern Ireland covering:
+    - Financial year and quarter
+    - Legislation used (Misuse of Drugs Act, PACE, Justice & Security Act, etc.)
+    - PACE-specific search reasons (stolen articles, prohibited articles, blade/point, fireworks)
+    - Subject demographics (age group, gender)
+
+    Note: This dataset does not include a policing district breakdown.
+    All records are at Northern Ireland level only.
+
+    Examples:
+        Show summary table of all records::
+
+            bolster psni stop-search
+
+        Filter to a specific financial year::
+
+            bolster psni stop-search --year 2023/24
+
+        Export all records to CSV::
+
+            bolster psni stop-search --format csv --save stop_search.csv
+
+        Export 2024/25 data as JSON::
+
+            bolster psni stop-search --year 2024/25 --format json
+
+    Returns:
+        DataFrame with individual stop and search records.
+    """
+    from rich.table import Table
+
+    from bolster.data_sources.psni import stop_and_search
+
+    console = Console()
+
+    try:
+        if district:
+            console.print(
+                "[yellow]Note: This dataset has no district-level breakdown. "
+                "The --district filter is not applicable and will be ignored.[/yellow]\n"
+            )
+
+        console.print("\n[bold blue]Stop and Search Statistics[/bold blue]\n")
+        df = stop_and_search.get_latest_stop_and_search(force_refresh=force_refresh)
+
+        if year:
+            df = df[df["financial_year"] == year]
+            if df.empty:
+                available = sorted(df["financial_year"].cat.categories.tolist())
+                console.print(f"[red]No data found for year '{year}'. Available years: {available}[/red]")
+                return
+
+        title = f"Stop and Search Records ({year or 'all years'})"
+        console.print(f"[bold]{title}[/bold] — {len(df):,} records\n")
+
+        if output_format == "table":
+            table = Table(show_header=True, header_style="bold cyan")
+            for col in df.columns:
+                table.add_column(str(col))
+            display_df = df.head(50)
+            for _, row in display_df.iterrows():
+                table.add_row(*[str(v) for v in row.values])
+            console.print(table)
+            if len(df) > 50:
+                console.print(f"\n[yellow]Showing first 50 of {len(df):,} rows[/yellow]")
+
+        elif output_format == "csv":
+            console.print(df.to_csv(index=False))
+
+        elif output_format == "json":
+            console.print(df.to_json(orient="records", indent=2))
+
+        if save:
+            if save.endswith(".json"):
+                df.to_json(save, orient="records", indent=2)
+            else:
+                df.to_csv(save, index=False)
+            console.print(f"\n[green]Saved to {save}[/green]")
+
+        # Summary stats
+        years_covered = sorted(df["financial_year"].unique().tolist())
+        console.print(
+            f"\n[dim]Financial years: {years_covered[0]}–{years_covered[-1]} | "
+            f"{len(df):,} records | "
+            f"Top legislation: {df['legislation'].value_counts().index[0]}[/dim]"
+        )
+
+    except Exception as e:
+        console.print(f"[bold red]Error:[/bold red] {str(e)}", style="red")
+        raise click.Abort() from e
+
+
 @nisra.command(name="planning-statistics")
 @click.option(
     "--dimension",

--- a/src/bolster/data_sources/psni/__init__.py
+++ b/src/bolster/data_sources/psni/__init__.py
@@ -26,6 +26,7 @@ Example:
 See individual module docstrings for detailed documentation.
 """
 
+from . import stop_and_search
 from ._base import (
     PSNIDataError,
     PSNIDataNotFoundError,
@@ -78,6 +79,8 @@ from .road_traffic_collisions import (
 )
 
 __all__ = [
+    # Stop and Search module
+    "stop_and_search",
     # Crime Statistics - Main functions
     "get_historical_crime_statistics",
     "get_latest_crime_statistics",

--- a/src/bolster/data_sources/psni/stop_and_search.py
+++ b/src/bolster/data_sources/psni/stop_and_search.py
@@ -1,0 +1,308 @@
+"""PSNI Stop and Search Statistics.
+
+Provides access to Police Service of Northern Ireland stop and search data,
+covering individual stop and search records from 2017/18 to the latest
+available financial year.
+
+Data includes:
+- Financial year and quarter (quarterly breakdowns)
+- Legislation used (Misuse of Drugs Act, PACE, Justice & Security Act, etc.)
+- PACE-specific reasons for search (stolen articles, prohibited articles, blade/point, fireworks)
+- Subject demographics: age group and gender
+- Geographic level: Northern Ireland-wide (no district breakdown in this dataset)
+
+Data Source:
+    **Primary Source**: OpenDataNI — Stop and Search Statistics 2017/18–2024/25
+
+    https://www.opendatani.gov.uk/dataset/stop-and-search
+
+    Data is published by the PSNI under the Open Government Licence v3.0.
+
+Update Frequency: Annual (full dataset refreshed with each release)
+Geographic Coverage: Northern Ireland (NI-wide only — no district breakdown)
+Time Coverage: 2017/18 financial year to present
+Row count: ~199,000 individual stop and search records
+
+Example:
+    >>> from bolster.data_sources.psni import stop_and_search
+    >>> df = stop_and_search.get_latest_stop_and_search()
+    >>> 'financial_year' in df.columns
+    True
+    >>> stop_and_search.validate_stop_and_search(df)
+    True
+"""
+
+import logging
+
+import pandas as pd
+
+from bolster.utils.web import session
+
+from ._base import PSNIValidationError, download_file
+
+logger = logging.getLogger(__name__)
+
+# OpenDataNI CKAN API (admin endpoint — the public endpoint redirects to a Cloudflare page)
+OPENDATANI_API = "https://admin.opendatani.gov.uk/api/3/action"
+
+# Stable dataset identifier on OpenDataNI
+DATASET_ID = "421d96c1-fa5b-43e7-914c-b9a13e163d33"
+
+# Fallback URL confirmed working as of 2025 — used if CKAN API is unavailable
+FALLBACK_CSV_URL = (
+    "https://admin.opendatani.gov.uk/dataset/421d96c1-fa5b-43e7-914c-b9a13e163d33"
+    "/resource/73fcba18-4616-4a60-91ea-873f69f6d063"
+    "/download/stop-and-search-open-data-201718to202425.csv"
+)
+
+# Cache TTL: monthly updates, so refresh roughly monthly
+CACHE_TTL_HOURS = 24 * 30
+
+# Mapping from verbose raw column names to clean snake_case equivalents
+COLUMN_RENAMES: dict[str, str] = {
+    "Financial Year": "financial_year",
+    "Geographical Level": "geographical_level",
+    "Legislation": "legislation",
+    "(PACE) Reason for search - Stolen Articles": "pace_reason_stolen_articles",
+    "(PACE) Reason for search - Prohibited Articles": "pace_reason_prohibited_articles",
+    "(PACE) Reason for search - Blade or Point": "pace_reason_blade_or_point",
+    "(PACE) Reason for search - Fireworks": "pace_reason_fireworks",
+    "Quarter": "quarter",
+    "AgeGroup": "age_group",
+    "Gender": "gender",
+}
+
+# Quarter ordering for categorical dtype (chronological order within a year)
+QUARTER_ORDER = [
+    "April to June",
+    "July to September",
+    "October to December",
+    "January to March",
+]
+
+# Age group ordering for categorical dtype
+AGE_GROUP_ORDER = [
+    "Under 18",
+    "18 to 25",
+    "26 to 35",
+    "36 to 45",
+    "46 to 55",
+    "56 to 65",
+    "Over 65",
+    "Not Specified",
+]
+
+
+def get_latest_dataset_url() -> str:
+    """Query the OpenDataNI CKAN API to find the latest Stop and Search CSV URL.
+
+    Fetches resource metadata for the stop-and-search dataset from the OpenDataNI
+    CKAN API and returns the download URL for the CSV resource. Falls back to the
+    known direct URL if the API request fails.
+
+    Returns:
+        Download URL for the latest stop and search CSV file.
+
+    Example:
+        >>> url = get_latest_dataset_url()
+        >>> url.startswith("https://")
+        True
+        >>> url.endswith(".csv")
+        True
+    """
+    try:
+        resp = session.get(
+            f"{OPENDATANI_API}/package_show",
+            params={"id": DATASET_ID},
+            headers={"User-Agent": "bolster/1.0"},
+            timeout=30,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+
+        if not data.get("success"):
+            logger.warning("OpenDataNI CKAN API returned unsuccessful response; falling back to known URL")
+            return FALLBACK_CSV_URL
+
+        resources = data.get("result", {}).get("resources", [])
+        for resource in resources:
+            if resource.get("format", "").upper() == "CSV":
+                url = resource.get("url", "")
+                if url:
+                    logger.info(f"Found CSV resource via CKAN API: {url}")
+                    return url
+
+        logger.warning("No CSV resource found via CKAN API; falling back to known URL")
+        return FALLBACK_CSV_URL
+
+    except Exception as e:
+        logger.warning(f"CKAN API request failed ({e}); falling back to known URL")
+        return FALLBACK_CSV_URL
+
+
+def _parse_stop_and_search(file_path: str) -> pd.DataFrame:
+    """Parse a downloaded Stop and Search CSV file into a clean DataFrame.
+
+    Args:
+        file_path: Local path to the downloaded CSV file.
+
+    Returns:
+        Cleaned DataFrame with snake_case column names and appropriate dtypes.
+
+    Raises:
+        PSNIValidationError: If the CSV does not contain the expected columns.
+    """
+    df = pd.read_csv(file_path)
+
+    # Validate raw columns before renaming
+    expected_raw = set(COLUMN_RENAMES.keys())
+    missing = expected_raw - set(df.columns)
+    if missing:
+        raise PSNIValidationError(
+            f"Stop and Search CSV missing expected columns: {missing}. Found columns: {df.columns.tolist()}"
+        )
+
+    # Rename to snake_case
+    df = df.rename(columns=COLUMN_RENAMES)
+
+    # Normalise age_group: harmonise 'over 65' -> 'Over 65' (case inconsistency in source)
+    df["age_group"] = df["age_group"].str.strip()
+    df["age_group"] = df["age_group"].replace({"over 65": "Over 65", "Specified": "Not Specified"})
+
+    # Normalise legislation: strip trailing whitespace (source has trailing spaces in some rows)
+    df["legislation"] = df["legislation"].str.strip()
+
+    # Boolean columns for PACE reasons (Yes/No -> bool)
+    pace_cols = [
+        "pace_reason_stolen_articles",
+        "pace_reason_prohibited_articles",
+        "pace_reason_blade_or_point",
+        "pace_reason_fireworks",
+    ]
+    for col in pace_cols:
+        df[col] = df[col].str.strip().str.upper().map({"YES": True, "NO": False})
+
+    # Ordered categoricals for dimensions with a natural order
+    df["quarter"] = pd.Categorical(df["quarter"], categories=QUARTER_ORDER, ordered=True)
+    df["age_group"] = pd.Categorical(df["age_group"], categories=AGE_GROUP_ORDER, ordered=True)
+
+    # Unordered categoricals for nominal dimensions
+    for col in ["financial_year", "geographical_level", "legislation", "gender"]:
+        df[col] = df[col].astype("category")
+
+    logger.info(f"Parsed {len(df):,} stop and search records")
+    return df
+
+
+def get_latest_stop_and_search(force_refresh: bool = False) -> pd.DataFrame:
+    """Download and return the latest PSNI Stop and Search dataset.
+
+    Fetches the current stop and search data from OpenDataNI, caches it
+    locally for ~30 days, and returns a cleaned DataFrame with snake_case
+    column names and appropriate dtypes.
+
+    The dataset covers individual stop and search records for Northern Ireland
+    from financial year 2017/18 to the most recently published year. Note that
+    the dataset does **not** include a district-level geographic breakdown —
+    all records are at Northern Ireland level.
+
+    Args:
+        force_refresh: If True, bypass the local cache and re-download the data.
+
+    Returns:
+        DataFrame with columns:
+            - financial_year (category): e.g. ``"2023/24"``
+            - geographical_level (category): always ``"Northern Ireland"``
+            - legislation (category): legislation under which the search was conducted
+            - pace_reason_stolen_articles (bool): PACE reason — stolen articles
+            - pace_reason_prohibited_articles (bool): PACE reason — prohibited articles
+            - pace_reason_blade_or_point (bool): PACE reason — blade or point
+            - pace_reason_fireworks (bool): PACE reason — fireworks
+            - quarter (Categorical[ordered]): quarter label, e.g. ``"April to June"``
+            - age_group (Categorical[ordered]): age band of the subject
+            - gender (category): subject gender
+
+    Raises:
+        PSNIDataNotFoundError: If the download fails.
+        PSNIValidationError: If the downloaded file does not match the expected schema.
+
+    Example:
+        >>> df = get_latest_stop_and_search()
+        >>> len(df) > 100_000
+        True
+        >>> sorted(df['financial_year'].cat.categories.tolist())  # doctest: +SKIP
+        ['2017/18', '2018/19', '2019/20', '2020/21', '2021/22', '2022/23', '2023/24', '2024/25']
+    """
+    url = get_latest_dataset_url()
+    file_path = download_file(url, cache_ttl_hours=CACHE_TTL_HOURS, force_refresh=force_refresh)
+    return _parse_stop_and_search(str(file_path))
+
+
+def validate_stop_and_search(df: pd.DataFrame) -> bool:
+    """Validate the integrity of a Stop and Search DataFrame.
+
+    Checks that the DataFrame has the expected shape, required columns,
+    a sensible set of financial years, no unexpected null values in key
+    fields, and that PACE boolean columns contain only booleans.
+
+    Args:
+        df: DataFrame to validate (e.g. from :func:`get_latest_stop_and_search`).
+
+    Returns:
+        ``True`` if all checks pass.
+
+    Raises:
+        PSNIValidationError: If any check fails, with a descriptive message.
+
+    Example:
+        >>> df = get_latest_stop_and_search()
+        >>> validate_stop_and_search(df)
+        True
+    """
+    if df.empty:
+        raise PSNIValidationError("Stop and Search DataFrame is empty")
+
+    required_columns = {
+        "financial_year",
+        "geographical_level",
+        "legislation",
+        "pace_reason_stolen_articles",
+        "pace_reason_prohibited_articles",
+        "pace_reason_blade_or_point",
+        "pace_reason_fireworks",
+        "quarter",
+        "age_group",
+        "gender",
+    }
+    missing = required_columns - set(df.columns)
+    if missing:
+        raise PSNIValidationError(f"Missing required columns: {missing}")
+
+    # Must have records from at least 2017/18
+    years = df["financial_year"].unique().tolist()
+    str_years = [str(y) for y in years]
+    if "2017/18" not in str_years:
+        raise PSNIValidationError(f"Expected data from 2017/18 but found years: {sorted(str_years)}")
+
+    # Must have records for multiple financial years
+    if len(str_years) < 2:
+        raise PSNIValidationError(f"Expected multiple financial years, found only: {str_years}")
+
+    # PACE columns must be boolean (no nulls from failed mapping)
+    pace_cols = [
+        "pace_reason_stolen_articles",
+        "pace_reason_prohibited_articles",
+        "pace_reason_blade_or_point",
+        "pace_reason_fireworks",
+    ]
+    for col in pace_cols:
+        null_count = df[col].isna().sum()
+        if null_count > 0:
+            raise PSNIValidationError(f"Column '{col}' has {null_count} unexpected null values")
+
+    # At least 50,000 records (significantly less than 199k would indicate truncation)
+    if len(df) < 50_000:
+        raise PSNIValidationError(f"Too few records: expected ≥50,000 but got {len(df):,}")
+
+    logger.info(f"Validation passed: {len(df):,} records, years {sorted(str_years)}")
+    return True

--- a/tests/test_psni_stop_and_search_integrity.py
+++ b/tests/test_psni_stop_and_search_integrity.py
@@ -1,0 +1,244 @@
+"""Data integrity tests for PSNI Stop and Search Statistics.
+
+Tests cover:
+- Required columns present and correctly typed
+- Multiple financial years of data present (2017/18 onwards)
+- Demographic columns have expected values
+- Validation function edge cases (no network calls in TestValidation)
+"""
+
+import pandas as pd
+import pytest
+
+from bolster.data_sources.psni import stop_and_search
+from bolster.data_sources.psni._base import PSNIValidationError
+
+
+class TestStopAndSearchIntegrity:
+    """Integration tests against the real dataset — requires network access."""
+
+    @pytest.fixture(scope="class")
+    def latest_data(self) -> pd.DataFrame:
+        return stop_and_search.get_latest_stop_and_search()
+
+    def test_required_columns_present(self, latest_data: pd.DataFrame) -> None:
+        """All expected snake_case columns must be present."""
+        expected = {
+            "financial_year",
+            "geographical_level",
+            "legislation",
+            "pace_reason_stolen_articles",
+            "pace_reason_prohibited_articles",
+            "pace_reason_blade_or_point",
+            "pace_reason_fireworks",
+            "quarter",
+            "age_group",
+            "gender",
+        }
+        missing = expected - set(latest_data.columns)
+        assert not missing, f"Missing columns: {missing}"
+
+    def test_row_count(self, latest_data: pd.DataFrame) -> None:
+        """Dataset should have well over 100,000 records."""
+        assert len(latest_data) > 100_000, f"Expected >100,000 rows, got {len(latest_data):,}"
+
+    def test_multiple_financial_years(self, latest_data: pd.DataFrame) -> None:
+        """Dataset must span multiple financial years."""
+        years = latest_data["financial_year"].unique().tolist()
+        assert len(years) >= 3, f"Expected ≥3 financial years, got {len(years)}: {years}"
+
+    def test_data_from_2017_18(self, latest_data: pd.DataFrame) -> None:
+        """Dataset must include records from 2017/18 (earliest year in series)."""
+        year_strings = [str(y) for y in latest_data["financial_year"].unique()]
+        assert "2017/18" in year_strings, f"2017/18 not found in years: {sorted(year_strings)}"
+
+    def test_no_negative_counts(self, latest_data: pd.DataFrame) -> None:
+        """There should be no numeric columns with negative values."""
+        numeric_cols = latest_data.select_dtypes(include="number").columns
+        for col in numeric_cols:
+            min_val = latest_data[col].min()
+            assert min_val >= 0, f"Column '{col}' has negative values (min={min_val})"
+
+    def test_pace_columns_are_boolean(self, latest_data: pd.DataFrame) -> None:
+        """PACE reason columns must be boolean with no nulls."""
+        pace_cols = [
+            "pace_reason_stolen_articles",
+            "pace_reason_prohibited_articles",
+            "pace_reason_blade_or_point",
+            "pace_reason_fireworks",
+        ]
+        for col in pace_cols:
+            assert latest_data[col].dtype == bool, f"Column '{col}' should be bool, got {latest_data[col].dtype}"
+            assert latest_data[col].isna().sum() == 0, f"Column '{col}' has unexpected nulls"
+
+    def test_gender_values(self, latest_data: pd.DataFrame) -> None:
+        """Gender column should only contain expected values."""
+        expected_genders = {"Male", "Female", "Other/Unknown"}
+        actual_genders = set(latest_data["gender"].unique())
+        unexpected = actual_genders - expected_genders
+        assert not unexpected, f"Unexpected gender values: {unexpected}"
+
+    def test_quarter_is_ordered_categorical(self, latest_data: pd.DataFrame) -> None:
+        """Quarter column must be an ordered categorical."""
+        assert hasattr(latest_data["quarter"], "cat"), "quarter must be a Categorical dtype"
+        assert latest_data["quarter"].cat.ordered, "quarter Categorical must be ordered"
+
+    def test_all_quarters_present(self, latest_data: pd.DataFrame) -> None:
+        """All four quarters of the financial year must appear in the data."""
+        expected_quarters = {
+            "April to June",
+            "July to September",
+            "October to December",
+            "January to March",
+        }
+        actual = set(latest_data["quarter"].unique())
+        missing = expected_quarters - actual
+        assert not missing, f"Missing quarters: {missing}"
+
+    def test_age_group_ordered_categorical(self, latest_data: pd.DataFrame) -> None:
+        """age_group column must be an ordered categorical."""
+        assert hasattr(latest_data["age_group"], "cat"), "age_group must be Categorical"
+        assert latest_data["age_group"].cat.ordered, "age_group Categorical must be ordered"
+
+    def test_under_18_present(self, latest_data: pd.DataFrame) -> None:
+        """Under-18 age group must be present (important demographic for reporting)."""
+        age_groups = latest_data["age_group"].unique().tolist()
+        assert "Under 18" in age_groups, f"'Under 18' not found in age groups: {age_groups}"
+
+    def test_misuse_of_drugs_act_present(self, latest_data: pd.DataFrame) -> None:
+        """Misuse of Drugs Act should be the predominant legislation (known from data)."""
+        leg_counts = latest_data["legislation"].value_counts()
+        top_legislation = leg_counts.index[0]
+        assert "Misuse of Drugs Act" in top_legislation, (
+            f"Expected Misuse of Drugs Act to be top legislation, got: {top_legislation}"
+        )
+
+    def test_validate_passes_on_real_data(self, latest_data: pd.DataFrame) -> None:
+        """validate_stop_and_search must return True on the real dataset."""
+        result = stop_and_search.validate_stop_and_search(latest_data)
+        assert result is True
+
+    def test_get_latest_dataset_url_returns_csv(self) -> None:
+        """get_latest_dataset_url must return an https CSV URL."""
+        url = stop_and_search.get_latest_dataset_url()
+        assert url.startswith("https://"), f"URL should start with https://, got: {url}"
+        assert url.endswith(".csv"), f"URL should end with .csv, got: {url}"
+
+
+class TestValidation:
+    """Unit tests for validate_stop_and_search edge cases — no network calls."""
+
+    def _make_minimal_df(self) -> pd.DataFrame:
+        """Create a minimal valid DataFrame for use in tests."""
+        return pd.DataFrame(
+            {
+                "financial_year": pd.Categorical(["2017/18", "2023/24"]),
+                "geographical_level": pd.Categorical(["Northern Ireland", "Northern Ireland"]),
+                "legislation": pd.Categorical(["Misuse of Drugs Act S23", "Police and Criminal Evidence Order (PACE)"]),
+                "pace_reason_stolen_articles": [False, True],
+                "pace_reason_prohibited_articles": [False, False],
+                "pace_reason_blade_or_point": [False, False],
+                "pace_reason_fireworks": [False, False],
+                "quarter": pd.Categorical(
+                    ["April to June", "July to September"],
+                    categories=[
+                        "April to June",
+                        "July to September",
+                        "October to December",
+                        "January to March",
+                    ],
+                    ordered=True,
+                ),
+                "age_group": pd.Categorical(
+                    ["18 to 25", "26 to 35"],
+                    categories=[
+                        "Under 18",
+                        "18 to 25",
+                        "26 to 35",
+                        "36 to 45",
+                        "46 to 55",
+                        "56 to 65",
+                        "Over 65",
+                        "Not Specified",
+                    ],
+                    ordered=True,
+                ),
+                "gender": pd.Categorical(["Male", "Female"]),
+            }
+        )
+
+    def test_validate_empty_dataframe(self) -> None:
+        """validate_stop_and_search must raise PSNIValidationError on empty DataFrame."""
+        with pytest.raises(PSNIValidationError, match="empty"):
+            stop_and_search.validate_stop_and_search(pd.DataFrame())
+
+    def test_validate_missing_columns(self) -> None:
+        """validate_stop_and_search must raise PSNIValidationError if columns are missing."""
+        df = pd.DataFrame({"financial_year": ["2017/18"], "legislation": ["test"]})
+        with pytest.raises(PSNIValidationError, match="Missing required columns"):
+            stop_and_search.validate_stop_and_search(df)
+
+    def test_validate_missing_2017_18(self) -> None:
+        """validate_stop_and_search must raise PSNIValidationError if 2017/18 is absent."""
+        df = self._make_minimal_df()
+        # Replace with a year that doesn't include 2017/18
+        df["financial_year"] = pd.Categorical(["2022/23", "2023/24"])
+        with pytest.raises(PSNIValidationError, match="2017/18"):
+            stop_and_search.validate_stop_and_search(df)
+
+    def test_validate_single_year_fails(self) -> None:
+        """validate_stop_and_search must raise PSNIValidationError if only one year present."""
+        df = self._make_minimal_df()
+        df["financial_year"] = pd.Categorical(["2017/18", "2017/18"])
+        with pytest.raises(PSNIValidationError, match="multiple financial years"):
+            stop_and_search.validate_stop_and_search(df)
+
+    def test_validate_too_few_records(self) -> None:
+        """validate_stop_and_search must raise PSNIValidationError if fewer than 50,000 rows."""
+        df = self._make_minimal_df()
+        # Minimal df has 2 rows — well below the 50k threshold
+        with pytest.raises(PSNIValidationError, match="Too few records"):
+            stop_and_search.validate_stop_and_search(df)
+
+    def test_validate_null_pace_column(self) -> None:
+        """validate_stop_and_search must raise PSNIValidationError if PACE column has nulls."""
+        # Build a df large enough to pass the row count check
+        rows = 60_000
+        df = pd.DataFrame(
+            {
+                "financial_year": pd.Categorical(["2017/18"] * (rows // 2) + ["2023/24"] * (rows // 2)),
+                "geographical_level": pd.Categorical(["Northern Ireland"] * rows),
+                "legislation": pd.Categorical(["Misuse of Drugs Act S23"] * rows),
+                "pace_reason_stolen_articles": [None] * rows,  # nulls — should fail
+                "pace_reason_prohibited_articles": [False] * rows,
+                "pace_reason_blade_or_point": [False] * rows,
+                "pace_reason_fireworks": [False] * rows,
+                "quarter": pd.Categorical(
+                    ["April to June"] * rows,
+                    categories=[
+                        "April to June",
+                        "July to September",
+                        "October to December",
+                        "January to March",
+                    ],
+                    ordered=True,
+                ),
+                "age_group": pd.Categorical(
+                    ["18 to 25"] * rows,
+                    categories=[
+                        "Under 18",
+                        "18 to 25",
+                        "26 to 35",
+                        "36 to 45",
+                        "46 to 55",
+                        "56 to 65",
+                        "Over 65",
+                        "Not Specified",
+                    ],
+                    ordered=True,
+                ),
+                "gender": pd.Categorical(["Male"] * rows),
+            }
+        )
+        with pytest.raises(PSNIValidationError, match="null"):
+            stop_and_search.validate_stop_and_search(df)


### PR DESCRIPTION
## Summary

- Adds `psni.stop_and_search` module providing access to ~199,000 individual PSNI stop and search records from OpenDataNI (financial years 2017/18–2024/25)
- CKAN API URL discovery (`get_latest_dataset_url()`) with automatic fallback to a known stable direct URL
- Clean snake_case schema with ordered categoricals for `quarter` and `age_group`, boolean PACE reason columns, and normalised `legislation` strings (trailing whitespace + case inconsistencies fixed at source)
- CLI command `bolster psni stop-search` with `--year`, `--format` (table/csv/json), and `--save` options
- 20 tests: 14 real-data integrity tests + 6 unit validation tests — all passing, 89.5% patch coverage, 1273 total tests passing

## Schema (actual CSV columns)

| Raw column | Cleaned name | Type |
|---|---|---|
| `Financial Year` | `financial_year` | category |
| `Geographical Level` | `geographical_level` | category (always "Northern Ireland") |
| `Legislation` | `legislation` | category |
| `(PACE) Reason for search - Stolen Articles` | `pace_reason_stolen_articles` | bool |
| `(PACE) Reason for search - Prohibited Articles` | `pace_reason_prohibited_articles` | bool |
| `(PACE) Reason for search - Blade or Point` | `pace_reason_blade_or_point` | bool |
| `(PACE) Reason for search - Fireworks` | `pace_reason_fireworks` | bool |
| `Quarter` | `quarter` | Categorical[ordered] |
| `AgeGroup` | `age_group` | Categorical[ordered] |
| `Gender` | `gender` | category |

Note: the dataset has **no district-level breakdown** — all 199,661 records are at Northern Ireland level only.

## Data insights from the real dataset

1. **Misuse of Drugs Act dominates**: 133,375 of 199,661 records (66.8%) use the Misuse of Drugs Act S23 as the primary legislation — making drug searches by far the most common type of stop and search in Northern Ireland.

2. **Under-18s account for 11.4% of stops**: 22,698 records involve subjects under 18, which is a significant share given that under-18s make up ~21% of the NI population. The 18–25 age band is the single largest group (82,187 records, 41.2%).

3. **Sharp year-on-year decline**: searches peaked at 29,882 records in 2017/18 and fell to 18,096 in 2024/25 (data to Q3 only) — roughly a 40% reduction in annual stop and search activity over the period, though 2024/25 is not yet a full financial year.

## Usage

```python
from bolster.data_sources.psni import stop_and_search

df = stop_and_search.get_latest_stop_and_search()
# 199,661 rows × 10 columns

# Year filter
df_2324 = df[df["financial_year"] == "2023/24"]

# PACE drug-related searches
drugs = df[df["legislation"].str.contains("Misuse of Drugs")]

# Validate
stop_and_search.validate_stop_and_search(df)  # True
```

```bash
# CLI
bolster psni stop-search
bolster psni stop-search --year 2023/24
bolster psni stop-search --format csv --save stop_search.csv
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)