### PR TITLE
feat: dispatch bolster-release event to mcp.bolster.online on release

### DIFF
--- a/.github/workflows/notify-mcp-server.yml
+++ b/.github/workflows/notify-mcp-server.yml
@@ -1,0 +1,25 @@
+name: 🔔 Notify MCP Server of Release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  dispatch:
+    name: Trigger mcp.bolster.online upgrade
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.MCP_DISPATCH_TOKEN }}
+          script: |
+            await github.rest.repos.createDispatchEvent({
+              owner: 'andrewbolster',
+              repo: 'mcp.bolster.online',
+              event_type: 'bolster-release',
+              client_payload: {
+                version: context.payload.release.tag_name,
+                release_url: context.payload.release.html_url
+              }
+            })
+            core.info(`Dispatched bolster-release event for ${context.payload.release.tag_name}`)


### PR DESCRIPTION
## Summary

Adds a workflow that fires when a bolster GitHub release is published, dispatching a `bolster-release` event to `andrewbolster/mcp.bolster.online` so it can automatically open a dependency bump PR.

## Setup required

`MCP_DISPATCH_TOKEN` secret already added to this repo (fine-grained PAT with `contents: write`, `pull-requests: write`, and `actions: write` on `andrewbolster/mcp.bolster.online`).

## Test plan
- [ ] Publish a release and verify the dispatch event triggers the upgrade workflow in mcp.bolster.online

🤖 Generated with [Claude Code](https://claude.com/claude-code)