### PR TITLE
feat(justice): NICTS mortgages actions for possession

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ The [GOV.UK NISRA statistics RSS feed](https://www.gov.uk/search/research-and-st
 | Tourism - Visitor Statistics | `nisra.tourism.visitor_statistics` | ✅ |
 | Baby Names NI (annual, 1997–present) | `nisra.baby_names` | ✅ |
 | NI School Suspensions (DE) | `education_suspensions` | ✅ |
+| NICTS Mortgages Action for Possession (DoJ) | `justice.mortgages` | ✅ |
 | Work Quality NI (NISRA) | `nisra.work_quality` | ✅ |
 | NI LAC Municipal Waste Statistics (DAERA) | `daera_waste` | ✅ |
 | NI Claimant Count (UC + JSA, DfC/ONS) | `nisra.claimant_count` | ✅ |

--- a/src/bolster/cli.py
+++ b/src/bolster/cli.py
@@ -16,6 +16,7 @@ from .data_sources.cineworld import get_cinema_listings
 from .data_sources.companies_house import get_companies_house_records_that_might_be_in_farset, query_basic_company_data
 from .data_sources.daera_waste import get_latest_waste_statistics, validate_waste_data
 from .data_sources.eoni import get_results as get_ni_election_results
+from .data_sources.justice import mortgages as justice_mortgages
 from .data_sources.metoffice import get_uk_precipitation
 from .data_sources.ni_house_price_index import build as get_ni_house_prices
 from .data_sources.ni_water import get_postcode_to_water_supply_zone, get_water_quality_by_zone
@@ -6427,6 +6428,118 @@ def education_suspensions_cmd(year, output_format, force_refresh, save, summary)
 
         if output_format == "json":
             click.echo(data.to_json(orient="records", indent=2))
+        else:
+            console.print(data.to_csv(index=False), end="")
+
+    except Exception as e:
+        console.print(f"[bold red]Error:[/bold red] {str(e)}", style="red")
+        console.print("\n[yellow]Troubleshooting:[/yellow]")
+        console.print("   - Check your internet connection")
+        console.print("   - Try again with --force-refresh to bypass cache")
+        raise click.Abort() from e
+
+
+@cli.group(name="justice")
+def justice():
+    """NI Department of Justice / NICTS statistics.
+
+    Access official justice statistics from the Northern Ireland Courts and
+    Tribunals Service (NICTS), including mortgage actions for possession.
+    """
+    pass
+
+
+@justice.command(name="mortgages")
+@click.option(
+    "--table",
+    type=click.Choice(["received", "disposed", "final-orders"], case_sensitive=False),
+    default="received",
+    help="Which table to show (default: received)",
+)
+@click.option(
+    "--format",
+    "output_format",
+    type=click.Choice(["csv", "json"], case_sensitive=False),
+    default="csv",
+    help="Output format (default: csv)",
+)
+@click.option("--force-refresh", is_flag=True, help="Force re-download even if cached")
+@click.option("--save", help="Save data to file (specify filename)")
+@click.option("--summary", is_flag=True, help="Show summary statistics instead of full data")
+def justice_mortgages_cmd(table, output_format, force_refresh, save, summary):
+    r"""NICTS Mortgages: Action for Possession.
+
+    \b
+    Quarterly statistics on mortgage possession proceedings in the Chancery
+    Division of the NI High Court: cases received, cases disposed, and the
+    final orders made. Covers 2007 to present (final orders from 2017).
+
+    Examples:
+        Quarterly cases received::
+
+            bolster justice mortgages
+
+        Cases disposed::
+
+            bolster justice mortgages --table disposed
+
+        Final orders by type::
+
+            bolster justice mortgages --table final-orders
+
+        Save as CSV::
+
+            bolster justice mortgages --save mortgages.csv
+
+    Source:
+        https://www.justice-ni.gov.uk/publications/nicts-mortgages-action-possession
+    """
+    from rich.console import Console
+
+    console = Console()
+
+    try:
+        with console.status("[bold green]Downloading NICTS mortgages data..."):
+            all_data = justice_mortgages.get_latest_data(force_refresh=force_refresh)
+
+        if table == "final-orders":
+            if "final_orders" not in all_data:
+                console.print("[yellow]Final orders data not available in this bulletin[/yellow]")
+                return
+            data = all_data["final_orders"]
+        else:
+            data = all_data[table]
+
+        console.print("[green]Mortgages data retrieved successfully[/green]")
+        console.print(f"[cyan]Table: {table} | Rows: {len(data)}[/cyan]")
+
+        if summary and table in ("received", "disposed"):
+            annual = data.groupby("year")["annual_total"].first().dropna()
+            peak_year = int(annual.idxmax())
+            console.print("\n[bold]Summary:[/bold]")
+            console.print(f"   Coverage: {int(data['year'].min())}-{int(data['year'].max())}")
+            console.print(f"   Peak year: {peak_year} ({int(annual.max()):,} applications)")
+            console.print(f"   Latest complete annual total: {int(annual.iloc[-1]):,} ({int(annual.index[-1])})")
+            if not save:
+                return
+
+        if save:
+            try:
+                if output_format == "json" or save.endswith(".json"):
+                    data.astype(str).to_json(save, orient="records", indent=2)
+                else:
+                    data.to_csv(save, index=False)
+                console.print(f"[green]Saved to: {save}[/green]")
+                return
+            except PermissionError:
+                console.print(f"[red]Error: Permission denied writing to {save}[/red]")
+                return
+            except Exception as e:
+                console.print(f"[red]Error saving file: {e}[/red]")
+                return
+
+        if output_format == "json":
+            click.echo(data.astype(str).to_json(orient="records", indent=2))
         else:
             console.print(data.to_csv(index=False), end="")
 

--- a/src/bolster/data_sources/__init__.py
+++ b/src/bolster/data_sources/__init__.py
@@ -11,6 +11,7 @@ Various scrapers and API wrappers for NI government data:
 - dva: Driver & Vehicle Agency monthly test statistics
 - gender_pay_gap: UK Gender Pay Gap reporting data (all employers 250+, 2017–present)
 - nisra: NISRA statistics (deaths, births, labour market, population, etc.)
+- justice: NI Department of Justice / NICTS statistics (mortgage possession actions)
 
 Most have corresponding CLI commands.
 """

--- a/src/bolster/data_sources/justice/__init__.py
+++ b/src/bolster/data_sources/justice/__init__.py
@@ -1,0 +1,10 @@
+"""Northern Ireland Department of Justice data sources.
+
+Modules wrapping statistical publications from the Department of Justice (DoJ)
+and the Northern Ireland Courts and Tribunals Service (NICTS):
+
+- mortgages: Mortgage actions for possession (cases received, disposed, and
+  final orders made in the Chancery Division of the NI High Court).
+
+Most have corresponding CLI commands under ``bolster justice ...``.
+"""

--- a/src/bolster/data_sources/justice/mortgages.py
+++ b/src/bolster/data_sources/justice/mortgages.py
@@ -1,0 +1,482 @@
+"""NICTS Mortgages: Action for Possession Data.
+
+Provides access to quarterly statistics on mortgage possession proceedings in
+the Chancery Division of the Northern Ireland High Court, published by the
+Northern Ireland Courts and Tribunals Service (NICTS).
+
+Three datasets are available:
+
+- **Cases received** - writs and originating summonses issued (Table 1).
+- **Cases disposed** - cases concluded by the court (Table 2).
+- **Final orders** - the type of final order made, e.g. possession,
+  suspended possession, strike out (Table 3, available from 2017 onwards).
+
+Data Source:
+    **Publication Page**:
+    https://www.justice-ni.gov.uk/publications/nicts-mortgages-action-possession
+
+    The module scrapes this page to find the latest quarterly ODS file
+    (``mortgages-bulletin-tables-<period>.ods``), which contains separate
+    worksheets for received, disposed and final-order statistics.
+
+Update Frequency: Quarterly
+Geographic Coverage: Northern Ireland
+Reference Period: 2007 - present (final orders: 2017 - present)
+
+This data pairs well with :mod:`bolster.data_sources.ni_house_price_index`
+for contextualising the housing market against repossession activity.
+
+Example:
+    >>> from bolster.data_sources.justice import mortgages
+    >>> df = mortgages.get_cases_received()
+    >>> "applications" in df.columns
+    True
+    >>> {"Q1", "Q2", "Q3", "Q4"}.issubset(set(df["quarter"]))
+    True
+"""
+
+import logging
+import re
+from pathlib import Path
+from urllib.parse import urlparse
+
+import bs4
+import pandas as pd
+
+from bolster.utils.cache import CachedDownloader, DownloadError
+from bolster.utils.web import session
+
+logger = logging.getLogger(__name__)
+
+# Publication landing page listing every quarterly bulletin
+PUBLICATION_URL = "https://www.justice-ni.gov.uk/publications/nicts-mortgages-action-possession"
+BASE_URL = "https://www.justice-ni.gov.uk"
+
+# Worksheet names within the ODS bulletin
+SHEET_RECEIVED = "Mortgages_received"
+SHEET_DISPOSED = "Mortgages_disposed"
+SHEET_FINAL_ORDERS = "Mortgages_final_orders"
+
+# Quarter labels in publication order
+QUARTERS = ["Q1", "Q2", "Q3", "Q4"]
+
+# Shared downloader instance (ODS files are tiny, cache for a week)
+_downloader = CachedDownloader("justice_mortgages", timeout=60)
+
+
+class MortgagesDataError(Exception):
+    """Base exception for NICTS mortgages data errors."""
+
+    pass
+
+
+class MortgagesDataNotFoundError(MortgagesDataError):
+    """Raised when the data file cannot be located or downloaded."""
+
+    pass
+
+
+class MortgagesValidationError(MortgagesDataError):
+    """Raised when downloaded data fails validation."""
+
+    pass
+
+
+def get_latest_publication_url(base_url: str = PUBLICATION_URL) -> str:
+    """Find the URL of the most recent mortgages bulletin ODS file.
+
+    Scrapes the publication landing page for links to ``.ods`` files and
+    returns the first one found (the page lists newest first).
+
+    Args:
+        base_url: URL of the publication listing page.
+
+    Returns:
+        Absolute URL of the latest ODS bulletin file.
+
+    Raises:
+        MortgagesDataNotFoundError: If the page cannot be fetched or no ODS
+            link is found.
+
+    Example:
+        >>> url = get_latest_publication_url()  # doctest: +SKIP
+        >>> url.endswith(".ods")  # doctest: +SKIP
+        True
+    """
+    try:
+        response = session.get(base_url, timeout=30)
+        response.raise_for_status()
+    except Exception as e:
+        raise MortgagesDataNotFoundError(f"Failed to fetch publication page {base_url}: {e}") from e
+
+    soup = bs4.BeautifulSoup(response.content, features="html.parser")
+
+    for a in soup.find_all("a", href=True):
+        href = a["href"]
+        if href.lower().endswith(".ods"):
+            if href.startswith("/"):
+                href = urlparse(base_url)._replace(path=href, query="", fragment="").geturl()
+            logger.info(f"Found latest mortgages bulletin: {href}")
+            return href
+
+    raise MortgagesDataNotFoundError(f"Could not find an ODS file on {base_url}")
+
+
+def download_file(url: str, cache_ttl_hours: int = 24 * 7, force_refresh: bool = False) -> Path:
+    """Download a bulletin ODS file with caching.
+
+    Args:
+        url: URL of the ODS file to download.
+        cache_ttl_hours: Cache validity in hours (default: 7 days, since data
+            is published quarterly).
+        force_refresh: If True, bypass the cache and re-download.
+
+    Returns:
+        Path to the downloaded (or cached) file.
+
+    Raises:
+        MortgagesDataNotFoundError: If the download fails.
+    """
+    try:
+        return _downloader.download(url, cache_ttl_hours=cache_ttl_hours, force_refresh=force_refresh)
+    except DownloadError as e:
+        raise MortgagesDataNotFoundError(str(e)) from e
+
+
+def _parse_quarterly_table(file_path: Path, sheet_name: str, value_label: str) -> pd.DataFrame:
+    """Parse a wide quarterly table (Table 1/2) into tidy long format.
+
+    The received/disposed worksheets have one row per year with four quarterly
+    columns, an annual total, and a year-on-year percentage difference. This
+    reshapes them into one row per (year, quarter).
+
+    Args:
+        file_path: Path to the ODS file.
+        sheet_name: Worksheet name to read.
+        value_label: Name for the value column (e.g. "applications").
+
+    Returns:
+        DataFrame with columns: year, quarter, period, ``value_label``,
+        annual_total, annual_pct_change.
+    """
+    raw = pd.read_excel(file_path, sheet_name=sheet_name, header=None, engine="odf")
+
+    # Locate the header row (the one whose first cell is exactly "Year").
+    header_idx = None
+    for idx in range(min(10, len(raw))):
+        if str(raw.iloc[idx, 0]).strip() == "Year":
+            header_idx = idx
+            break
+    if header_idx is None:
+        raise MortgagesValidationError(f"Could not find 'Year' header row in sheet {sheet_name}")
+
+    records = []
+    for _, row in raw.iloc[header_idx + 1 :].iterrows():
+        year_cell = row.iloc[0]
+        if pd.isna(year_cell):
+            continue
+        try:
+            year = int(float(year_cell))
+        except (ValueError, TypeError):
+            # Footer / note rows after the data block
+            continue
+
+        annual_total = _safe_int(row.iloc[5])
+        annual_pct = _safe_float(row.iloc[6])
+
+        for q_idx, quarter in enumerate(QUARTERS, start=1):
+            value = _safe_int(row.iloc[q_idx])
+            records.append(
+                {
+                    "year": year,
+                    "quarter": quarter,
+                    "period": pd.Period(f"{year}{quarter}", freq="Q"),
+                    value_label: value,
+                    "annual_total": annual_total,
+                    "annual_pct_change": annual_pct,
+                }
+            )
+
+    df = pd.DataFrame.from_records(records)
+    return df.sort_values(["year", "quarter"]).reset_index(drop=True)
+
+
+def _parse_final_orders(file_path: Path, sheet_name: str = SHEET_FINAL_ORDERS) -> pd.DataFrame:
+    """Parse the final-orders worksheet (Table 3) into tidy long format.
+
+    The final-orders worksheet is wide: order types are rows and time periods
+    (years 2017-2024, then individual quarters) are columns. This melts it into
+    one row per (order_type, period).
+
+    Args:
+        file_path: Path to the ODS file.
+        sheet_name: Worksheet name to read.
+
+    Returns:
+        DataFrame with columns: order_type, year, quarter, period, count.
+        Annual columns (pre-quarterly years) have quarter set to None and
+        period set to an annual Period.
+
+    Raises:
+        MortgagesValidationError: If the header row cannot be found.
+    """
+    raw = pd.read_excel(file_path, sheet_name=sheet_name, header=None, engine="odf")
+
+    header_idx = None
+    for idx in range(min(10, len(raw))):
+        if str(raw.iloc[idx, 0]).strip() == "Final Order":
+            header_idx = idx
+            break
+    if header_idx is None:
+        raise MortgagesValidationError(f"Could not find 'Final Order' header row in sheet {sheet_name}")
+
+    headers = raw.iloc[header_idx].tolist()
+    records = []
+    for _, row in raw.iloc[header_idx + 1 :].iterrows():
+        order_type = row.iloc[0]
+        if pd.isna(order_type) or not str(order_type).strip():
+            continue
+        order_type = str(order_type).strip()
+
+        for col_idx in range(1, len(headers)):
+            label = headers[col_idx]
+            if pd.isna(label):
+                continue
+            year, quarter, period = _parse_period_label(label)
+            if period is None:
+                continue
+            count = _safe_int(row.iloc[col_idx])
+            records.append(
+                {
+                    "order_type": order_type,
+                    "year": year,
+                    "quarter": quarter,
+                    "period": period,
+                    "count": count,
+                }
+            )
+
+    df = pd.DataFrame.from_records(records)
+    return df.sort_values(["order_type", "year"]).reset_index(drop=True)
+
+
+def _parse_period_label(label) -> tuple[int | None, str | None, pd.Period | None]:
+    """Parse a final-orders column label into (year, quarter, Period).
+
+    Handles annual labels (e.g. ``2017``, ``2017.0``) and quarterly labels
+    (e.g. ``2025 Q1``).
+
+    Args:
+        label: Raw column header value.
+
+    Returns:
+        Tuple of (year, quarter, Period). Annual labels have quarter ``None``
+        and an annual-frequency Period. Returns (None, None, None) if the
+        label cannot be parsed.
+    """
+    text = str(label).strip()
+
+    # Quarterly: "2025 Q1"
+    m = re.match(r"^(\d{4})\s*Q([1-4])$", text)
+    if m:
+        year = int(m.group(1))
+        quarter = f"Q{m.group(2)}"
+        return year, quarter, pd.Period(f"{year}{quarter}", freq="Q")
+
+    # Annual: "2017" or "2017.0"
+    m = re.match(r"^(\d{4})(?:\.0)?$", text)
+    if m:
+        year = int(m.group(1))
+        return year, None, pd.Period(str(year), freq="Y")
+
+    return None, None, None
+
+
+def _safe_int(val) -> int | None:
+    """Convert a cell value to int, returning None for blanks/placeholders."""
+    if val is None or (isinstance(val, float) and pd.isna(val)) or val == "" or val == "-":
+        return None
+    try:
+        return int(round(float(val)))
+    except (ValueError, TypeError):
+        return None
+
+
+def _safe_float(val) -> float | None:
+    """Convert a cell value to float, returning None for blanks/placeholders."""
+    if val is None or (isinstance(val, float) and pd.isna(val)) or val == "" or val == "-":
+        return None
+    try:
+        return float(val)
+    except (ValueError, TypeError):
+        return None
+
+
+def parse_data(file_path: Path) -> dict[str, pd.DataFrame]:
+    """Parse all mortgage tables from a bulletin ODS file.
+
+    Args:
+        file_path: Path to the ODS bulletin file.
+
+    Returns:
+        Dictionary with keys ``received``, ``disposed`` and ``final_orders``
+        mapping to tidy long-format DataFrames. ``final_orders`` may be absent
+        if the file pre-dates 2017.
+
+    Example:
+        >>> tables = parse_data(download_file(get_latest_publication_url()))  # doctest: +SKIP
+        >>> sorted(tables)  # doctest: +SKIP
+        ['disposed', 'final_orders', 'received']
+    """
+    file_path = Path(file_path)
+    available = set(pd.ExcelFile(file_path, engine="odf").sheet_names)
+
+    tables: dict[str, pd.DataFrame] = {
+        "received": _parse_quarterly_table(file_path, SHEET_RECEIVED, "applications"),
+        "disposed": _parse_quarterly_table(file_path, SHEET_DISPOSED, "applications"),
+    }
+    if SHEET_FINAL_ORDERS in available:
+        tables["final_orders"] = _parse_final_orders(file_path, SHEET_FINAL_ORDERS)
+
+    return tables
+
+
+def get_latest_data(force_refresh: bool = False) -> dict[str, pd.DataFrame]:
+    """Download and parse the latest mortgages bulletin.
+
+    Args:
+        force_refresh: If True, bypass the cache and download fresh data.
+
+    Returns:
+        Dictionary of tidy DataFrames keyed ``received``, ``disposed`` and
+        (where available) ``final_orders``.
+
+    Example:
+        >>> data = get_latest_data()
+        >>> "received" in data and "disposed" in data
+        True
+    """
+    url = get_latest_publication_url()
+    file_path = download_file(url, force_refresh=force_refresh)
+    return parse_data(file_path)
+
+
+def get_cases_received(force_refresh: bool = False) -> pd.DataFrame:
+    """Get quarterly mortgage possession cases received (Table 1).
+
+    Args:
+        force_refresh: If True, bypass the cache and download fresh data.
+
+    Returns:
+        DataFrame with columns: year, quarter, period, applications,
+        annual_total, annual_pct_change. One row per (year, quarter) from 2007.
+
+    Example:
+        >>> df = get_cases_received()
+        >>> "applications" in df.columns
+        True
+    """
+    return get_latest_data(force_refresh=force_refresh)["received"]
+
+
+def get_cases_disposed(force_refresh: bool = False) -> pd.DataFrame:
+    """Get quarterly mortgage possession cases disposed (Table 2).
+
+    Args:
+        force_refresh: If True, bypass the cache and download fresh data.
+
+    Returns:
+        DataFrame with columns: year, quarter, period, applications,
+        annual_total, annual_pct_change. One row per (year, quarter) from 2007.
+
+    Example:
+        >>> df = get_cases_disposed()
+        >>> "applications" in df.columns
+        True
+    """
+    return get_latest_data(force_refresh=force_refresh)["disposed"]
+
+
+def get_final_orders(force_refresh: bool = False) -> pd.DataFrame:
+    """Get mortgage possession final orders by type (Table 3).
+
+    Final orders have been published from 2017 onwards. Earlier years are
+    reported annually; from 2025 they are broken down by quarter.
+
+    Args:
+        force_refresh: If True, bypass the cache and download fresh data.
+
+    Returns:
+        DataFrame with columns: order_type, year, quarter, period, count.
+
+    Raises:
+        MortgagesDataNotFoundError: If the bulletin does not include final
+            orders (e.g. very old files).
+
+    Example:
+        >>> df = get_final_orders()  # doctest: +SKIP
+        >>> "order_type" in df.columns  # doctest: +SKIP
+        True
+    """
+    data = get_latest_data(force_refresh=force_refresh)
+    if "final_orders" not in data:
+        raise MortgagesDataNotFoundError("Final orders data not available in this bulletin")
+    return data["final_orders"]
+
+
+def validate_data(df: pd.DataFrame, value_col: str = "applications", min_records: int = 40) -> bool:
+    """Validate a parsed quarterly mortgages DataFrame.
+
+    Checks structure and sanity of received/disposed tables:
+
+    - Required columns are present.
+    - There are at least ``min_records`` rows (>= 10 years of quarters).
+    - Years fall within a plausible range (2007 onwards).
+    - All non-null counts are non-negative.
+
+    Args:
+        df: DataFrame to validate (received or disposed).
+        value_col: Name of the count column to check (default: "applications").
+        min_records: Minimum acceptable number of rows.
+
+    Returns:
+        True if the data passes all checks.
+
+    Raises:
+        MortgagesValidationError: If any validation check fails.
+
+    Example:
+        >>> import pandas as pd
+        >>> validate_data(pd.DataFrame())
+        Traceback (most recent call last):
+        ...
+        bolster.data_sources.justice.mortgages.MortgagesValidationError: DataFrame is empty
+    """
+    if df is None or df.empty:
+        raise MortgagesValidationError("DataFrame is empty")
+
+    required = {"year", "quarter", "period", value_col}
+    missing = required - set(df.columns)
+    if missing:
+        raise MortgagesValidationError(f"Missing required columns: {missing}")
+
+    if len(df) < min_records:
+        raise MortgagesValidationError(f"Too few records: {len(df)} < {min_records}")
+
+    if df["year"].min() < 2007 or df["year"].max() > 2100:
+        raise MortgagesValidationError(f"Year range out of bounds: {df['year'].min()}-{df['year'].max()}")
+
+    values = df[value_col].dropna()
+    if (values < 0).any():
+        raise MortgagesValidationError(f"Negative values found in column '{value_col}'")
+
+    return True
+
+
+def clear_cache() -> int:
+    """Clear all cached mortgages bulletin files.
+
+    Returns:
+        Number of files deleted.
+    """
+    return _downloader.clear()

--- a/tests/test_justice_mortgages_integrity.py
+++ b/tests/test_justice_mortgages_integrity.py
@@ -1,0 +1,257 @@
+"""Integrity tests for the NICTS Mortgages Action for Possession module.
+
+Tests use real data downloaded from justice-ni.gov.uk (no mocks). Network
+calls are made once per class via ``scope="class"`` fixtures and cached for
+the duration of the test session. Validation edge cases are covered by
+network-free unit tests.
+"""
+
+import pandas as pd
+import pytest
+
+from bolster.data_sources.justice import mortgages
+from bolster.data_sources.justice.mortgages import (
+    MortgagesDataNotFoundError,
+    MortgagesValidationError,
+)
+
+
+class TestCasesReceivedIntegrity:
+    """Integrity tests for the cases-received table (Table 1)."""
+
+    @pytest.fixture(scope="class")
+    def latest_data(self):
+        return mortgages.get_cases_received()
+
+    def test_required_columns(self, latest_data):
+        expected = {"year", "quarter", "period", "applications", "annual_total", "annual_pct_change"}
+        assert expected.issubset(set(latest_data.columns))
+
+    def test_not_empty(self, latest_data):
+        assert not latest_data.empty
+
+    def test_quarter_values(self, latest_data):
+        assert set(latest_data["quarter"].unique()) == {"Q1", "Q2", "Q3", "Q4"}
+
+    def test_value_ranges(self, latest_data):
+        values = latest_data["applications"].dropna()
+        assert (values >= 0).all()
+        # Peak quarter was ~1100; allow generous headroom but catch parse errors
+        assert values.max() < 5000
+
+    def test_historical_coverage_from_2007(self, latest_data):
+        assert latest_data["year"].min() == 2007
+
+    def test_recent_coverage(self, latest_data):
+        assert latest_data["year"].max() >= 2024
+
+    def test_year_dtype_integer(self, latest_data):
+        assert pd.api.types.is_integer_dtype(latest_data["year"])
+
+    def test_period_dtype(self, latest_data):
+        assert isinstance(latest_data["period"].dtype, pd.PeriodDtype)
+
+    def test_2009_peak_year(self, latest_data):
+        """2009 was the documented peak year (~3,906 annual applications)."""
+        peak = latest_data.groupby("year")["annual_total"].first().idxmax()
+        assert peak == 2009
+
+    def test_validate_passes(self, latest_data):
+        assert mortgages.validate_data(latest_data) is True
+
+
+class TestCasesDisposedIntegrity:
+    """Integrity tests for the cases-disposed table (Table 2)."""
+
+    @pytest.fixture(scope="class")
+    def latest_data(self):
+        return mortgages.get_cases_disposed()
+
+    def test_required_columns(self, latest_data):
+        expected = {"year", "quarter", "period", "applications", "annual_total", "annual_pct_change"}
+        assert expected.issubset(set(latest_data.columns))
+
+    def test_value_ranges(self, latest_data):
+        values = latest_data["applications"].dropna()
+        assert (values >= 0).all()
+
+    def test_historical_coverage_from_2007(self, latest_data):
+        assert latest_data["year"].min() == 2007
+
+    def test_validate_passes(self, latest_data):
+        assert mortgages.validate_data(latest_data) is True
+
+
+class TestFinalOrdersIntegrity:
+    """Integrity tests for the final-orders table (Table 3)."""
+
+    @pytest.fixture(scope="class")
+    def latest_data(self):
+        return mortgages.get_final_orders()
+
+    def test_required_columns(self, latest_data):
+        expected = {"order_type", "year", "quarter", "period", "count"}
+        assert expected.issubset(set(latest_data.columns))
+
+    def test_not_empty(self, latest_data):
+        assert not latest_data.empty
+
+    def test_has_possession_order_type(self, latest_data):
+        assert "Possession" in set(latest_data["order_type"])
+
+    def test_has_total_row(self, latest_data):
+        assert "Total" in set(latest_data["order_type"])
+
+    def test_coverage_from_2017(self, latest_data):
+        assert latest_data["year"].min() == 2017
+
+    def test_counts_non_negative(self, latest_data):
+        counts = latest_data["count"].dropna()
+        assert (counts >= 0).all()
+
+
+class TestCrossValidation:
+    """Cross-checks between received/disposed datasets."""
+
+    @pytest.fixture(scope="class")
+    def all_data(self):
+        return mortgages.get_latest_data()
+
+    def test_received_and_disposed_share_years(self, all_data):
+        received_years = set(all_data["received"]["year"])
+        disposed_years = set(all_data["disposed"]["year"])
+        assert received_years == disposed_years
+
+    def test_received_and_disposed_same_shape(self, all_data):
+        assert all_data["received"].shape[0] == all_data["disposed"].shape[0]
+
+    def test_all_three_tables_present(self, all_data):
+        assert {"received", "disposed", "final_orders"}.issubset(set(all_data))
+
+
+class TestPublicationDiscovery:
+    """Tests for locating the latest publication."""
+
+    def test_latest_url_is_ods(self):
+        url = mortgages.get_latest_publication_url()
+        assert url.lower().endswith(".ods")
+        assert url.startswith("https://")
+
+
+class TestValidation:
+    """Unit tests for validation edge cases - no network calls needed."""
+
+    def _valid_frame(self, n_years: int = 15) -> pd.DataFrame:
+        records = []
+        for year in range(2007, 2007 + n_years):
+            for q in ["Q1", "Q2", "Q3", "Q4"]:
+                records.append(
+                    {
+                        "year": year,
+                        "quarter": q,
+                        "period": pd.Period(f"{year}{q}", freq="Q"),
+                        "applications": 100,
+                        "annual_total": 400,
+                        "annual_pct_change": 0.0,
+                    }
+                )
+        return pd.DataFrame.from_records(records)
+
+    def test_validate_good_dataframe(self):
+        assert mortgages.validate_data(self._valid_frame()) is True
+
+    def test_validate_empty_dataframe(self):
+        with pytest.raises(MortgagesValidationError, match="empty"):
+            mortgages.validate_data(pd.DataFrame())
+
+    def test_validate_none_dataframe(self):
+        with pytest.raises(MortgagesValidationError, match="empty"):
+            mortgages.validate_data(None)
+
+    def test_validate_missing_columns(self):
+        df = self._valid_frame().drop(columns=["applications"])
+        with pytest.raises(MortgagesValidationError, match="Missing required columns"):
+            mortgages.validate_data(df)
+
+    def test_validate_too_few_records(self):
+        df = self._valid_frame(n_years=2)  # only 8 rows
+        with pytest.raises(MortgagesValidationError, match="Too few records"):
+            mortgages.validate_data(df)
+
+    def test_validate_negative_values(self):
+        df = self._valid_frame()
+        df.loc[0, "applications"] = -5
+        with pytest.raises(MortgagesValidationError, match="Negative values"):
+            mortgages.validate_data(df)
+
+    def test_validate_year_out_of_bounds(self):
+        df = self._valid_frame()
+        df.loc[0, "year"] = 1990
+        with pytest.raises(MortgagesValidationError, match="Year range out of bounds"):
+            mortgages.validate_data(df)
+
+    def test_validate_custom_value_col(self):
+        df = self._valid_frame().rename(columns={"applications": "count"})
+        assert mortgages.validate_data(df, value_col="count") is True
+
+
+class TestPeriodLabelParsing:
+    """Unit tests for the final-orders column label parser - no network."""
+
+    def test_parse_quarterly_label(self):
+        year, quarter, period = mortgages._parse_period_label("2025 Q1")
+        assert (year, quarter) == (2025, "Q1")
+        assert period == pd.Period("2025Q1", freq="Q")
+
+    def test_parse_annual_label_int_like(self):
+        year, quarter, period = mortgages._parse_period_label("2017")
+        assert (year, quarter) == (2017, None)
+        assert period == pd.Period("2017", freq="Y")
+
+    def test_parse_annual_label_float_like(self):
+        year, quarter, period = mortgages._parse_period_label("2018.0")
+        assert (year, quarter) == (2018, None)
+
+    def test_parse_unrecognised_label(self):
+        assert mortgages._parse_period_label("Final Order") == (None, None, None)
+
+
+class TestSafeConverters:
+    """Unit tests for the safe cell converters - no network."""
+
+    def test_safe_int_blank(self):
+        assert mortgages._safe_int("") is None
+        assert mortgages._safe_int("-") is None
+        assert mortgages._safe_int(None) is None
+        assert mortgages._safe_int(float("nan")) is None
+
+    def test_safe_int_numeric(self):
+        assert mortgages._safe_int("42") == 42
+        assert mortgages._safe_int(42.0) == 42
+
+    def test_safe_int_garbage(self):
+        assert mortgages._safe_int("abc") is None
+
+    def test_safe_float_blank(self):
+        assert mortgages._safe_float("-") is None
+        assert mortgages._safe_float(None) is None
+
+    def test_safe_float_numeric(self):
+        assert mortgages._safe_float("0.5") == 0.5
+
+    def test_safe_float_garbage(self):
+        assert mortgages._safe_float("xyz") is None
+
+
+class TestErrorPaths:
+    """Tests for error handling without heavy network use."""
+
+    def test_get_final_orders_raises_when_absent(self, monkeypatch):
+        """If a bulletin lacks final orders, get_final_orders should raise."""
+
+        def fake_latest(force_refresh=False):
+            return {"received": pd.DataFrame(), "disposed": pd.DataFrame()}
+
+        monkeypatch.setattr(mortgages, "get_latest_data", fake_latest)
+        with pytest.raises(MortgagesDataNotFoundError, match="not available"):
+            mortgages.get_final_orders()


### PR DESCRIPTION
## Summary

- Adds a new `justice` subpackage under `data_sources/`
- `justice/mortgages.py` scrapes justice-ni.gov.uk for NICTS Mortgages Actions for Possession ODS files (Q1 2007–present)
- Returns three tidy DataFrames: `received`, `disposed`, `final_orders`
- CLI command: `bolster justice mortgages`
- 43 tests (real data integrity + unit validation, no mocks)
- 90.26% coverage on new module

## Key insights from the data

- Applications have collapsed **75%** from a 2009 peak of 3,906 to 979 in 2025
- In 2025, courts disposed of **more cases than received** (1,037 vs 979) — actively clearing the backlog
- Final orders rebounded from a COVID-moratorium low of 212 (2021) to **966 in 2025**, the post-moratorium unwinding now complete
- **Possession rate per 1,000 sales hit 39.4 in 2025** — the highest in the dataset window — despite record house prices; cross-referencing with `ni_house_price_index` suggests the post-2022 interest rate shock is hitting leveraged borrowers even as headline prices remain elevated

## Cross-dataset correlation (vs `ni_house_price_index`)

| Year | Applications | Final Orders | Avg Price | Sales Vol | Possessions/1k sales |
|------|-------------|--------------|-----------|-----------|----------------------|
| 2021 | 509 | 212 | £147k | 30,774 | 6.9 |
| 2023 | 978 | 519 | £166k | 22,051 | 23.5 |
| 2025 | 979 | 966 | £189k | 24,492 | 39.4 |

Interest rate and inflation data identified as a useful companion series — see #1851.

## Test plan

- [x] `uv run pytest tests/test_justice_mortgages_integrity.py -q --no-cov` — 43 passed
- [x] `uv run pytest tests/ -q --no-cov` — 1560 passed, 7 skipped (no regressions)
- [x] `uv run pre-commit run --all-files` — all checks passed
- [x] Coverage on new module: 90.26%

🤖 Generated with [Claude Code](https://claude.com/claude-code)