### PR TITLE
chore: run rebase workflow hourly to keep bot PRs up to date

### DIFF
--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -2,6 +2,8 @@ name: Rebase Pull Requests
 on:
     push:
         branches: [main]
+    schedule:
+        - cron: '0 * * * *'  # hourly
     workflow_dispatch:
         inputs:
             pr_number:


### PR DESCRIPTION
## Summary

Adds an hourly schedule trigger to the rebase workflow so that Dependabot
and other bot PRs that fall behind main get rebased automatically — not
just when a human PR merges.

Without this, bot PRs get stuck `BEHIND` indefinitely since the rebase
only fired on push to main, creating a chicken-and-egg situation where
nothing merges because nothing is up to date.

🤖 Generated with [Claude Code](https://claude.com/claude-code)