### PR TITLE
feat: dispatch bolster-release event to mcp.bolster.online on release

### DIFF
--- a/.github/workflows/notify-mcp-server.yml
+++ b/.github/workflows/notify-mcp-server.yml
@@ -1,0 +1,25 @@
+name: 🔔 Notify MCP Server of Release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  dispatch:
+    name: Trigger mcp.bolster.online upgrade
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.MCP_DISPATCH_TOKEN }}
+          script: |
+            await github.rest.repos.createDispatchEvent({
+              owner: 'andrewbolster',
+              repo: 'mcp.bolster.online',
+              event_type: 'bolster-release',
+              client_payload: {
+                version: context.payload.release.tag_name,
+                release_url: context.payload.release.html_url
+              }
+            })
+            core.info(`Dispatched bolster-release event for ${context.payload.release.tag_name}`)

--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@ The [GOV.UK NISRA statistics RSS feed](https://www.gov.uk/search/research-and-st
 | Disease Prevalence Registers (PHA/DoH) | `nisra.disease_prevalence` | ✅ |
 | PSNI Stop & Search (OpenDataNI) | `psni.stop_and_search` | ✅ |
 | PSNI PACE Stop & Search / Arrests | `psni.pace` | ✅ |
+| Bank of England Base Rate | `boe_base_rate` | ✅ |
 | Security Situation Statistics | - | ❌ Cloudflare-blocked |
 | Anti-social Behaviour | - | ❌ Cloudflare-blocked |
 | Domestic Abuse Incidents/Crimes | - | ❌ Cloudflare-blocked |

--- a/src/bolster/cli.py
+++ b/src/bolster/cli.py
@@ -12,6 +12,8 @@ from rich.text import Text
 
 from . import __version__
 from .data_sources import dva, education_suspensions, gender_pay_gap
+from .data_sources.boe_base_rate import get_latest_data as get_boe_base_rate
+from .data_sources.boe_base_rate import get_rate_changes as get_boe_rate_changes
 from .data_sources.cineworld import get_cinema_listings
 from .data_sources.companies_house import get_companies_house_records_that_might_be_in_farset, query_basic_company_data
 from .data_sources.daera_waste import get_latest_waste_statistics, validate_waste_data
@@ -6551,6 +6553,78 @@ def justice_mortgages_cmd(table, output_format, force_refresh, save, summary):
         raise click.Abort() from e
 
 
+@cli.command(name="boe-base-rate")
+@click.option(
+    "--resolution",
+    type=click.Choice(["daily", "monthly", "quarterly", "annual"], case_sensitive=False),
+    default="monthly",
+    help="Time resolution (default: monthly).",
+)
+@click.option(
+    "--changes",
+    is_flag=True,
+    help="Show the event-based history of rate changes (back to 1694) instead of the level series.",
+)
+@click.option("--year", type=int, help="Filter data to a single calendar year.")
+@click.option(
+    "--format",
+    "output_format",
+    type=click.Choice(["csv", "json"], case_sensitive=False),
+    default="csv",
+    help="Output format (default: csv).",
+)
+@click.option("--force-refresh", is_flag=True, help="Bypass cache and re-download.")
+@click.option("--save", help="Save data to a file (specify filename).")
+def boe_base_rate_cmd(resolution, changes, year, output_format, force_refresh, save):
+    """Bank of England official Bank Rate (base rate).
+
+    Retrieves the unified UK base rate from the Bank of England's published
+    spreadsheet. The daily level series runs back to 1973; the event-based
+    history of rate changes (--changes) runs back to 1694.
+
+    The level series shares a fixed schema with the other macroeconomic
+    modules (date, year, quarter, month, resolution, series, value, unit,
+    geography, source) so it can be joined against inflation and other series.
+
+    Examples:
+        bolster boe-base-rate --resolution monthly
+        bolster boe-base-rate --resolution annual --year 2024
+        bolster boe-base-rate --changes --format json --save changes.json
+
+    Source:
+        https://www.bankofengland.co.uk/boeapps/database/Bank-Rate.asp
+    """
+    console = Console()
+    try:
+        if changes:
+            data = get_boe_rate_changes(force_refresh=force_refresh)
+        else:
+            data = get_boe_base_rate(resolution=resolution, force_refresh=force_refresh)
+
+        if year:
+            data = data[data["year"] == year]
+
+        if save:
+            if output_format == "json":
+                data.astype(str).to_json(save, orient="records", indent=2)
+            else:
+                data.to_csv(save, index=False)
+            console.print(f"[green]Saved {len(data)} rows to {save}[/green]")
+            return
+
+        if output_format == "json":
+            click.echo(data.astype(str).to_json(orient="records", indent=2))
+        else:
+            console.print(data.to_csv(index=False), end="")
+
+    except Exception as e:
+        console.print(f"[bold red]Error:[/bold red] {str(e)}", style="red")
+        console.print("\n[yellow]Troubleshooting:[/yellow]")
+        console.print("   - Check your internet connection")
+        console.print("   - Try again with --force-refresh to bypass cache")
+        raise click.Abort() from e
+
+
 @cli.command()
 def list_sources():
     """List all available data sources and their descriptions.
@@ -6632,6 +6706,7 @@ def list_sources():
     click.echo("  dva                        DVA monthly test statistics (vehicle, driver, theory)")
     click.echo("  education suspensions      NI school suspensions and expulsions (DE)")
     click.echo("  gender-pay-gap             UK Gender Pay Gap Reporting service")
+    click.echo("  boe-base-rate              Bank of England official Bank Rate (base rate)")
 
     click.echo("\nUSAGE EXAMPLES")
     click.echo("  bolster water-quality BT1 5GS              # Water quality by postcode")

--- a/src/bolster/data_sources/__init__.py
+++ b/src/bolster/data_sources/__init__.py
@@ -12,6 +12,8 @@ Various scrapers and API wrappers for NI government data:
 - gender_pay_gap: UK Gender Pay Gap reporting data (all employers 250+, 2017–present)
 - nisra: NISRA statistics (deaths, births, labour market, population, etc.)
 - justice: NI Department of Justice / NICTS statistics (mortgage possession actions)
+- ons_cpi: ONS UK inflation indices (CPI, CPIH, RPI)
+- boe_base_rate: Bank of England official Bank Rate (base rate)
 
 Most have corresponding CLI commands.
 """

--- a/src/bolster/data_sources/boe_base_rate.py
+++ b/src/bolster/data_sources/boe_base_rate.py
@@ -1,0 +1,428 @@
+"""Bank of England official Bank Rate (base rate).
+
+Wraps the Bank of England's published base-rate spreadsheet to provide
+standardised access to the UK policy interest rate:
+
+- A **unified daily rate** series back to 1973, formed by coalescing the
+  successive rate regimes the BoE has used (Minimum Lending Rate, Minimum
+  Band 1 Dealing Rate, Repo Rate and the current Official Bank Rate) into a
+  single continuous level.
+- An **event-based history of rate changes** back to 1694, exposed via
+  :func:`get_rate_changes`.
+
+The base rate is a *level* (a standing interest rate), not a flow, so when it
+is resampled to coarser resolutions the **last observation** in each period is
+used rather than a sum or mean.
+
+This is the second of three macroeconomic context modules and emits the same
+**fixed output schema** as :mod:`bolster.data_sources.ons_cpi`, so that the
+macro series can be joined and resampled against one another:
+
+==========  ==========================================================
+Column      Description
+==========  ==========================================================
+date        ``datetime64[ns]`` period-start (Jan 2024 -> 2024-01-01,
+            Q1 2024 -> 2024-01-01, year 2024 -> 2024-01-01,
+            a daily observation keeps its own date)
+year        ``int`` calendar year
+quarter     ``str`` "Q1".."Q4", or ``pd.NA`` for annual/monthly/daily
+month       ``int`` 1-12, or ``pd.NA`` for quarterly/annual/daily
+resolution  ``str`` "daily" | "monthly" | "quarterly" | "annual"
+series      ``str`` always "base_rate"
+value       ``float`` rate in per-cent
+unit        ``str`` always "%"
+geography   ``str`` always "UK"
+source      ``str`` always "BoE"
+==========  ==========================================================
+
+.. note::
+    The Bank of England's dynamic statistics API
+    (``/boe-apps/statistics-api/``, ``/boe-apps/sdw/``) returns HTTP 403 for
+    automated requests. The static spreadsheet linked below is the only
+    reliable programmatic route and is what this module uses.
+
+Source:
+    https://www.bankofengland.co.uk/boeapps/database/Bank-Rate.asp
+
+Example:
+    >>> from bolster.data_sources import boe_base_rate
+    >>> df = boe_base_rate.get_latest_data(resolution="annual")  # doctest: +SKIP
+    >>> sorted(df.columns)  # doctest: +SKIP
+    ['date', 'geography', 'month', 'quarter', 'resolution', 'series', 'source', 'unit', 'value', 'year']
+"""
+
+import io
+import logging
+
+import pandas as pd
+
+from bolster.utils.web import session
+
+logger = logging.getLogger(__name__)
+
+#: Static XLS published by the Bank of England (Excel 97-2003, needs ``xlrd``).
+DATA_URL = "https://www.bankofengland.co.uk/-/media/boe/files/monetary-policy/baserate.xls"
+
+#: Sheet holding the daily series (one column per historical rate regime).
+RAW_DATA_SHEET = "Raw Data"
+
+#: Sheet holding the irregular event-based rate changes since 1694.
+HISTORICAL_SHEET = "HISTORICAL SINCE 1694"
+
+#: Geography for all series exposed by this module.
+GEOGRAPHY = "UK"
+
+#: Data publisher.
+SOURCE = "BoE"
+
+#: Series identifier used across the macroeconomic modules.
+SERIES = "base_rate"
+
+#: Unit of the rate.
+UNIT = "%"
+
+#: Output schema column order shared across all macroeconomic modules.
+SCHEMA_COLUMNS = [
+    "date",
+    "year",
+    "quarter",
+    "month",
+    "resolution",
+    "series",
+    "value",
+    "unit",
+    "geography",
+    "source",
+]
+
+#: Schema for :func:`get_rate_changes` (no period-resolution context).
+RATE_CHANGES_COLUMNS = [
+    "date",
+    "year",
+    "series",
+    "value",
+    "unit",
+    "geography",
+    "source",
+]
+
+#: Supported resolutions and how the period start maps to ``quarter``/``month``.
+RESOLUTIONS = ("daily", "monthly", "quarterly", "annual")
+
+#: Columns on the "Raw Data" sheet that carry a rate level (coalesced L->R).
+_RATE_COLUMNS = [
+    "Bank Rate",
+    "Min Lending Rate",
+    "Min Band 1 Dealing Rate",
+    "Repo Rate",
+    "Official Bank Rate",
+]
+
+#: Three-letter month abbreviation -> month number.
+_MONTH_ABBR_TO_NUM = {
+    "Jan": 1,
+    "Feb": 2,
+    "Mar": 3,
+    "Apr": 4,
+    "May": 5,
+    "Jun": 6,
+    "Jul": 7,
+    "Aug": 8,
+    "Sep": 9,
+    "Oct": 10,
+    "Nov": 11,
+    "Dec": 12,
+}
+
+#: Quarter number -> label.
+_QUARTER_LABELS = {1: "Q1", 2: "Q2", 3: "Q3", 4: "Q4"}
+
+
+class BoEDataError(Exception):
+    """Base exception for Bank of England data errors."""
+
+
+class BoEValidationError(BoEDataError):
+    """Raised when a DataFrame fails :func:`validate_data`."""
+
+
+def _download_workbook(force_refresh: bool = False) -> pd.ExcelFile:
+    """Download the BoE base-rate workbook and return it as an ``ExcelFile``.
+
+    The workbook is a binary ``.xls`` and is therefore not cached by the
+    shared :class:`~bolster.utils.web.CachingSession` (which only caches HTML);
+    ``force_refresh`` is accepted for API parity with the sibling macroeconomic
+    modules but has no effect on this code path.
+
+    Args:
+        force_refresh: Accepted for API parity; binary downloads are not cached.
+
+    Returns:
+        A :class:`pandas.ExcelFile` opened with the ``xlrd`` engine.
+
+    Raises:
+        BoEDataError: If the download fails or the bytes are not a valid xls.
+    """
+    del force_refresh  # Binary responses are not cached; nothing to refresh.
+    try:
+        response = session.get(DATA_URL, timeout=60)
+        response.raise_for_status()
+        return pd.ExcelFile(io.BytesIO(response.content), engine="xlrd")
+    except Exception as e:  # noqa: BLE001 - re-wrapped as a domain error
+        raise BoEDataError(f"Failed to fetch BoE base rate workbook from {DATA_URL}: {e}") from e
+
+
+def _coalesce_daily(workbook: pd.ExcelFile) -> pd.DataFrame:
+    """Build the unified daily rate series from the "Raw Data" sheet.
+
+    The sheet has one column per successive rate regime; on any given day only
+    the column for the regime then in force is populated. The unified rate is
+    the right-most non-null value across the rate columns for each row.
+
+    Args:
+        workbook: Open BoE workbook.
+
+    Returns:
+        DataFrame with ``date`` (datetime64) and ``value`` (float) columns,
+        sorted by date with one row per calendar day.
+
+    Raises:
+        BoEDataError: If the sheet is missing expected columns or yields no rows.
+    """
+    raw = workbook.parse(sheet_name=RAW_DATA_SHEET, header=1)
+
+    if "Date" not in raw.columns:
+        raise BoEDataError(f"'{RAW_DATA_SHEET}' sheet is missing a 'Date' column; got {list(raw.columns)}")
+
+    present = [c for c in _RATE_COLUMNS if c in raw.columns]
+    if not present:
+        raise BoEDataError(f"'{RAW_DATA_SHEET}' sheet has no recognised rate columns; got {list(raw.columns)}")
+
+    dates = pd.to_datetime(raw["Date"], errors="coerce")
+    # Coerce each regime column to numeric first so the row-wise ffill operates
+    # on float (not object) data, then take the right-most non-null value = the
+    # rate in force that day.
+    rates = raw[present].apply(pd.to_numeric, errors="coerce")
+    value = rates.ffill(axis=1).iloc[:, -1]
+
+    df = pd.DataFrame({"date": dates, "value": pd.to_numeric(value, errors="coerce")})
+    df = df.dropna(subset=["date", "value"]).sort_values("date").reset_index(drop=True)
+
+    if df.empty:
+        raise BoEDataError(f"No usable rows parsed from '{RAW_DATA_SHEET}' sheet")
+
+    df["value"] = df["value"].astype("float64")
+    return df
+
+
+def _empty_frame() -> pd.DataFrame:
+    """Return an empty DataFrame with the canonical schema and dtypes."""
+    df = pd.DataFrame(columns=SCHEMA_COLUMNS)
+    df["date"] = pd.to_datetime(df["date"])
+    df["year"] = df["year"].astype("Int64")
+    df["value"] = df["value"].astype("float64")
+    return df
+
+
+def _attach_schema(df: pd.DataFrame, resolution: str) -> pd.DataFrame:
+    """Attach the shared schema columns to a ``date``/``value`` frame.
+
+    Args:
+        df: Frame with at least ``date`` and ``value`` columns. ``date`` must
+            already be normalised to the period start for the resolution.
+        resolution: One of :data:`RESOLUTIONS`.
+
+    Returns:
+        DataFrame conforming to :data:`SCHEMA_COLUMNS`.
+    """
+    out = df.copy()
+    out["date"] = pd.to_datetime(out["date"])
+    out["year"] = out["date"].dt.year.astype("Int64")
+
+    if resolution == "monthly":
+        out["month"] = out["date"].dt.month.astype("Int64")
+        out["quarter"] = pd.NA
+    elif resolution == "quarterly":
+        out["quarter"] = out["date"].dt.quarter.map(_QUARTER_LABELS)
+        out["month"] = pd.NA
+    else:  # daily and annual carry neither a quarter nor a month label
+        out["quarter"] = pd.NA
+        out["month"] = pd.NA
+
+    out["resolution"] = resolution
+    out["series"] = SERIES
+    out["value"] = out["value"].astype("float64")
+    out["unit"] = UNIT
+    out["geography"] = GEOGRAPHY
+    out["source"] = SOURCE
+    return out[SCHEMA_COLUMNS].reset_index(drop=True)
+
+
+def get_latest_data(resolution: str = "monthly", force_refresh: bool = False) -> pd.DataFrame:
+    """Fetch the unified UK base rate at a given resolution.
+
+    The base rate is a standing level, so coarser resolutions take the **last
+    observation** in each period (i.e. the rate in force at period end).
+
+    Args:
+        resolution: "daily", "monthly" (default), "quarterly" or "annual".
+        force_refresh: Accepted for API parity; binary downloads are not cached.
+
+    Returns:
+        DataFrame conforming to :data:`SCHEMA_COLUMNS`, sorted by ``date``.
+
+    Raises:
+        ValueError: If ``resolution`` is not recognised.
+        BoEDataError: If the workbook download or parse fails.
+
+    Example:
+        >>> df = get_latest_data(resolution="annual")  # doctest: +SKIP
+        >>> df.iloc[-1][["series", "unit", "geography", "source"]].tolist()  # doctest: +SKIP
+        ['base_rate', '%', 'UK', 'BoE']
+    """
+    if resolution not in RESOLUTIONS:
+        raise ValueError(f"Unknown resolution {resolution!r}. Valid: {sorted(RESOLUTIONS)}")
+
+    workbook = _download_workbook(force_refresh=force_refresh)
+    daily = _coalesce_daily(workbook)
+
+    if daily.empty:
+        return _empty_frame()
+
+    if resolution == "daily":
+        return _attach_schema(daily, "daily")
+
+    freq = {"monthly": "MS", "quarterly": "QS", "annual": "YS"}[resolution]
+    # Resample to the period start, taking the last rate observed in the period.
+    resampled = daily.set_index("date")["value"].resample(freq).last().dropna()
+    period = resampled.reset_index()
+    period.columns = ["date", "value"]
+    return _attach_schema(period, resolution)
+
+
+def get_rate_changes(force_refresh: bool = False) -> pd.DataFrame:
+    """Fetch the event-based history of base-rate changes back to 1694.
+
+    Each row is a rate *change* effective on a given date (the value is the new
+    rate). The series is irregular by nature. Where the source records only a
+    year and month (the earliest entries pre-date daily records), the change is
+    dated to the first of that month.
+
+    Args:
+        force_refresh: Accepted for API parity; binary downloads are not cached.
+
+    Returns:
+        DataFrame with columns :data:`RATE_CHANGES_COLUMNS`, sorted by ``date``.
+
+    Raises:
+        BoEDataError: If the workbook download or parse fails, or no changes
+            could be parsed.
+
+    Example:
+        >>> df = get_rate_changes()  # doctest: +SKIP
+        >>> df.iloc[0][["date", "value"]].tolist()  # doctest: +SKIP
+        [Timestamp('1694-10-01 00:00:00'), 6.0]
+    """
+    workbook = _download_workbook(force_refresh=force_refresh)
+    raw = workbook.parse(sheet_name=HISTORICAL_SHEET, header=None)
+
+    # Columns: 0=year, 1=day, 2=month abbr, 3=new rate. Year is sparse (only
+    # filled on the first change of each year) so it is forward-filled.
+    cols = raw.iloc[:, [0, 1, 2, 3]].copy()
+    cols.columns = ["year", "day", "month", "value"]
+    cols["year"] = cols["year"].ffill()
+
+    cols["mnum"] = cols["month"].astype(str).str.strip().str[:3].str.title().map(_MONTH_ABBR_TO_NUM)
+    cols = cols[cols["mnum"].notna()].copy()  # drops header rows and footnotes
+
+    cols["day"] = pd.to_numeric(cols["day"], errors="coerce").fillna(1).astype(int)
+    cols["year"] = pd.to_numeric(cols["year"], errors="coerce")
+    cols["value"] = pd.to_numeric(cols["value"], errors="coerce")
+    cols = cols.dropna(subset=["year", "value"])
+
+    cols["date"] = pd.to_datetime(
+        {"year": cols["year"].astype(int), "month": cols["mnum"].astype(int), "day": cols["day"]},
+        errors="coerce",
+    )
+    cols = cols.dropna(subset=["date"]).sort_values("date").reset_index(drop=True)
+
+    if cols.empty:
+        raise BoEDataError(f"No rate changes parsed from '{HISTORICAL_SHEET}' sheet")
+
+    out = pd.DataFrame(
+        {
+            "date": cols["date"],
+            "year": cols["date"].dt.year.astype("Int64"),
+            "series": SERIES,
+            "value": cols["value"].astype("float64"),
+            "unit": UNIT,
+            "geography": GEOGRAPHY,
+            "source": SOURCE,
+        }
+    )
+    return out[RATE_CHANGES_COLUMNS].reset_index(drop=True)
+
+
+def validate_data(df: pd.DataFrame) -> bool:
+    """Validate that a DataFrame conforms to the macroeconomic schema.
+
+    Checks performed:
+
+    - All :data:`SCHEMA_COLUMNS` are present.
+    - At least one row is present.
+    - ``geography`` is exclusively "UK" and ``source`` exclusively "BoE".
+    - ``series`` is exclusively "base_rate" and ``unit`` exclusively "%".
+    - ``resolution`` only contains known values.
+    - ``value`` is numeric, non-null and within a sane 0-25 %% range.
+
+    Args:
+        df: DataFrame to validate.
+
+    Returns:
+        ``True`` if all checks pass.
+
+    Raises:
+        BoEValidationError: If any check fails.
+
+    Example:
+        >>> df = get_latest_data(resolution="annual")  # doctest: +SKIP
+        >>> validate_data(df)  # doctest: +SKIP
+        True
+    """
+    missing = [c for c in SCHEMA_COLUMNS if c not in df.columns]
+    if missing:
+        raise BoEValidationError(f"Missing required columns: {missing}")
+
+    if len(df) == 0:
+        raise BoEValidationError("DataFrame is empty")
+
+    bad_geo = set(df["geography"].unique()) - {GEOGRAPHY}
+    if bad_geo:
+        raise BoEValidationError(f"Unexpected geography values: {bad_geo}")
+
+    bad_source = set(df["source"].unique()) - {SOURCE}
+    if bad_source:
+        raise BoEValidationError(f"Unexpected source values: {bad_source}")
+
+    bad_series = set(df["series"].unique()) - {SERIES}
+    if bad_series:
+        raise BoEValidationError(f"Unexpected series values: {bad_series}")
+
+    bad_unit = set(df["unit"].unique()) - {UNIT}
+    if bad_unit:
+        raise BoEValidationError(f"Unexpected unit values: {bad_unit}")
+
+    bad_res = set(df["resolution"].unique()) - set(RESOLUTIONS)
+    if bad_res:
+        raise BoEValidationError(f"Unexpected resolution values: {bad_res}")
+
+    if not pd.api.types.is_numeric_dtype(df["value"]):
+        raise BoEValidationError("Column 'value' must be numeric")
+
+    if df["value"].isna().any():
+        raise BoEValidationError("Column 'value' contains nulls")
+
+    if (df["value"] < 0).any() or (df["value"] > 25).any():
+        raise BoEValidationError("Column 'value' has rates outside the plausible 0-25% range")
+
+    return True

--- a/src/bolster/data_sources/boe_base_rate.py
+++ b/src/bolster/data_sources/boe_base_rate.py
@@ -373,7 +373,7 @@ def validate_data(df: pd.DataFrame) -> bool:
     - ``geography`` is exclusively "UK" and ``source`` exclusively "BoE".
     - ``series`` is exclusively "base_rate" and ``unit`` exclusively "%".
     - ``resolution`` only contains known values.
-    - ``value`` is numeric, non-null and within a sane 0-25 %% range.
+    - ``value`` is numeric, non-null and within a sane 0-25% range.
 
     Args:
         df: DataFrame to validate.

--- a/tests/test_boe_base_rate_integrity.py
+++ b/tests/test_boe_base_rate_integrity.py
@@ -1,0 +1,300 @@
+"""Data-integrity and validation tests for :mod:`bolster.data_sources.boe_base_rate`.
+
+Integrity tests hit the live Bank of England spreadsheet (no mocks) and use
+``scope="class"`` fixtures so the workbook is downloaded once per class.
+Validation tests are pure-Python edge cases that need no network access.
+"""
+
+import pandas as pd
+import pytest
+
+from bolster.data_sources import boe_base_rate
+from bolster.data_sources.boe_base_rate import BoEDataError, BoEValidationError
+
+
+class _StubWorkbook:
+    """Minimal stand-in for ``pandas.ExcelFile`` exposing ``parse(sheet_name)``.
+
+    Lets the parse/coalesce branches be exercised without an xls writer (xlrd
+    can only read .xls and there is no .xls writer in the dev environment).
+    """
+
+    def __init__(self, sheets: dict[str, pd.DataFrame]):
+        self._sheets = sheets
+
+    def parse(self, sheet_name, header=0):  # noqa: ARG002 - header ignored; frames pre-shaped
+        return self._sheets[sheet_name]
+
+
+class TestDataIntegrity:
+    """Live-data checks against the published BoE base-rate workbook."""
+
+    @pytest.fixture(scope="class")
+    def monthly_data(self):
+        return boe_base_rate.get_latest_data(resolution="monthly")
+
+    @pytest.fixture(scope="class")
+    def daily_data(self):
+        return boe_base_rate.get_latest_data(resolution="daily")
+
+    @pytest.fixture(scope="class")
+    def rate_changes(self):
+        return boe_base_rate.get_rate_changes()
+
+    def test_schema_columns(self, monthly_data):
+        assert list(monthly_data.columns) == boe_base_rate.SCHEMA_COLUMNS
+
+    def test_not_empty(self, monthly_data):
+        assert len(monthly_data) > 0
+
+    def test_geography_is_uk(self, monthly_data):
+        assert set(monthly_data["geography"].unique()) == {"UK"}
+
+    def test_source_is_boe(self, monthly_data):
+        assert set(monthly_data["source"].unique()) == {"BoE"}
+
+    def test_series_is_base_rate(self, monthly_data):
+        assert set(monthly_data["series"].unique()) == {"base_rate"}
+
+    def test_unit_is_percent(self, monthly_data):
+        assert set(monthly_data["unit"].unique()) == {"%"}
+
+    def test_rate_reasonable_range(self, monthly_data):
+        # The UK base rate has stayed between 0% and 20% across modern history.
+        assert monthly_data["value"].min() >= 0
+        assert monthly_data["value"].max() <= 20
+
+    def test_value_is_float(self, monthly_data):
+        assert pd.api.types.is_float_dtype(monthly_data["value"])
+
+    def test_no_null_values(self, monthly_data):
+        assert not monthly_data["value"].isna().any()
+
+    def test_monthly_has_month_no_quarter(self, monthly_data):
+        assert monthly_data["month"].notna().all()
+        assert monthly_data["quarter"].isna().all()
+
+    def test_dates_are_period_start(self, monthly_data):
+        # Monthly observations are dated to the first of the month.
+        assert (monthly_data["date"].dt.day == 1).all()
+
+    def test_historical_coverage(self, daily_data):
+        # Daily data must reach back to at least 1973 and forward to recent years.
+        assert daily_data["date"].min() <= pd.Timestamp("1973-01-01")
+        assert daily_data["date"].max() >= pd.Timestamp("2020-01-01")
+
+    def test_daily_resolution_label(self, daily_data):
+        assert set(daily_data["resolution"].unique()) == {"daily"}
+        assert daily_data["quarter"].isna().all()
+        assert daily_data["month"].isna().all()
+
+    def test_resolutions_available(self):
+        for resolution in ("daily", "monthly", "quarterly", "annual"):
+            df = boe_base_rate.get_latest_data(resolution=resolution)
+            assert len(df) > 0
+            assert set(df["resolution"].unique()) == {resolution}
+            assert boe_base_rate.validate_data(df)
+
+    def test_quarterly_labels(self):
+        df = boe_base_rate.get_latest_data(resolution="quarterly")
+        assert set(df["quarter"].dropna().unique()) <= {"Q1", "Q2", "Q3", "Q4"}
+        assert df["month"].isna().all()
+
+    def test_coarser_resolution_has_fewer_rows(self, monthly_data, daily_data):
+        annual = boe_base_rate.get_latest_data(resolution="annual")
+        assert len(annual) < len(monthly_data) < len(daily_data)
+
+    def test_invalid_resolution_raises(self):
+        with pytest.raises(ValueError):
+            boe_base_rate.get_latest_data(resolution="weekly")
+
+    def test_rate_changes_schema(self, rate_changes):
+        assert list(rate_changes.columns) == boe_base_rate.RATE_CHANGES_COLUMNS
+
+    def test_rate_changes_historical_depth(self, rate_changes):
+        # The event history extends back to the 1694 founding-era rate.
+        assert rate_changes["date"].min() <= pd.Timestamp("1700-01-01")
+        assert len(rate_changes) > 500
+
+    def test_rate_changes_sorted_and_valued(self, rate_changes):
+        assert rate_changes["date"].is_monotonic_increasing
+        assert not rate_changes["value"].isna().any()
+        assert rate_changes["value"].between(0, 20).all()
+        assert set(rate_changes["geography"].unique()) == {"UK"}
+        assert set(rate_changes["source"].unique()) == {"BoE"}
+
+    def test_schema_compatible_with_ons_cpi(self, monthly_data):
+        # The two macro modules must share identical schema columns so they can
+        # be concatenated without realigning/introducing NaN columns.
+        ons_like = pd.DataFrame(
+            {
+                "date": [pd.Timestamp("2024-01-01")],
+                "year": pd.array([2024], dtype="Int64"),
+                "quarter": [pd.NA],
+                "month": pd.array([1], dtype="Int64"),
+                "resolution": ["monthly"],
+                "series": ["D7G7"],
+                "value": [3.4],
+                "unit": ["%"],
+                "geography": ["UK"],
+                "source": ["ONS"],
+            }
+        )
+        combined = pd.concat([monthly_data, ons_like], ignore_index=True)
+        assert list(combined.columns) == boe_base_rate.SCHEMA_COLUMNS
+        assert len(combined) == len(monthly_data) + 1
+
+    def test_validate_live_data(self, monthly_data):
+        assert boe_base_rate.validate_data(monthly_data) is True
+
+
+class TestInternals:
+    """Unit tests for parse/coalesce helpers using stub workbooks (no network)."""
+
+    def test_coalesce_takes_rightmost_non_null(self):
+        raw = pd.DataFrame(
+            {
+                "Date": pd.to_datetime(["1973-01-01", "2003-02-06", "2024-01-01"]),
+                "Bank Rate": [9.0, None, None],
+                "Min Lending Rate": [None, None, None],
+                "Min Band 1 Dealing Rate": [None, None, None],
+                "Repo Rate": [None, 3.75, None],
+                "Official Bank Rate": [None, None, 5.25],
+            }
+        )
+        wb = _StubWorkbook({boe_base_rate.RAW_DATA_SHEET: raw})
+        daily = boe_base_rate._coalesce_daily(wb)
+        assert daily["value"].tolist() == [9.0, 3.75, 5.25]
+        assert pd.api.types.is_float_dtype(daily["value"])
+
+    def test_coalesce_missing_date_column_raises(self):
+        raw = pd.DataFrame({"Bank Rate": [9.0]})
+        wb = _StubWorkbook({boe_base_rate.RAW_DATA_SHEET: raw})
+        with pytest.raises(BoEDataError, match="Date"):
+            boe_base_rate._coalesce_daily(wb)
+
+    def test_coalesce_no_rate_columns_raises(self):
+        raw = pd.DataFrame({"Date": pd.to_datetime(["1973-01-01"]), "Zero line": [0]})
+        wb = _StubWorkbook({boe_base_rate.RAW_DATA_SHEET: raw})
+        with pytest.raises(BoEDataError, match="rate columns"):
+            boe_base_rate._coalesce_daily(wb)
+
+    def test_coalesce_all_null_rows_raises(self):
+        raw = pd.DataFrame(
+            {
+                "Date": pd.to_datetime([None, None]),
+                "Bank Rate": [None, None],
+                "Official Bank Rate": [None, None],
+            }
+        )
+        wb = _StubWorkbook({boe_base_rate.RAW_DATA_SHEET: raw})
+        with pytest.raises(BoEDataError, match="No usable rows"):
+            boe_base_rate._coalesce_daily(wb)
+
+    def test_empty_frame_has_schema_and_dtypes(self):
+        df = boe_base_rate._empty_frame()
+        assert list(df.columns) == boe_base_rate.SCHEMA_COLUMNS
+        assert len(df) == 0
+        assert pd.api.types.is_datetime64_any_dtype(df["date"])
+        assert pd.api.types.is_float_dtype(df["value"])
+
+    def test_attach_schema_daily(self):
+        src = pd.DataFrame({"date": pd.to_datetime(["2024-06-15"]), "value": [5.25]})
+        out = boe_base_rate._attach_schema(src, "daily")
+        assert list(out.columns) == boe_base_rate.SCHEMA_COLUMNS
+        assert out.loc[0, "resolution"] == "daily"
+        assert pd.isna(out.loc[0, "quarter"])
+        assert pd.isna(out.loc[0, "month"])
+
+    def test_attach_schema_quarterly(self):
+        src = pd.DataFrame({"date": pd.to_datetime(["2024-04-01"]), "value": [5.0]})
+        out = boe_base_rate._attach_schema(src, "quarterly")
+        assert out.loc[0, "quarter"] == "Q2"
+        assert pd.isna(out.loc[0, "month"])
+
+
+class TestValidation:
+    """Unit tests for :func:`validate_data` edge cases (no network calls)."""
+
+    def _valid_frame(self) -> pd.DataFrame:
+        return pd.DataFrame(
+            {
+                "date": [pd.Timestamp("2024-01-01")],
+                "year": pd.array([2024], dtype="Int64"),
+                "quarter": [pd.NA],
+                "month": pd.array([1], dtype="Int64"),
+                "resolution": ["monthly"],
+                "series": ["base_rate"],
+                "value": [5.25],
+                "unit": ["%"],
+                "geography": ["UK"],
+                "source": ["BoE"],
+            }
+        )
+
+    def test_validate_valid_frame(self):
+        assert boe_base_rate.validate_data(self._valid_frame()) is True
+
+    def test_validate_empty_dataframe(self):
+        df = self._valid_frame().iloc[0:0]
+        with pytest.raises(BoEValidationError, match="empty"):
+            boe_base_rate.validate_data(df)
+
+    def test_validate_missing_columns(self):
+        df = self._valid_frame().drop(columns=["value"])
+        with pytest.raises(BoEValidationError, match="Missing required columns"):
+            boe_base_rate.validate_data(df)
+
+    def test_validate_bad_geography(self):
+        df = self._valid_frame()
+        df["geography"] = "IE"
+        with pytest.raises(BoEValidationError, match="geography"):
+            boe_base_rate.validate_data(df)
+
+    def test_validate_bad_source(self):
+        df = self._valid_frame()
+        df["source"] = "ECB"
+        with pytest.raises(BoEValidationError, match="source"):
+            boe_base_rate.validate_data(df)
+
+    def test_validate_bad_series(self):
+        df = self._valid_frame()
+        df["series"] = "cpi"
+        with pytest.raises(BoEValidationError, match="series"):
+            boe_base_rate.validate_data(df)
+
+    def test_validate_bad_unit(self):
+        df = self._valid_frame()
+        df["unit"] = "bps"
+        with pytest.raises(BoEValidationError, match="unit"):
+            boe_base_rate.validate_data(df)
+
+    def test_validate_bad_resolution(self):
+        df = self._valid_frame()
+        df["resolution"] = "weekly"
+        with pytest.raises(BoEValidationError, match="resolution"):
+            boe_base_rate.validate_data(df)
+
+    def test_validate_non_numeric_value(self):
+        df = self._valid_frame()
+        df["value"] = "high"
+        with pytest.raises(BoEValidationError, match="numeric"):
+            boe_base_rate.validate_data(df)
+
+    def test_validate_null_value(self):
+        df = self._valid_frame()
+        df["value"] = pd.array([None], dtype="Float64").astype("float64")
+        with pytest.raises(BoEValidationError, match="nulls"):
+            boe_base_rate.validate_data(df)
+
+    def test_validate_negative_values(self):
+        df = self._valid_frame()
+        df["value"] = -1.0
+        with pytest.raises(BoEValidationError, match="0-25"):
+            boe_base_rate.validate_data(df)
+
+    def test_validate_implausibly_high_value(self):
+        df = self._valid_frame()
+        df["value"] = 99.0
+        with pytest.raises(BoEValidationError, match="0-25"):
+            boe_base_rate.validate_data(df)


### PR DESCRIPTION
## Summary

Adds a workflow that fires when a bolster GitHub release is published, dispatching a `bolster-release` event to `andrewbolster/mcp.bolster.online` so it can automatically open a dependency bump PR.

## Setup required

Add `MCP_DISPATCH_TOKEN` as a repository secret in this repo:
- Go to Settings → Secrets and variables → Actions → New repository secret
- Name: `MCP_DISPATCH_TOKEN`
- Value: a fine-grained PAT with `contents: write` and `actions: write` on `andrewbolster/mcp.bolster.online`

## Test plan
- [ ] Add `MCP_DISPATCH_TOKEN` secret
- [ ] Publish a release and verify the dispatch event appears in mcp.bolster.online's Actions tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)