### PR TITLE
fix: use BOLSTER_TOKEN PAT for auto-merge to trigger downstream workflows

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -33,10 +33,13 @@ jobs:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
             # Enable auto-merge (will only merge when all checks pass)
+            # Uses BOLSTER_TOKEN (PAT) instead of GITHUB_TOKEN so the resulting
+            # push to main triggers downstream workflows (e.g. rebase.yml).
+            # GITHUB_TOKEN-authored pushes are suppressed by GitHub to prevent loops.
             - name: Enable auto-merge for bot PRs
               # For Dependabot: skip major updates (uncomment line below if desired)
               # if: github.actor != 'dependabot[bot]' || steps.dependabot-metadata.outputs.update-type != 'version-update:semver-major'
               run: gh pr merge --auto --squash "$PR_URL"
               env:
                   PR_URL: ${{ github.event.pull_request.html_url }}
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  GITHUB_TOKEN: ${{ secrets.BOLSTER_TOKEN }}


### PR DESCRIPTION
## Summary

Fixes the root cause of Dependabot PRs not triggering `rebase.yml` after merging.

## Problem

`GITHUB_TOKEN`-authored pushes to main are intentionally suppressed by GitHub to prevent recursive workflow loops. When `automerge.yml` used `GITHUB_TOKEN` for `gh pr merge --auto`, the resulting merge commit push didn't trigger `push`-based workflows like `rebase.yml`.

## Fix

Use `BOLSTER_TOKEN` (a fine-grained PAT with `contents: write` + `pull-requests: write` on this repo) for the merge step. PAT-authored pushes are not suppressed and correctly trigger downstream workflows.

The approve step still uses `GITHUB_TOKEN` — that's fine since approval doesn't generate a push.

## Effect

After this merges, every subsequent bot PR merge will trigger `rebase.yml`, keeping other open PRs up to date automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)