### PR TITLE
fix: only auto-release patch versions; minor and major require manual dispatch

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -144,9 +144,11 @@ jobs:
             }
           }
 
-          // Major versions require explicit workflow_dispatch - never auto-release
-          if (versionBump === 'major') {
-            console.log('Breaking change detected - major version requires manual release via workflow_dispatch');
+          // Only patch releases are fully automated.
+          // Minor (feat:) and major (breaking) require explicit workflow_dispatch
+          // to avoid out-of-order version bumps from concurrent PRs.
+          if (versionBump === 'major' || versionBump === 'minor') {
+            console.log(`${versionBump} version detected - requires manual release via workflow_dispatch`);
             core.setOutput('should_release', 'false');
             return;
           }


### PR DESCRIPTION
## Problem

`feat:` commits triggered automatic minor version bumps on every push to main. When multiple feature PRs merged in quick succession (or while a version bump PR was already open), this created competing version PRs — e.g. v0.6.1 and v0.7.0 open simultaneously, breaking the version sequence.

## Fix

Gate `minor` bumps the same way `major` already was — require explicit `workflow_dispatch`. Only `patch` bumps (from `fix:`, `chore:`, `deps:` commits) are fully automated.

To release a new minor version, run the workflow manually:
> Actions → Automated Release → Run workflow → version_bump: minor

## Effect

- `fix:` / `chore:` / `deps:` commits → automatic patch release as before
- `feat:` commits → no automatic release; human triggers minor release when ready
- `BREAKING CHANGE` commits → no automatic release; human triggers major release

🤖 Generated with [Claude Code](https://claude.com/claude-code)