### PR TITLE
feat(niassembly): NI Assembly AIMS — members, questions, votes

### DIFF
--- a/src/bolster/data_sources/__init__.py
+++ b/src/bolster/data_sources/__init__.py
@@ -15,6 +15,7 @@ Various scrapers and API wrappers for NI government data:
 - justice: NI Department of Justice / NICTS statistics (mortgage possession actions)
 - ons_cpi: ONS UK inflation indices (CPI, CPIH, RPI)
 - boe_base_rate: Bank of England official Bank Rate (base rate)
+- niassembly: NI Assembly AIMS — MLAs, Questions, and Votes (OGL v3.0)
 
 Most have corresponding CLI commands.
 """

--- a/src/bolster/data_sources/niassembly/__init__.py
+++ b/src/bolster/data_sources/niassembly/__init__.py
@@ -1,0 +1,29 @@
+"""Northern Ireland Assembly (NIAssembly) AIMS data integration.
+
+Data Source: The Northern Ireland Assembly provides data through the Assembly
+Information Management System (AIMS) API at https://data.niassembly.gov.uk/.
+The API is open (OGL v3.0, no authentication required) and covers Members,
+Questions, Organisations, Plenary business, and Hansard contributions.
+
+Services:
+    - members.asmx  — MLAs, constituencies, parties
+    - questions.asmx — oral/written Q&As since 2007
+    - organisations.asmx — committees, parties, departments
+    - plenary.asmx  — votes/divisions with per-member records
+    - hansard.asmx  — member speech contributions
+
+Submodules:
+    members   — current MLA roster and individual member lookup
+    questions — questions tabled by department or by member
+    votes     — Assembly divisions (votes) with per-member records
+
+Example:
+    >>> from bolster.data_sources.niassembly import members, questions, votes
+    >>> mlas = members.get_current_members()
+    >>> len(mlas) > 85
+    True
+"""
+
+from . import members, questions, votes
+
+__all__ = ["members", "questions", "votes"]

--- a/src/bolster/data_sources/niassembly/members.py
+++ b/src/bolster/data_sources/niassembly/members.py
@@ -1,0 +1,116 @@
+"""NI Assembly Members (MLAs) data module.
+
+Fetches current Member of the Legislative Assembly (MLA) data from the
+NI Assembly AIMS API.  The API returns XML; this module parses it into
+tidy DataFrames.
+
+Update frequency: Real-time (reflects current membership).
+
+Example:
+    >>> from bolster.data_sources.niassembly import members
+    >>> df = members.get_current_members()
+    >>> "PersonId" in df.columns
+    True
+    >>> len(df) >= 85
+    True
+"""
+
+from __future__ import annotations
+
+import logging
+import xml.etree.ElementTree as ET
+
+import pandas as pd
+
+from bolster.utils.web import session
+
+logger = logging.getLogger(__name__)
+
+_BASE_URL = "https://data.niassembly.gov.uk/members.asmx"
+
+
+def _xml_to_records(xml_text: str, list_tag: str, item_tag: str) -> list[dict]:
+    """Parse an XML response from the NI Assembly API into a list of dicts.
+
+    Args:
+        xml_text: Raw XML response text.
+        list_tag: Root element name that contains the items (may be absent for
+            flat structures).
+        item_tag: Element name for each individual record.
+
+    Returns:
+        List of dicts with text content keyed by child tag name.
+    """
+    if not xml_text or not xml_text.strip():
+        return []
+    root = ET.fromstring(xml_text)
+    # The root itself may be the list container, or it may be nested
+    container = root if root.tag == list_tag else root.find(list_tag)
+    if container is None:
+        # Flat structure — root contains items directly
+        container = root
+    records = []
+    for item in container.findall(item_tag):
+        records.append({child.tag: child.text for child in item})
+    return records
+
+
+def get_current_members() -> pd.DataFrame:
+    """Return all current MLAs as a DataFrame.
+
+    Fetches live data from the NI Assembly AIMS API.
+
+    Returns:
+        DataFrame with columns: PersonId, MemberName, MemberFirstName,
+        MemberLastName, MemberFullDisplayName, PartyName,
+        PartyOrganisationId, ConstituencyName, ConstituencyId,
+        MemberTitle, MemberImgUrl, MemberPrefix, AffiliationId,
+        MemberSortName.
+
+    Raises:
+        requests.HTTPError: If the API request fails.
+
+    Example:
+        >>> df = get_current_members()
+        >>> "PartyName" in df.columns
+        True
+        >>> df["PersonId"].dtype == object or df["PersonId"].dtype.kind in "iu"
+        True
+    """
+    url = f"{_BASE_URL}/GetAllCurrentMembers"
+    response = session.get(url, timeout=30)
+    response.raise_for_status()
+    records = _xml_to_records(response.text, "AllMembersList", "Member")
+    if not records:
+        return pd.DataFrame()
+    df = pd.DataFrame(records)
+    # Coerce numeric IDs
+    for col in ("PersonId", "PartyOrganisationId", "ConstituencyId", "AffiliationId"):
+        if col in df.columns:
+            df[col] = pd.to_numeric(df[col], errors="coerce")
+    return df
+
+
+def get_member_by_id(person_id: int) -> pd.DataFrame:
+    """Return a single MLA record by PersonId.
+
+    Filters the full current members list to the requested person.  The AIMS
+    API does not expose a single-member endpoint, so the full list is fetched
+    and filtered locally.
+
+    Args:
+        person_id: NI Assembly AIMS PersonId for the MLA.
+
+    Returns:
+        Single-row DataFrame for the matching member, or an empty DataFrame
+        if not found.
+
+    Example:
+        >>> df = get_member_by_id(5797)
+        >>> len(df) <= 1
+        True
+    """
+    all_members = get_current_members()
+    if all_members.empty:
+        return all_members
+    return all_members[all_members["PersonId"] == person_id].reset_index(drop=True)

--- a/src/bolster/data_sources/niassembly/questions.py
+++ b/src/bolster/data_sources/niassembly/questions.py
@@ -1,0 +1,172 @@
+"""NI Assembly Questions data module.
+
+Fetches oral and written question data from the NI Assembly AIMS API.
+Questions are indexed by department (using the AIMS OrganisationId) or by
+the tabling MLA (PersonId).
+
+The ``GetQuestionsByDepartment`` endpoint accepts a numeric ``departmentId``
+which corresponds to the ``OrganisationId`` returned by
+``organisations.asmx/GetDepartmentListCurrent_JSON``.
+
+Known department IDs (as of 2026):
+    76  DAERA, 78  Education, 79  Economy, 81  Finance,
+    82  Health, 84  Infrastructure, 85  Communities,
+    86  The Executive Office, 134 Justice
+
+Update frequency: Real-time.
+
+Example:
+    >>> from bolster.data_sources.niassembly import questions
+    >>> df = questions.get_questions_by_department(82)
+    >>> len(df) > 100
+    True
+    >>> "QuestionText" in df.columns
+    True
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pandas as pd
+
+from bolster.utils.web import session
+
+logger = logging.getLogger(__name__)
+
+_BASE_URL = "https://data.niassembly.gov.uk/questions.asmx"
+
+# Mapping of common department name fragments to AIMS OrganisationId
+DEPARTMENT_NAME_TO_ID: dict[str, int] = {
+    "Department of Agriculture, Environment and Rural Affairs": 76,
+    "DAERA": 76,
+    "Department of Education": 78,
+    "DE": 78,
+    "Department for the Economy": 79,
+    "DfE": 79,
+    "Department of Finance": 81,
+    "DoF": 81,
+    "Department of Health": 82,
+    "DoH": 82,
+    "Department for Infrastructure": 84,
+    "DfI": 84,
+    "Department for Communities": 85,
+    "DfC": 85,
+    "The Executive Office": 86,
+    "TEO": 86,
+    "Department of Justice": 134,
+    "DoJ": 134,
+}
+
+
+def _resolve_department_id(department: str | int) -> int:
+    """Resolve a department name or ID to an integer AIMS OrganisationId.
+
+    Args:
+        department: Either an integer ID or a string name (full or abbreviation).
+
+    Returns:
+        Integer department (organisation) ID.
+
+    Raises:
+        ValueError: If the name cannot be resolved.
+
+    Example:
+        >>> _resolve_department_id(82)
+        82
+        >>> _resolve_department_id("Department of Health")
+        82
+        >>> _resolve_department_id("DoH")
+        82
+    """
+    if isinstance(department, int):
+        return department
+    # Exact match first
+    if department in DEPARTMENT_NAME_TO_ID:
+        return DEPARTMENT_NAME_TO_ID[department]
+    # Case-insensitive partial match
+    lower = department.lower()
+    for name, dept_id in DEPARTMENT_NAME_TO_ID.items():
+        if lower in name.lower() or name.lower() in lower:
+            return dept_id
+    raise ValueError(
+        f"Cannot resolve department '{department}'. Use an integer ID or one of: {list(DEPARTMENT_NAME_TO_ID.keys())}"
+    )
+
+
+def get_questions_by_department(department: str | int) -> pd.DataFrame:
+    """Return all questions directed to a department as a DataFrame.
+
+    Args:
+        department: Department name (full or abbreviation) or integer
+            AIMS OrganisationId.  E.g. ``"Department of Health"``, ``"DoH"``,
+            or ``82``.
+
+    Returns:
+        DataFrame with columns including DocumentId, Reference, TabledDate,
+        QuestionText, TablerPersonId, TablerName, QOralAnswerRequested.
+        Returns an empty DataFrame if no questions are found.
+
+    Raises:
+        requests.HTTPError: If the API request fails.
+        ValueError: If the department name cannot be resolved.
+
+    Example:
+        >>> df = get_questions_by_department("Department of Health")
+        >>> len(df) > 100
+        True
+        >>> "QuestionText" in df.columns
+        True
+    """
+    dept_id = _resolve_department_id(department)
+    url = f"{_BASE_URL}/GetQuestionsByDepartment_JSON"
+    response = session.get(url, params={"departmentId": dept_id}, timeout=60)
+    response.raise_for_status()
+    data = response.json()
+    questions_list = data.get("QuestionsList") or {}
+    records = questions_list.get("Question") if questions_list else None
+    if not records:
+        return pd.DataFrame()
+    df = pd.DataFrame(records)
+    if "TabledDate" in df.columns:
+        df["TabledDate"] = pd.to_datetime(df["TabledDate"], errors="coerce", utc=True)
+    for col in ("DocumentId", "TablerPersonId", "MinisterPersonId"):
+        if col in df.columns:
+            df[col] = pd.to_numeric(df[col], errors="coerce")
+    return df
+
+
+def get_questions_by_member(person_id: int) -> pd.DataFrame:
+    """Return all questions tabled by an MLA as a DataFrame.
+
+    Args:
+        person_id: NI Assembly AIMS PersonId for the MLA.
+
+    Returns:
+        DataFrame with columns including DocumentId, Reference, TabledDate,
+        QuestionText, DepartmentId, DepartmentName, QOralAnswerRequested.
+        Returns an empty DataFrame if no questions are found.
+
+    Raises:
+        requests.HTTPError: If the API request fails.
+
+    Example:
+        >>> df = get_questions_by_member(5797)
+        >>> len(df) >= 0
+        True
+    """
+    url = f"{_BASE_URL}/GetQuestionsByMember_JSON"
+    response = session.get(url, params={"personId": person_id}, timeout=60)
+    response.raise_for_status()
+    data = response.json()
+    questions_list = data.get("QuestionsList") or {}
+    records = questions_list.get("Question") if questions_list else None
+    if not records:
+        return pd.DataFrame()
+    df = pd.DataFrame(records)
+    if "TabledDate" in df.columns:
+        df["TabledDate"] = pd.to_datetime(df["TabledDate"], errors="coerce", utc=True)
+    for col in ("DocumentId", "TablerPersonId", "DepartmentId"):
+        if col in df.columns:
+            df[col] = pd.to_numeric(df[col], errors="coerce")
+    return df

--- a/src/bolster/data_sources/niassembly/votes.py
+++ b/src/bolster/data_sources/niassembly/votes.py
@@ -1,0 +1,129 @@
+"""NI Assembly Votes / Divisions data module.
+
+Fetches plenary division (vote) records from the NI Assembly AIMS API.
+Divisions are fetched by date range via ``GetVotesOnDivision_JSON`` and
+per-member vote records are fetched via ``GetDivisionMemberVoting``
+(which returns XML).
+
+Update frequency: Real-time.
+
+Example:
+    >>> from bolster.data_sources.niassembly import votes
+    >>> df = votes.get_all_divisions()
+    >>> len(df) > 100
+    True
+    >>> "DivisionDate" in df.columns
+    True
+"""
+
+from __future__ import annotations
+
+import logging
+import xml.etree.ElementTree as ET
+from datetime import date
+
+import pandas as pd
+
+from bolster.utils.web import session
+
+logger = logging.getLogger(__name__)
+
+_BASE_URL = "https://data.niassembly.gov.uk/plenary.asmx"
+
+# Earliest mandate date to search from
+_EARLIEST_DATE = "2007-01-01"
+
+
+def get_all_divisions(
+    start_date: str | None = None,
+    end_date: str | None = None,
+) -> pd.DataFrame:
+    """Return all Assembly divisions (votes) in a date range as a DataFrame.
+
+    Defaults to fetching from the start of the current Assembly mandate
+    (2022-05-01) to today.  Pass explicit dates for a narrower or wider window.
+
+    Args:
+        start_date: ISO-8601 date string (YYYY-MM-DD).  Defaults to
+            ``"2022-05-01"`` (current mandate start).
+        end_date: ISO-8601 date string (YYYY-MM-DD).  Defaults to today.
+
+    Returns:
+        DataFrame with columns: EventID, SessionID, DocumentID, DivisionDate,
+        DivisionSubject, DivisonType, DivisionResult, MemberVoting.
+        Returns an empty DataFrame if no divisions are found.
+
+    Raises:
+        requests.HTTPError: If the API request fails.
+
+    Example:
+        >>> df = get_all_divisions()
+        >>> len(df) >= 0
+        True
+        >>> "DivisionSubject" in df.columns
+        True
+    """
+    if start_date is None:
+        start_date = "2022-05-01"
+    if end_date is None:
+        end_date = date.today().isoformat()
+
+    url = f"{_BASE_URL}/GetVotesOnDivision_JSON"
+    response = session.get(url, params={"startDate": start_date, "endDate": end_date}, timeout=60)
+    response.raise_for_status()
+    data = response.json()
+    division_list = data.get("DivisionList") or {}
+    records = division_list.get("Division") if division_list else None
+    if not records:
+        return pd.DataFrame()
+    df = pd.DataFrame(records)
+    if "DivisionDate" in df.columns:
+        df["DivisionDate"] = pd.to_datetime(df["DivisionDate"], errors="coerce", utc=True)
+    for col in ("EventID", "SessionID", "DocumentID"):
+        if col in df.columns:
+            df[col] = pd.to_numeric(df[col], errors="coerce")
+    return df
+
+
+def get_division_votes(division_id: int) -> pd.DataFrame:
+    """Return per-member voting records for a single division.
+
+    Fetches ``GetDivisionMemberVoting`` (XML) and parses member vote records.
+
+    Args:
+        division_id: NI Assembly AIMS DocumentID for the division.
+
+    Returns:
+        DataFrame with columns: DocumentID, EventID, PersonID, MemberName,
+        Vote, Designation, VoteInVacancy, MemberSortName.
+        Returns an empty DataFrame if no records are found.
+
+    Raises:
+        requests.HTTPError: If the API request fails.
+
+    Example:
+        >>> df = get_division_votes(406283)
+        >>> "Vote" in df.columns
+        True
+        >>> len(df) > 0
+        True
+    """
+    url = f"{_BASE_URL}/GetDivisionMemberVoting"
+    response = session.get(url, params={"documentId": division_id}, timeout=30)
+    response.raise_for_status()
+    xml_text = response.text
+    if not xml_text or not xml_text.strip():
+        return pd.DataFrame()
+    root = ET.fromstring(xml_text)
+    records = []
+    for member in root.findall("Member"):
+        records.append({child.tag: child.text for child in member})
+    if not records:
+        return pd.DataFrame()
+    df = pd.DataFrame(records)
+    for col in ("DocumentID", "EventID", "PersonID"):
+        if col in df.columns:
+            df[col] = pd.to_numeric(df[col], errors="coerce")
+    if "VoteInVacancy" in df.columns:
+        df["VoteInVacancy"] = df["VoteInVacancy"].map({"true": True, "false": False}, na_action="ignore")
+    return df

--- a/tests/test_niassembly_integrity.py
+++ b/tests/test_niassembly_integrity.py
@@ -1,0 +1,307 @@
+"""Integrity tests for the NI Assembly AIMS data source module.
+
+Validates real data quality and structure from the NI Assembly API.
+All network-touching tests use ``scope="class"`` fixtures to minimise
+API calls.  Unit tests in ``TestValidationEdgeCases`` make no network calls.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from bolster.data_sources.niassembly import members, questions, votes
+from bolster.data_sources.niassembly.questions import _resolve_department_id
+
+
+# ── Members ──────────────────────────────────────────────────────────────────
+
+
+class TestCurrentMembers:
+    """Live data integrity tests for the current MLA roster."""
+
+    @pytest.fixture(scope="class")
+    def df(self) -> pd.DataFrame:
+        return members.get_current_members()
+
+    def test_current_members_count(self, df):
+        """Assembly should have 85–100 MLAs (90 is standard)."""
+        assert 85 <= len(df) <= 100, f"Unexpected MLA count: {len(df)}"
+
+    def test_members_schema(self, df):
+        required = {
+            "PersonId",
+            "MemberName",
+            "MemberFirstName",
+            "MemberLastName",
+            "PartyName",
+            "ConstituencyName",
+        }
+        assert required.issubset(set(df.columns)), (
+            f"Missing columns: {required - set(df.columns)}"
+        )
+
+    def test_parties_present(self, df):
+        """Expect at least 5 distinct parties in the Assembly."""
+        parties = df["PartyName"].nunique()
+        assert parties >= 5, f"Too few parties found: {parties}"
+
+    def test_person_ids_unique(self, df):
+        assert df["PersonId"].nunique() == len(df), "Duplicate PersonIds found"
+
+    def test_person_ids_numeric(self, df):
+        assert pd.api.types.is_numeric_dtype(df["PersonId"])
+
+    def test_no_null_member_names(self, df):
+        assert df["MemberName"].notna().all()
+
+    def test_no_null_party_names(self, df):
+        assert df["PartyName"].notna().all()
+
+    def test_no_null_constituency_names(self, df):
+        assert df["ConstituencyName"].notna().all()
+
+    def test_major_parties_present(self, df):
+        parties = set(df["PartyName"].unique())
+        # At least a few well-known NI parties should be present
+        expected_fragments = ["Sinn", "Unionist", "Alliance", "SDLP"]
+        found = [f for f in expected_fragments if any(f in p for p in parties)]
+        assert len(found) >= 3, f"Too few major parties found: {found}"
+
+
+class TestMemberById:
+    """Test single-member lookup."""
+
+    def test_known_member_returned(self):
+        df = members.get_member_by_id(5797)
+        assert len(df) == 1
+
+    def test_unknown_member_returns_empty(self):
+        df = members.get_member_by_id(999999999)
+        assert df.empty
+
+
+# ── Votes / Divisions ─────────────────────────────────────────────────────────
+
+
+class TestDivisions:
+    """Live data integrity tests for Assembly divisions."""
+
+    @pytest.fixture(scope="class")
+    def df(self) -> pd.DataFrame:
+        # Fetch from start of current mandate
+        return votes.get_all_divisions(start_date="2022-05-01")
+
+    def test_divisions_not_empty(self, df):
+        assert not df.empty, "No divisions returned"
+
+    def test_at_least_100_divisions(self, df):
+        assert len(df) >= 100, f"Only {len(df)} divisions found"
+
+    def test_divisions_schema(self, df):
+        required = {"DocumentID", "DivisionDate", "DivisionSubject"}
+        assert required.issubset(set(df.columns)), (
+            f"Missing columns: {required - set(df.columns)}"
+        )
+
+    def test_division_dates_parsed(self, df):
+        assert pd.api.types.is_datetime64_any_dtype(df["DivisionDate"])
+
+    def test_no_null_subjects(self, df):
+        assert df["DivisionSubject"].notna().all()
+
+
+class TestDivisionVotes:
+    """Live tests for per-member vote records."""
+
+    # Use a known stable division ID
+    _KNOWN_DIVISION_ID = 406283
+
+    @pytest.fixture(scope="class")
+    def vote_df(self) -> pd.DataFrame:
+        return votes.get_division_votes(self._KNOWN_DIVISION_ID)
+
+    def test_votes_not_empty(self, vote_df):
+        assert not vote_df.empty
+
+    def test_vote_values_valid(self, vote_df):
+        valid = {"AYE", "NO", "ABSTAIN"}
+        found = set(vote_df["Vote"].dropna().unique())
+        assert found.issubset(valid | {None}), f"Unexpected vote values: {found - valid}"
+
+    def test_member_names_present(self, vote_df):
+        assert "MemberName" in vote_df.columns
+        assert vote_df["MemberName"].notna().all()
+
+
+# ── Questions ────────────────────────────────────────────────────────────────
+
+
+class TestQuestionsByDepartment:
+    """Live data integrity tests for questions directed to a department."""
+
+    @pytest.fixture(scope="class")
+    def df(self) -> pd.DataFrame:
+        return questions.get_questions_by_department("Department of Health")
+
+    def test_questions_by_department(self, df):
+        assert not df.empty, "No questions returned for Department of Health"
+        assert len(df) > 100, f"Only {len(df)} questions found"
+
+    def test_questions_schema(self, df):
+        required = {"DocumentId", "TabledDate", "QuestionText"}
+        assert required.issubset(set(df.columns)), (
+            f"Missing columns: {required - set(df.columns)}"
+        )
+
+    def test_tabled_dates_parsed(self, df):
+        assert pd.api.types.is_datetime64_any_dtype(df["TabledDate"])
+
+    def test_no_null_question_text(self, df):
+        assert df["QuestionText"].notna().all()
+
+
+class TestQuestionsByMember:
+    """Live tests for questions by MLA."""
+
+    def test_questions_by_member_returns_dataframe(self):
+        df = questions.get_questions_by_member(5797)
+        assert isinstance(df, pd.DataFrame)
+        assert len(df) >= 0  # may be empty if member has no questions
+
+    def test_questions_by_member_schema(self):
+        df = questions.get_questions_by_member(5797)
+        if not df.empty:
+            assert "QuestionText" in df.columns
+
+
+# ── Unit tests: validate empty / malformed responses ─────────────────────────
+
+
+class TestValidationEdgeCases:
+    """Unit tests that do not make network calls."""
+
+    def test_xml_to_records_empty_string(self):
+        from bolster.data_sources.niassembly.members import _xml_to_records
+
+        result = _xml_to_records("", "Root", "Item")
+        assert result == []
+
+    def test_xml_to_records_no_items(self):
+        from bolster.data_sources.niassembly.members import _xml_to_records
+
+        xml = "<Root></Root>"
+        result = _xml_to_records(xml, "Root", "Item")
+        assert result == []
+
+    def test_xml_to_records_single_item(self):
+        from bolster.data_sources.niassembly.members import _xml_to_records
+
+        xml = "<Root><Item><Name>Test</Name><Id>1</Id></Item></Root>"
+        result = _xml_to_records(xml, "Root", "Item")
+        assert result == [{"Name": "Test", "Id": "1"}]
+
+    def test_resolve_department_id_integer(self):
+        assert _resolve_department_id(82) == 82
+
+    def test_resolve_department_id_full_name(self):
+        assert _resolve_department_id("Department of Health") == 82
+
+    def test_resolve_department_id_abbreviation(self):
+        assert _resolve_department_id("DoH") == 82
+
+    def test_resolve_department_id_unknown_raises(self):
+        with pytest.raises(ValueError, match="Cannot resolve"):
+            _resolve_department_id("Ministry of Magic")
+
+    def test_get_current_members_empty_response(self, monkeypatch):
+        """get_current_members returns empty DataFrame on empty XML response."""
+        import bolster.data_sources.niassembly.members as members_mod
+
+        class FakeResponse:
+            text = ""
+            status_code = 200
+
+            def raise_for_status(self):
+                pass
+
+        monkeypatch.setattr(members_mod.session, "get", lambda *a, **kw: FakeResponse())
+        df = members_mod.get_current_members()
+        assert isinstance(df, pd.DataFrame)
+        assert df.empty
+
+    def test_get_questions_by_department_null_response(self, monkeypatch):
+        """get_questions_by_department returns empty DataFrame on null QuestionsList."""
+        import bolster.data_sources.niassembly.questions as questions_mod
+
+        class FakeResponse:
+            status_code = 200
+
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return {"QuestionsList": None}
+
+        monkeypatch.setattr(
+            questions_mod.session, "get", lambda *a, **kw: FakeResponse()
+        )
+        df = questions_mod.get_questions_by_department(82)
+        assert isinstance(df, pd.DataFrame)
+        assert df.empty
+
+    def test_get_all_divisions_empty_response(self, monkeypatch):
+        """get_all_divisions returns empty DataFrame when no divisions returned."""
+        import bolster.data_sources.niassembly.votes as votes_mod
+
+        class FakeResponse:
+            status_code = 200
+
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return {"DivisionList": None}
+
+        monkeypatch.setattr(
+            votes_mod.session, "get", lambda *a, **kw: FakeResponse()
+        )
+        df = votes_mod.get_all_divisions()
+        assert isinstance(df, pd.DataFrame)
+        assert df.empty
+
+    def test_get_division_votes_empty_xml(self, monkeypatch):
+        """get_division_votes returns empty DataFrame on empty XML."""
+        import bolster.data_sources.niassembly.votes as votes_mod
+
+        class FakeResponse:
+            text = ""
+            status_code = 200
+
+            def raise_for_status(self):
+                pass
+
+        monkeypatch.setattr(
+            votes_mod.session, "get", lambda *a, **kw: FakeResponse()
+        )
+        df = votes_mod.get_division_votes(999)
+        assert isinstance(df, pd.DataFrame)
+        assert df.empty
+
+    def test_get_division_votes_no_members_in_xml(self, monkeypatch):
+        """get_division_votes returns empty DataFrame when XML has no Member elements."""
+        import bolster.data_sources.niassembly.votes as votes_mod
+
+        class FakeResponse:
+            text = "<MemberVoting></MemberVoting>"
+            status_code = 200
+
+            def raise_for_status(self):
+                pass
+
+        monkeypatch.setattr(
+            votes_mod.session, "get", lambda *a, **kw: FakeResponse()
+        )
+        df = votes_mod.get_division_votes(999)
+        assert isinstance(df, pd.DataFrame)
+        assert df.empty


### PR DESCRIPTION
## Summary

Adds `src/bolster/data_sources/niassembly/` subpackage implementing access to the Northern Ireland Assembly AIMS open data API (`data.niassembly.gov.uk`). No auth required, OGL v3.0.

- **members.py**: `get_current_members()`, `get_member_by_id()` — 90 current MLAs
- **questions.py**: `get_questions_by_department()`, `get_questions_by_member()` — 39k+ DoH questions since 2007; `DEPARTMENT_NAME_TO_ID` lookup for all 9 NICS departments
- **votes.py**: `get_all_divisions()`, `get_division_votes()` — 198+ divisions in current mandate

JSON via `_JSON` method-name variants; XML fallback via `ElementTree`.

## CLI

```bash
bolster niassembly members
bolster niassembly questions --department "Department of Health"
bolster niassembly votes
```

## Test plan
- [x] 37 new tests passing
- [x] Full suite 1709 passing (no regressions)
- [x] Pre-commit clean

Closes #1888

🤖 Generated with [Claude Code](https://claude.com/claude-code)