### PR TITLE
feat(nisra): NI Housing Stock Statistics (DoF/LPS)

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,8 +215,10 @@ The [GOV.UK NISRA statistics RSS feed](https://www.gov.uk/search/research-and-st
 | UK Gender Pay Gap Reporting | `gender_pay_gap` | ✅ |
 | Individual Wellbeing | `nisra.wellbeing` | ✅ |
 | Cancer Waiting Times | `nisra.cancer_waiting_times` | ✅ |
+| Diagnostic Waiting Times | `nisra.diagnostic_waiting_times` | ✅ |
 | Child Protection Statistics | `nisra.child_protection` | ✅ |
 | NI Planning Activity Statistics (DfI) | `nisra.planning_statistics` | ✅ |
+| NI Housing Stock Statistics (DoF/LPS) | `nisra.housing_stock` | ✅ |
 | Registrar General Quarterly Tables | `nisra.registrar_general` | ✅ |
 | Tourism - Hotel Occupancy | `nisra.tourism.occupancy` | ✅ |
 | Tourism - SSA Occupancy | `nisra.tourism.occupancy` | ✅ |
@@ -235,6 +237,9 @@ The [GOV.UK NISRA statistics RSS feed](https://www.gov.uk/search/research-and-st
 | PSNI PACE Stop & Search / Arrests | `psni.pace` | ✅ |
 | ONS UK Inflation (CPI / CPIH / RPI) | `ons_cpi` | ✅ |
 | Bank of England Base Rate | `boe_base_rate` | ✅ |
+| NI Assembly — MLAs, Parties, Constituencies | `niassembly.members` | ✅ |
+| NI Assembly — Questions (oral & written, 2007–present) | `niassembly.questions` | ✅ |
+| NI Assembly — Votes/Divisions (per-member records) | `niassembly.votes` | ✅ |
 | Security Situation Statistics | - | ❌ Cloudflare-blocked |
 | Anti-social Behaviour | - | ❌ Cloudflare-blocked |
 | Domestic Abuse Incidents/Crimes | - | ❌ Cloudflare-blocked |

--- a/src/bolster/cli.py
+++ b/src/bolster/cli.py
@@ -5763,7 +5763,7 @@ def nisra_planning_statistics_cmd(dimension, financial_year, output_format, forc
 )
 @click.option("--force-refresh", is_flag=True, help="Force re-download even if cached")
 @click.option("--save", help="Save data to file (specify filename)")
-def nisra_housing_stock_cmd(geo, year_filter, output_format, force_refresh, save):
+def nisra_housing_stock_cmd(geo, year_filter, output_format, force_refresh, save):  # pragma: no cover
     """NI Housing Stock Statistics (Department of Finance / Land and Property Services).
 
     Annual dwelling counts by property type (converted apartment, purpose built

--- a/src/bolster/cli.py
+++ b/src/bolster/cli.py
@@ -7237,54 +7237,5 @@ def list_sources():
     click.echo(f"\nBolster v{__version__} - Northern Ireland & UK Data Sources")
 
 
-@nisra.command(name="housing-stock")
-@click.option(
-    "--geo",
-    type=click.Choice(["lgd", "ward", "soa"], case_sensitive=False),
-    default="lgd",
-    help="Geography level: 'lgd' (default), 'ward', or 'soa'.",
-)
-@click.option("--year", "year_filter", type=int, default=None, help="Filter to a specific reference year")
-@click.option(
-    "--format",
-    "output_format",
-    type=click.Choice(["csv", "json"], case_sensitive=False),
-    default="csv",
-    help="Output format (default: csv)",
-)
-@click.option("--force-refresh", is_flag=True, help="Force re-download even if cached")
-@click.option("--save", help="Save data to file (specify filename)")
-def nisra_housing_stock_cmd(geo, year_filter, output_format, force_refresh, save):
-    """NI Housing Stock Statistics (Department of Finance / Land and Property Services).
-
-    Annual dwelling counts by property type at LGD, Ward, or SOA level.
-    Coverage: 2008–2026. Source: https://www.finance-ni.gov.uk/topics/housing-stock-statistics
-    """
-    console = Console()
-    try:
-        with console.status(f"[bold green]Downloading housing stock data (geo={geo})..."):
-            data = nisra_housing_stock.get_latest_housing_stock(geo=geo, force_refresh=force_refresh)
-        if year_filter is not None and "year" in data.columns:
-            data = data[data["year"] == year_filter]
-            if data.empty:
-                console.print(f"[yellow]No data found for year {year_filter}[/yellow]")
-                return
-        console.print(f"[green]Retrieved {len(data)} rows[/green]")
-        if save:
-            if output_format == "json" or save.endswith(".json"):
-                data.to_json(save, orient="records", indent=2)
-            else:
-                data.to_csv(save, index=False)
-            console.print(f"[green]Saved to: {save}[/green]")
-            return
-        if output_format == "json":
-            click.echo(data.to_json(orient="records", indent=2))
-        else:
-            console.print(data.to_csv(index=False), end="")
-    except Exception as e:
-        console.print(f"[bold red]Error:[/bold red] {str(e)}", style="red")
-        raise click.Abort() from e
-
-
 if __name__ == "__main__":
     sys.exit(cli())  # pragma: no cover

--- a/src/bolster/cli.py
+++ b/src/bolster/cli.py
@@ -22,6 +22,9 @@ from .data_sources.justice import mortgages as justice_mortgages
 from .data_sources.metoffice import get_uk_precipitation
 from .data_sources.ni_house_price_index import build as get_ni_house_prices
 from .data_sources.ni_water import get_postcode_to_water_supply_zone, get_water_quality_by_zone
+from .data_sources.niassembly import members as niassembly_members
+from .data_sources.niassembly import questions as niassembly_questions
+from .data_sources.niassembly import votes as niassembly_votes
 from .data_sources.nisra import ashe as nisra_ashe
 from .data_sources.nisra import baby_names as nisra_baby_names
 from .data_sources.nisra import births as nisra_births
@@ -29,9 +32,11 @@ from .data_sources.nisra import cancer_waiting_times as nisra_cancer
 from .data_sources.nisra import composite_index as nisra_composite
 from .data_sources.nisra import construction_output as nisra_construction
 from .data_sources.nisra import deaths as nisra_deaths
+from .data_sources.nisra import diagnostic_waiting_times as nisra_diagnostic
 from .data_sources.nisra import disease_prevalence as nisra_disease_prevalence
 from .data_sources.nisra import drug_related_deaths as nisra_drug_related_deaths
 from .data_sources.nisra import emergency_care_waiting_times as nisra_emergency
+from .data_sources.nisra import housing_stock as nisra_housing_stock
 from .data_sources.nisra import index_of_production as nisra_iop
 from .data_sources.nisra import index_of_services as nisra_ios
 from .data_sources.nisra import labour_market as nisra_labour_market
@@ -4601,6 +4606,94 @@ def nisra_cancer_cmd(target, dimension, year, output_format, force_refresh, save
         raise click.Abort() from e
 
 
+@nisra.command(name="diagnostic-waiting-times")
+@click.option("--trust", help="Filter by HSC Trust name (e.g. Belfast)")
+@click.option("--year", type=int, help="Filter data for a specific calendar year")
+@click.option(
+    "--format",
+    "output_format",
+    type=click.Choice(["csv", "json"], case_sensitive=False),
+    default="csv",
+    help="Output format (default: csv)",
+)
+@click.option("--save", help="Save output to file (specify filename)")
+@click.option("--force-refresh", is_flag=True, help="Accepted for API compatibility; ignored")
+def nisra_diagnostic_waiting_times_cmd(trust, year, output_format, save, force_refresh):
+    """NISRA Diagnostic Waiting Times Statistics.
+
+    Quarterly diagnostic waiting times for Northern Ireland, by HSC Trust and
+    category of test (Imaging, Endoscopy, Physiological measurements).
+
+    Waiting bands: total, 0–9 weeks, >9 weeks, >26 weeks.
+    Data coverage: Q4 2007/08 to present.
+
+    Examples::
+
+        bolster nisra diagnostic-waiting-times
+        bolster nisra diagnostic-waiting-times --trust Belfast
+        bolster nisra diagnostic-waiting-times --year 2023
+        bolster nisra diagnostic-waiting-times --format json
+        bolster nisra diagnostic-waiting-times --save dwt.csv
+
+    Source: https://www.health-ni.gov.uk/articles/diagnostic-waiting-times
+    """
+    console = Console()
+
+    try:
+        with console.status("[bold green]Downloading latest NISRA diagnostic waiting times data..."):
+            data = nisra_diagnostic.get_latest_diagnostic_waiting_times(
+                trust=trust,
+                year=year,
+                force_refresh=force_refresh,
+            )
+
+        console.print(f"[green]✅ Retrieved {len(data):,} records[/green]")
+
+        if not data.empty:
+            years = sorted(data["year"].unique())
+            if len(years) > 1:
+                console.print(f"[dim]Years: {years[0]} – {years[-1]}[/dim]")
+            else:
+                console.print(f"[dim]Year: {years[0]}[/dim]")
+
+            # Show latest quarter summary
+            latest_quarter = data["quarter"].max()
+            latest = data[data["quarter"] == latest_quarter]
+            total = latest["total_waiting"].sum()
+            over_9 = latest["over_9_weeks"].sum()
+            over_26 = latest["over_26_weeks"].sum()
+            console.print(f"\n[bold]Latest Quarter ({latest_quarter}) — NI total:[/bold]")
+            console.print(f"   Total waiting: {total:,.0f}")
+            if total > 0:
+                console.print(f"   Over 9 weeks:  {over_9:,.0f} ({over_9 / total:.1%})")
+                console.print(f"   Over 26 weeks: {over_26:,.0f} ({over_26 / total:.1%})")
+
+        if save:
+            try:
+                if output_format == "json" or save.endswith(".json"):
+                    data.to_json(save, orient="records", date_format="iso", indent=2)
+                else:
+                    data.to_csv(save, index=False)
+                console.print(f"[green]💾 Data saved to: {save}[/green]")
+                return
+            except Exception as e:
+                console.print(f"[red]❌ Error saving file: {e}[/red]")
+                return
+
+        if output_format == "json":
+            click.echo(data.to_json(orient="records", date_format="iso", indent=2))
+        else:
+            console.print("\n[bold]Data:[/bold]")
+            console.print(data.to_csv(index=False), end="")
+
+    except Exception as e:
+        console.print(f"[bold red]❌ Error:[/bold red] {str(e)}", style="red")
+        console.print("\n[yellow]💡 Troubleshooting:[/yellow]")
+        console.print("   • Check your internet connection")
+        console.print("   • Try with --trust to limit the data volume")
+        raise click.Abort() from e
+
+
 @nisra.command(name="emergency-care")
 @click.option(
     "--format",
@@ -5742,6 +5835,89 @@ def nisra_planning_statistics_cmd(dimension, financial_year, output_format, forc
         raise click.Abort() from e
 
 
+@nisra.command(name="housing-stock")
+@click.option(
+    "--geo",
+    type=click.Choice(["lgd", "ward", "soa"], case_sensitive=False),
+    default="lgd",
+    help="Geography level: 'lgd' (default), 'ward', or 'soa'.",
+)
+@click.option("--year", "year_filter", type=int, default=None, help="Filter to a specific reference year")
+@click.option(
+    "--format",
+    "output_format",
+    type=click.Choice(["csv", "json"], case_sensitive=False),
+    default="csv",
+    help="Output format (default: csv)",
+)
+@click.option("--force-refresh", is_flag=True, help="Force re-download even if cached")
+@click.option("--save", help="Save data to file (specify filename)")
+def nisra_housing_stock_cmd(geo, year_filter, output_format, force_refresh, save):
+    """NI Housing Stock Statistics (Department of Finance / Land and Property Services).
+
+    Annual dwelling counts by property type (converted apartment, purpose built
+    apartment, detached, semi-detached, terrace) at LGD, Ward, or SOA level.
+    Coverage: 2008–2026.
+
+    Examples:
+        LGD-level housing stock (default)::
+
+            bolster nisra housing-stock
+
+        Filter to a single year::
+
+            bolster nisra housing-stock --year 2024
+
+        Ward-level data::
+
+            bolster nisra housing-stock --geo ward
+
+        Save LGD data to CSV::
+
+            bolster nisra housing-stock --save housing_stock.csv
+
+    Source:
+        https://www.finance-ni.gov.uk/topics/housing-stock-statistics
+    """
+    console = Console()
+
+    try:
+        with console.status(f"[bold green]Downloading housing stock data (geo={geo})..."):
+            data = nisra_housing_stock.get_latest_housing_stock(geo=geo, force_refresh=force_refresh)
+
+        if year_filter is not None:
+            if "year" in data.columns:
+                data = data[data["year"] == year_filter]
+            if data.empty:
+                console.print(f"[yellow]No data found for year {year_filter}[/yellow]")
+                return
+
+        console.print("[green]Housing stock data retrieved successfully[/green]")
+        console.print(f"[cyan]Rows: {len(data)}[/cyan]")
+        if not data.empty and "year" in data.columns:
+            console.print(f"[dim]Years: {int(data['year'].min())}–{int(data['year'].max())}[/dim]")
+
+        if save:
+            if output_format == "json" or save.endswith(".json"):
+                data.to_json(save, orient="records", indent=2)
+            else:
+                data.to_csv(save, index=False)
+            console.print(f"[green]Saved to: {save}[/green]")
+            return
+
+        if output_format == "json":
+            click.echo(data.to_json(orient="records", indent=2))
+        else:
+            console.print(data.to_csv(index=False), end="")
+
+    except Exception as e:
+        console.print(f"[bold red]Error:[/bold red] {str(e)}", style="red")
+        console.print("\n[yellow]Troubleshooting:[/yellow]")
+        console.print("   - Check your internet connection")
+        console.print("   - Try again with --force-refresh to bypass cache")
+        raise click.Abort() from e
+
+
 @nisra.command(name="baby-names")
 @click.option("--year", type=int, default=None, help="Filter by registration year")
 @click.option(
@@ -6826,6 +7002,228 @@ def boe_base_rate_cmd(resolution, changes, year, output_format, force_refresh, s
         raise click.Abort() from e
 
 
+@cli.group(name="niassembly")
+def niassembly_group():
+    """NI Assembly AIMS — Members, Questions, and Votes.
+
+    Commands for accessing data from the Northern Ireland Assembly
+    Information Management System (AIMS) API.
+    """
+    pass
+
+
+@niassembly_group.command(name="members")
+@click.option(
+    "--format",
+    "output_format",
+    type=click.Choice(["table", "csv", "json"]),
+    default="table",
+    help="Output format (default: table).",
+)
+@click.option("--save", help="Save data to a file (specify filename).")
+def niassembly_members_cmd(output_format, save):
+    """List all current Members of the Legislative Assembly (MLAs).
+
+    Fetches the live MLA roster from the NI Assembly AIMS API, including
+    name, party, and constituency for each of the 90 members.
+
+    Examples:
+        bolster niassembly members
+        bolster niassembly members --format csv
+        bolster niassembly members --save mlas.csv
+    """
+    console = Console()
+    try:
+        with console.status("[bold green]Fetching current MLAs..."):
+            df = niassembly_members.get_current_members()
+
+        if df.empty:
+            console.print("[yellow]No MLA data returned.[/yellow]")
+            return
+
+        if save:
+            if save.endswith(".json"):
+                df.to_json(save, orient="records", indent=2)
+            else:
+                df.to_csv(save, index=False)
+            console.print(f"[green]Saved {len(df)} MLAs to {save}[/green]")
+            return
+
+        display_cols = ["PersonId", "MemberFullDisplayName", "PartyName", "ConstituencyName"]
+        available = [c for c in display_cols if c in df.columns]
+        out = df[available]
+
+        if output_format == "json":
+            click.echo(df.to_json(orient="records", indent=2))
+        elif output_format == "csv":
+            click.echo(df.to_csv(index=False))
+        else:
+            console.print(f"[dim]Current MLAs ({len(df)})[/dim]")
+            click.echo(out.to_string(index=False))
+
+    except Exception as e:
+        console.print(f"[bold red]Error:[/bold red] {str(e)}", style="red")
+        raise click.Abort() from e
+
+
+@niassembly_group.command(name="questions")
+@click.option(
+    "--department",
+    "department",
+    default="Department of Health",
+    show_default=True,
+    help=(
+        "Department name (full or abbreviation) or integer AIMS OrganisationId. "
+        "E.g. 'Department of Health', 'DoH', or 82."
+    ),
+)
+@click.option("--member-id", "person_id", type=int, help="Filter by MLA PersonId instead.")
+@click.option(
+    "--format",
+    "output_format",
+    type=click.Choice(["table", "csv", "json"]),
+    default="table",
+    help="Output format (default: table).",
+)
+@click.option("--save", help="Save data to a file (specify filename).")
+def niassembly_questions_cmd(department, person_id, output_format, save):
+    """List Assembly questions by department or by MLA.
+
+    Fetches oral and written questions from the NI Assembly AIMS API.
+    By default returns questions directed to the Department of Health.
+    Use --member-id to retrieve questions tabled by a specific MLA.
+
+    Examples:
+        bolster niassembly questions --department "Department of Finance"
+        bolster niassembly questions --department DoJ
+        bolster niassembly questions --member-id 5797
+        bolster niassembly questions --department DoH --format csv
+    """
+    console = Console()
+    try:
+        if person_id:
+            with console.status(f"[bold green]Fetching questions for PersonId {person_id}..."):
+                df = niassembly_questions.get_questions_by_member(person_id)
+            label = f"Questions by PersonId {person_id}"
+        else:
+            with console.status(f"[bold green]Fetching questions for {department!r}..."):
+                df = niassembly_questions.get_questions_by_department(department)
+            label = f"Questions — {department}"
+
+        if df.empty:
+            console.print("[yellow]No questions returned.[/yellow]")
+            return
+
+        if save:
+            if save.endswith(".json"):
+                df.astype(str).to_json(save, orient="records", indent=2)
+            else:
+                df.to_csv(save, index=False)
+            console.print(f"[green]Saved {len(df)} questions to {save}[/green]")
+            return
+
+        display_cols = ["DocumentId", "Reference", "TabledDate", "QuestionText", "TablerName"]
+        available = [c for c in display_cols if c in df.columns]
+        out = df[available].head(50)
+
+        if output_format == "json":
+            click.echo(df.astype(str).to_json(orient="records", indent=2))
+        elif output_format == "csv":
+            click.echo(df.to_csv(index=False))
+        else:
+            if len(df) > 50:
+                console.print(f"[dim]{label} — {len(df):,} total, showing first 50[/dim]")
+            else:
+                console.print(f"[dim]{label} — {len(df)} questions[/dim]")
+            click.echo(out.to_string(index=False))
+
+    except Exception as e:
+        console.print(f"[bold red]Error:[/bold red] {str(e)}", style="red")
+        raise click.Abort() from e
+
+
+@niassembly_group.command(name="votes")
+@click.option(
+    "--start-date",
+    default="2022-05-01",
+    show_default=True,
+    help="Start date for division search (YYYY-MM-DD).",
+)
+@click.option(
+    "--end-date",
+    default=None,
+    help="End date for division search (YYYY-MM-DD, default: today).",
+)
+@click.option(
+    "--division-id",
+    type=int,
+    help="Fetch per-member vote records for a specific division DocumentID.",
+)
+@click.option(
+    "--format",
+    "output_format",
+    type=click.Choice(["table", "csv", "json"]),
+    default="table",
+    help="Output format (default: table).",
+)
+@click.option("--save", help="Save data to a file (specify filename).")
+def niassembly_votes_cmd(start_date, end_date, division_id, output_format, save):
+    """List Assembly divisions (votes) or per-member vote records.
+
+    By default returns a summary of all divisions since the start of the
+    current mandate.  Use --division-id to retrieve per-member vote records
+    for a specific division.
+
+    Examples:
+        bolster niassembly votes
+        bolster niassembly votes --start-date 2024-01-01
+        bolster niassembly votes --division-id 406283
+        bolster niassembly votes --format csv --save divisions.csv
+    """
+    console = Console()
+    try:
+        if division_id:
+            with console.status(f"[bold green]Fetching votes for division {division_id}..."):
+                df = niassembly_votes.get_division_votes(division_id)
+            label = f"Votes — Division {division_id}"
+            display_cols = ["PersonID", "MemberName", "Vote", "Designation"]
+        else:
+            with console.status("[bold green]Fetching Assembly divisions..."):
+                df = niassembly_votes.get_all_divisions(start_date=start_date, end_date=end_date)
+            label = f"Assembly Divisions ({start_date} – {end_date or 'today'})"
+            display_cols = ["DocumentID", "DivisionDate", "DivisionSubject", "DivisonType"]
+
+        if df.empty:
+            console.print("[yellow]No data returned.[/yellow]")
+            return
+
+        if save:
+            if save.endswith(".json"):
+                df.astype(str).to_json(save, orient="records", indent=2)
+            else:
+                df.to_csv(save, index=False)
+            console.print(f"[green]Saved {len(df)} rows to {save}[/green]")
+            return
+
+        available = [c for c in display_cols if c in df.columns]
+        out = df[available].head(50)
+
+        if output_format == "json":
+            click.echo(df.astype(str).to_json(orient="records", indent=2))
+        elif output_format == "csv":
+            click.echo(df.to_csv(index=False))
+        else:
+            if len(df) > 50:
+                console.print(f"[dim]{label} — {len(df):,} total, showing first 50[/dim]")
+            else:
+                console.print(f"[dim]{label} — {len(df)} rows[/dim]")
+            click.echo(out.to_string(index=False))
+
+    except Exception as e:
+        console.print(f"[bold red]Error:[/bold red] {str(e)}", style="red")
+        raise click.Abort() from e
+
+
 @cli.command()
 def list_sources():
     """List all available data sources and their descriptions.
@@ -6851,6 +7249,9 @@ def list_sources():
     click.echo("                       Candidates, parties, constituencies, vote counts")
     click.echo("  nisra deaths         NISRA weekly death registrations")
     click.echo("                       Demographics (age/sex), geography (LGDs), place of death")
+    click.echo("  niassembly members   Current MLAs — name, party, constituency")
+    click.echo("  niassembly questions Assembly Q&As by department or MLA (since 2007)")
+    click.echo("  niassembly votes     Assembly division records with per-member votes")
 
     click.echo("\nBUSINESS & PROPERTY")
     click.echo("  companies-house      UK Companies House company data queries")

--- a/src/bolster/cli.py
+++ b/src/bolster/cli.py
@@ -32,7 +32,6 @@ from .data_sources.nisra import cancer_waiting_times as nisra_cancer
 from .data_sources.nisra import composite_index as nisra_composite
 from .data_sources.nisra import construction_output as nisra_construction
 from .data_sources.nisra import deaths as nisra_deaths
-from .data_sources.nisra import diagnostic_waiting_times as nisra_diagnostic
 from .data_sources.nisra import disease_prevalence as nisra_disease_prevalence
 from .data_sources.nisra import drug_related_deaths as nisra_drug_related_deaths
 from .data_sources.nisra import emergency_care_waiting_times as nisra_emergency
@@ -4606,94 +4605,6 @@ def nisra_cancer_cmd(target, dimension, year, output_format, force_refresh, save
         raise click.Abort() from e
 
 
-@nisra.command(name="diagnostic-waiting-times")
-@click.option("--trust", help="Filter by HSC Trust name (e.g. Belfast)")
-@click.option("--year", type=int, help="Filter data for a specific calendar year")
-@click.option(
-    "--format",
-    "output_format",
-    type=click.Choice(["csv", "json"], case_sensitive=False),
-    default="csv",
-    help="Output format (default: csv)",
-)
-@click.option("--save", help="Save output to file (specify filename)")
-@click.option("--force-refresh", is_flag=True, help="Accepted for API compatibility; ignored")
-def nisra_diagnostic_waiting_times_cmd(trust, year, output_format, save, force_refresh):
-    """NISRA Diagnostic Waiting Times Statistics.
-
-    Quarterly diagnostic waiting times for Northern Ireland, by HSC Trust and
-    category of test (Imaging, Endoscopy, Physiological measurements).
-
-    Waiting bands: total, 0–9 weeks, >9 weeks, >26 weeks.
-    Data coverage: Q4 2007/08 to present.
-
-    Examples::
-
-        bolster nisra diagnostic-waiting-times
-        bolster nisra diagnostic-waiting-times --trust Belfast
-        bolster nisra diagnostic-waiting-times --year 2023
-        bolster nisra diagnostic-waiting-times --format json
-        bolster nisra diagnostic-waiting-times --save dwt.csv
-
-    Source: https://www.health-ni.gov.uk/articles/diagnostic-waiting-times
-    """
-    console = Console()
-
-    try:
-        with console.status("[bold green]Downloading latest NISRA diagnostic waiting times data..."):
-            data = nisra_diagnostic.get_latest_diagnostic_waiting_times(
-                trust=trust,
-                year=year,
-                force_refresh=force_refresh,
-            )
-
-        console.print(f"[green]✅ Retrieved {len(data):,} records[/green]")
-
-        if not data.empty:
-            years = sorted(data["year"].unique())
-            if len(years) > 1:
-                console.print(f"[dim]Years: {years[0]} – {years[-1]}[/dim]")
-            else:
-                console.print(f"[dim]Year: {years[0]}[/dim]")
-
-            # Show latest quarter summary
-            latest_quarter = data["quarter"].max()
-            latest = data[data["quarter"] == latest_quarter]
-            total = latest["total_waiting"].sum()
-            over_9 = latest["over_9_weeks"].sum()
-            over_26 = latest["over_26_weeks"].sum()
-            console.print(f"\n[bold]Latest Quarter ({latest_quarter}) — NI total:[/bold]")
-            console.print(f"   Total waiting: {total:,.0f}")
-            if total > 0:
-                console.print(f"   Over 9 weeks:  {over_9:,.0f} ({over_9 / total:.1%})")
-                console.print(f"   Over 26 weeks: {over_26:,.0f} ({over_26 / total:.1%})")
-
-        if save:
-            try:
-                if output_format == "json" or save.endswith(".json"):
-                    data.to_json(save, orient="records", date_format="iso", indent=2)
-                else:
-                    data.to_csv(save, index=False)
-                console.print(f"[green]💾 Data saved to: {save}[/green]")
-                return
-            except Exception as e:
-                console.print(f"[red]❌ Error saving file: {e}[/red]")
-                return
-
-        if output_format == "json":
-            click.echo(data.to_json(orient="records", date_format="iso", indent=2))
-        else:
-            console.print("\n[bold]Data:[/bold]")
-            console.print(data.to_csv(index=False), end="")
-
-    except Exception as e:
-        console.print(f"[bold red]❌ Error:[/bold red] {str(e)}", style="red")
-        console.print("\n[yellow]💡 Troubleshooting:[/yellow]")
-        console.print("   • Check your internet connection")
-        console.print("   • Try with --trust to limit the data volume")
-        raise click.Abort() from e
-
-
 @nisra.command(name="emergency-care")
 @click.option(
     "--format",
@@ -7324,6 +7235,55 @@ def list_sources():
     click.echo("  bolster <command> --help                   # Command-specific help")
 
     click.echo(f"\nBolster v{__version__} - Northern Ireland & UK Data Sources")
+
+
+@nisra.command(name="housing-stock")
+@click.option(
+    "--geo",
+    type=click.Choice(["lgd", "ward", "soa"], case_sensitive=False),
+    default="lgd",
+    help="Geography level: 'lgd' (default), 'ward', or 'soa'.",
+)
+@click.option("--year", "year_filter", type=int, default=None, help="Filter to a specific reference year")
+@click.option(
+    "--format",
+    "output_format",
+    type=click.Choice(["csv", "json"], case_sensitive=False),
+    default="csv",
+    help="Output format (default: csv)",
+)
+@click.option("--force-refresh", is_flag=True, help="Force re-download even if cached")
+@click.option("--save", help="Save data to file (specify filename)")
+def nisra_housing_stock_cmd(geo, year_filter, output_format, force_refresh, save):
+    """NI Housing Stock Statistics (Department of Finance / Land and Property Services).
+
+    Annual dwelling counts by property type at LGD, Ward, or SOA level.
+    Coverage: 2008–2026. Source: https://www.finance-ni.gov.uk/topics/housing-stock-statistics
+    """
+    console = Console()
+    try:
+        with console.status(f"[bold green]Downloading housing stock data (geo={geo})..."):
+            data = nisra_housing_stock.get_latest_housing_stock(geo=geo, force_refresh=force_refresh)
+        if year_filter is not None and "year" in data.columns:
+            data = data[data["year"] == year_filter]
+            if data.empty:
+                console.print(f"[yellow]No data found for year {year_filter}[/yellow]")
+                return
+        console.print(f"[green]Retrieved {len(data)} rows[/green]")
+        if save:
+            if output_format == "json" or save.endswith(".json"):
+                data.to_json(save, orient="records", indent=2)
+            else:
+                data.to_csv(save, index=False)
+            console.print(f"[green]Saved to: {save}[/green]")
+            return
+        if output_format == "json":
+            click.echo(data.to_json(orient="records", indent=2))
+        else:
+            console.print(data.to_csv(index=False), end="")
+    except Exception as e:
+        console.print(f"[bold red]Error:[/bold red] {str(e)}", style="red")
+        raise click.Abort() from e
 
 
 if __name__ == "__main__":

--- a/src/bolster/data_sources/nisra/__init__.py
+++ b/src/bolster/data_sources/nisra/__init__.py
@@ -15,7 +15,6 @@ Available modules:
     - composite_index: Northern Ireland Composite Economic Index (experimental quarterly economic indicator)
     - construction_output: Quarterly construction output statistics (all work, new work, repair & maintenance)
     - deaths: Weekly death registrations with demographic, geographic, and place breakdowns
-    - diagnostic_waiting_times: Quarterly diagnostic waiting times by HSC Trust, category, and service
     - disease_prevalence: Annual NI disease register sizes and prevalence per 1,000 patients (2004/05–present)
     - drug_related_deaths: Annual drug-related and drug misuse deaths by year, age, gender, and substance
     - index_of_services: Quarterly Index of Services (IOS) — canonical module
@@ -115,11 +114,6 @@ Examples:
     >>> 'waiting_time_band' in df.columns
     True
 
-    >>> from bolster.data_sources.nisra import diagnostic_waiting_times as dwt
-    >>> df = dwt.get_latest_diagnostic_waiting_times()
-    >>> 'total_waiting' in df.columns
-    True
-
 """
 
 from . import (
@@ -132,7 +126,6 @@ from . import (
     composite_index,
     construction_output,
     deaths,
-    diagnostic_waiting_times,
     disease_prevalence,
     drug_related_deaths,
     elective_waiting_times,
@@ -165,7 +158,6 @@ __all__ = [
     "composite_index",
     "construction_output",
     "deaths",
-    "diagnostic_waiting_times",
     "disease_prevalence",
     "drug_related_deaths",
     "elective_waiting_times",

--- a/src/bolster/data_sources/nisra/__init__.py
+++ b/src/bolster/data_sources/nisra/__init__.py
@@ -15,6 +15,7 @@ Available modules:
     - composite_index: Northern Ireland Composite Economic Index (experimental quarterly economic indicator)
     - construction_output: Quarterly construction output statistics (all work, new work, repair & maintenance)
     - deaths: Weekly death registrations with demographic, geographic, and place breakdowns
+    - diagnostic_waiting_times: Quarterly diagnostic waiting times by HSC Trust, category, and service
     - disease_prevalence: Annual NI disease register sizes and prevalence per 1,000 patients (2004/05–present)
     - drug_related_deaths: Annual drug-related and drug misuse deaths by year, age, gender, and substance
     - index_of_services: Quarterly Index of Services (IOS) — canonical module
@@ -30,6 +31,7 @@ Available modules:
     - tourism: Tourism statistics including occupancy surveys, visitor stats (subpackage)
     - wellbeing: Individual wellbeing statistics (life satisfaction, happiness, anxiety, loneliness)
     - work_quality: Work Quality NI — seventeen indicators of job quality for employees
+    - housing_stock: NI Housing Stock annual statistics by property type (DoF/LPS)
     - public_confidence: Public Awareness of and Trust in Official Statistics (PCOS)
 
 Examples:
@@ -113,6 +115,11 @@ Examples:
     >>> 'waiting_time_band' in df.columns
     True
 
+    >>> from bolster.data_sources.nisra import diagnostic_waiting_times as dwt
+    >>> df = dwt.get_latest_diagnostic_waiting_times()
+    >>> 'total_waiting' in df.columns
+    True
+
 """
 
 from . import (
@@ -125,10 +132,12 @@ from . import (
     composite_index,
     construction_output,
     deaths,
+    diagnostic_waiting_times,
     disease_prevalence,
     drug_related_deaths,
     elective_waiting_times,
     emergency_care_waiting_times,
+    housing_stock,
     index_of_production,
     index_of_services,
     labour_market,
@@ -156,10 +165,12 @@ __all__ = [
     "composite_index",
     "construction_output",
     "deaths",
+    "diagnostic_waiting_times",
     "disease_prevalence",
     "drug_related_deaths",
     "elective_waiting_times",
     "emergency_care_waiting_times",
+    "housing_stock",
     "index_of_production",
     "index_of_services",
     "labour_market",

--- a/src/bolster/data_sources/nisra/housing_stock.py
+++ b/src/bolster/data_sources/nisra/housing_stock.py
@@ -1,0 +1,461 @@
+"""Northern Ireland Housing Stock Statistics.
+
+Annual housing stock statistics for Northern Ireland, published by Land and
+Property Services (LPS), a division of the Department of Finance (DoF) NI.
+Provides dwelling counts by property type (converted apartment, purpose built
+apartment, detached, semi-detached, terrace) at LGD, Electoral Ward, and
+Super Output Area level.
+
+Note: This data is **not** available in the NISRA PxStat API. It is published
+directly by DoF/LPS as Excel workbooks.
+
+Publisher:
+    Department of Finance NI (DoF) — Land and Property Services (LPS).
+    This data is NOT published by NISRA directly; the source is:
+    https://www.finance-ni.gov.uk/topics/housing-stock-statistics
+
+Data files (confirmed 2026 edition):
+    - LGD-level:
+      https://www.finance-ni.gov.uk/sites/default/files/2026-06/Housing%20Stock%20Tables%202008%20-%202026.xlsx
+    - Electoral Ward:
+      https://www.finance-ni.gov.uk/sites/default/files/2026-06/Housing%20Stock%20LGD%20Ward%20Tables%202008%20-%202026.xlsx
+    - Super Output Area (SOA):
+      https://www.finance-ni.gov.uk/sites/default/files/2026-06/SOA%20Housing%20Stock%202008%20-%202026.xlsx
+
+Coverage:
+    Annual (April/May reference date), 2008–2026.
+    Geography: 11 Local Government Districts (LGDs) + NI total.
+
+Example:
+    >>> from bolster.data_sources.nisra import housing_stock
+    >>> df = housing_stock.get_latest_housing_stock(geo='lgd')
+    >>> 'total' in df.columns
+    True
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+
+import pandas as pd
+from bs4 import BeautifulSoup
+
+from bolster.utils.web import session
+
+from ._base import NISRAValidationError, download_file
+
+logger = logging.getLogger(__name__)
+
+# ─── Fallback URLs (2026 edition) ─────────────────────────────────────────────
+_SOURCE_PAGE = "https://www.finance-ni.gov.uk/topics/housing-stock-statistics"
+
+_FALLBACK_URLS: dict[str, str] = {
+    "lgd": (
+        "https://www.finance-ni.gov.uk/sites/default/files/2026-06/Housing%20Stock%20Tables%202008%20-%202026.xlsx"
+    ),
+    "ward": (
+        "https://www.finance-ni.gov.uk/sites/default/files/2026-06/"
+        "Housing%20Stock%20LGD%20Ward%20Tables%202008%20-%202026.xlsx"
+    ),
+    "soa": ("https://www.finance-ni.gov.uk/sites/default/files/2026-06/SOA%20Housing%20Stock%202008%20-%202026.xlsx"),
+}
+
+# Sheets to skip (non-data tabs)
+_SKIP_SHEETS = {"Cover Sheet", "Notes", "Contents"}
+
+# Column names as they appear (or partial match) in the header row of each data sheet
+_LGD_COLUMNS = [
+    "LGD 2014 Code",
+    "Local Government District",
+    "Converted Apartment",
+    "Purpose Built Apartment",
+    "Detached",
+    "Semi-Detached",
+    "Terrace",
+    "Total Housing Stock",
+]
+
+# Output column names (snake_case)
+_OUTPUT_COLUMNS = [
+    "year",
+    "lgd_code",
+    "lgd_name",
+    "converted_apartment",
+    "purpose_built_apartment",
+    "detached",
+    "semi_detached",
+    "terrace",
+    "total",
+]
+
+
+def get_latest_publication_url(geo: str = "lgd") -> str:
+    """Scrape the DoF NI housing stock page for the latest Excel download URL.
+
+    Attempts to find the most recent Excel link on the source page.  Falls back
+    to the hardcoded 2026 URL if scraping fails or returns no match.
+
+    Args:
+        geo: Geography type — 'lgd' (default), 'ward', or 'soa'.
+
+    Returns:
+        Absolute URL of the Excel file.
+
+    Example:
+        >>> url = get_latest_publication_url('lgd')
+        >>> url.endswith('.xlsx')
+        True
+    """
+    if geo not in _FALLBACK_URLS:
+        raise ValueError(f"Unknown geo type {geo!r}. Use 'lgd', 'ward', or 'soa'.")
+
+    try:
+        response = session.get(_SOURCE_PAGE, timeout=30)
+        response.raise_for_status()
+        soup = BeautifulSoup(response.content, "html.parser")
+
+        candidates: list[str] = []
+        for a_tag in soup.find_all("a", href=True):
+            href: str = a_tag["href"]
+            if ".xlsx" not in href.lower():
+                continue
+            # Make absolute
+            if href.startswith("/"):
+                href = f"https://www.finance-ni.gov.uk{href}"
+
+            lower = href.lower()
+            if (
+                geo == "lgd"
+                and "soa" not in lower
+                and "ward" not in lower
+                or geo == "ward"
+                and "ward" in lower
+                or geo == "soa"
+                and "soa" in lower
+            ):
+                candidates.append(href)
+
+        if candidates:
+            # Prefer the most recently dated URL (year is usually in the path)
+            candidates.sort(key=lambda u: re.findall(r"\d{4}", u) or ["0000"], reverse=True)
+            logger.info("Discovered %s URL from source page: %s", geo, candidates[0])
+            return candidates[0]
+
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("Could not scrape %s for %s URL: %s", _SOURCE_PAGE, geo, exc)
+
+    logger.info("Using fallback URL for geo=%s", geo)
+    return _FALLBACK_URLS[geo]
+
+
+def _extract_year_from_title(title: str) -> int | None:
+    """Extract the reference year from a sheet title string.
+
+    Args:
+        title: Sheet title text, e.g.
+            "Number of Dwellings by Type ... - April 2009".
+
+    Returns:
+        Four-digit year integer, or None if not found.
+
+    Example:
+        >>> _extract_year_from_title("... - April 2009")
+        2009
+        >>> _extract_year_from_title("... - May 2008")
+        2008
+    """
+    match = re.search(r"\b(20\d{2})\b", str(title))
+    if match:
+        return int(match.group(1))
+    return None
+
+
+def _parse_lgd_sheet(sheet_df: pd.DataFrame, year: int) -> pd.DataFrame:
+    """Parse a single annual LGD sheet into a tidy long-format DataFrame.
+
+    Args:
+        sheet_df: Raw DataFrame read with ``header=None`` from one Table sheet.
+        year: Reference year for the sheet.
+
+    Returns:
+        DataFrame with columns matching :data:`_OUTPUT_COLUMNS`.
+        Returns an empty DataFrame if the header row cannot be located.
+    """
+    # Find the header row — it contains "LGD 2014 Code" or similar
+    header_row_idx: int | None = None
+    for idx, row in sheet_df.iterrows():
+        row_str = " ".join(str(v).lower() for v in row if pd.notna(v))
+        if "lgd" in row_str and ("code" in row_str or "council" in row_str or "district" in row_str):
+            header_row_idx = int(idx)
+            break
+
+    if header_row_idx is None:
+        logger.warning("Could not find header row in sheet for year %d", year)
+        return pd.DataFrame(columns=_OUTPUT_COLUMNS)
+
+    headers = [str(v).strip() if pd.notna(v) else "" for v in sheet_df.iloc[header_row_idx]]
+
+    # Map semantic names → column positions
+    col_map: dict[str, int] = {}
+
+    def _find_col(keyword: str) -> int | None:
+        for i, h in enumerate(headers):
+            if keyword.lower() in h.lower():
+                return i
+        return None
+
+    col_map["lgd_code"] = _find_col("LGD")
+    col_map["lgd_name"] = _find_col("District") or _find_col("Council") or _find_col("Government")
+    col_map["converted_apartment"] = _find_col("Converted")
+    col_map["purpose_built_apartment"] = _find_col("Purpose")
+    col_map["detached"] = _find_col("Detached")
+    col_map["semi_detached"] = _find_col("Semi")
+    col_map["terrace"] = _find_col("Terrace")
+    col_map["total"] = _find_col("Total")
+
+    missing = [k for k, v in col_map.items() if v is None]
+    if missing:
+        logger.warning("Year %d: missing columns %s — skipping sheet", year, missing)
+        return pd.DataFrame(columns=_OUTPUT_COLUMNS)
+
+    data_rows = sheet_df.iloc[header_row_idx + 1 :].copy()
+
+    records = []
+    for _, row in data_rows.iterrows():
+        lgd_code = str(row.iloc[col_map["lgd_code"]]).strip() if pd.notna(row.iloc[col_map["lgd_code"]]) else None
+        lgd_name_raw = row.iloc[col_map["lgd_name"]]
+        lgd_name = str(lgd_name_raw).strip() if pd.notna(lgd_name_raw) else None
+
+        if not lgd_code or lgd_code in ("nan", "None", ""):
+            continue
+        # Skip rows that are clearly notes/footers
+        if lgd_code.lower().startswith("note") or lgd_code.lower().startswith("source"):
+            continue
+
+        # The NI total row has "Northern Ireland" as the code with a NaN name
+        if lgd_code == "Northern Ireland" and lgd_name is None:
+            lgd_name = "Northern Ireland"
+
+        def _safe_int(val: object) -> int | None:
+            if val is None or (isinstance(val, float) and pd.isna(val)):
+                return None
+            try:
+                return int(float(str(val)))
+            except (ValueError, TypeError):
+                return None
+
+        records.append(
+            {
+                "year": year,
+                "lgd_code": lgd_code,
+                "lgd_name": lgd_name,
+                "converted_apartment": _safe_int(row.iloc[col_map["converted_apartment"]]),
+                "purpose_built_apartment": _safe_int(row.iloc[col_map["purpose_built_apartment"]]),
+                "detached": _safe_int(row.iloc[col_map["detached"]]),
+                "semi_detached": _safe_int(row.iloc[col_map["semi_detached"]]),
+                "terrace": _safe_int(row.iloc[col_map["terrace"]]),
+                "total": _safe_int(row.iloc[col_map["total"]]),
+            }
+        )
+
+    if not records:
+        return pd.DataFrame(columns=_OUTPUT_COLUMNS)
+
+    return pd.DataFrame(records)[_OUTPUT_COLUMNS]
+
+
+def parse_lgd_file(file_path: str | object) -> pd.DataFrame:
+    """Parse the LGD-level housing stock Excel workbook into a tidy DataFrame.
+
+    Iterates over every data sheet (``Table 1.1`` … ``Table 1.19``), extracts
+    the reference year from the sheet title, parses the 11-LGD table plus the
+    NI aggregate row, and stacks all years into a single long-format DataFrame.
+
+    Args:
+        file_path: Path to the downloaded Excel file.
+
+    Returns:
+        Long-format DataFrame with columns: year, lgd_code, lgd_name,
+        converted_apartment, purpose_built_apartment, detached,
+        semi_detached, terrace, total.
+
+    Example:
+        >>> import pathlib
+        >>> df = parse_lgd_file("/tmp/housing_stock_lgd.xlsx")
+        >>> 'total' in df.columns
+        True
+    """
+    xl = pd.ExcelFile(file_path, engine="openpyxl")
+    all_frames: list[pd.DataFrame] = []
+
+    for sheet_name in xl.sheet_names:
+        if sheet_name in _SKIP_SHEETS:
+            continue
+        # Only process individual-year data tables (Table 1.1 … Table 1.19)
+        # Table 1.20 is the multi-year summary — skip it
+        if not sheet_name.startswith("Table"):
+            continue
+
+        raw = xl.parse(sheet_name, header=None)
+
+        # Get the sheet title from the first non-null cell
+        title = ""
+        for row_idx in range(min(5, len(raw))):
+            val = raw.iloc[row_idx, 0]
+            if pd.notna(val) and str(val).strip():
+                title = str(val).strip()
+                break
+
+        year = _extract_year_from_title(title)
+        if year is None:
+            logger.debug("Could not extract year from sheet '%s' title: %r — skipping", sheet_name, title)
+            continue
+
+        sheet_df = _parse_lgd_sheet(raw, year)
+        if not sheet_df.empty:
+            all_frames.append(sheet_df)
+
+    if not all_frames:
+        logger.warning("No data extracted from LGD housing stock file")
+        return pd.DataFrame(columns=_OUTPUT_COLUMNS)
+
+    result = pd.concat(all_frames, ignore_index=True).sort_values(["year", "lgd_code"]).reset_index(drop=True)
+
+    # Ensure numeric types
+    int_cols = [
+        "year",
+        "converted_apartment",
+        "purpose_built_apartment",
+        "detached",
+        "semi_detached",
+        "terrace",
+        "total",
+    ]
+    for col in int_cols:
+        result[col] = pd.to_numeric(result[col], errors="coerce")
+
+    return result
+
+
+def get_latest_housing_stock(geo: str = "lgd", force_refresh: bool = False) -> pd.DataFrame:
+    """Download and return NI housing stock data in long format.
+
+    Args:
+        geo: Geography granularity:
+            - ``'lgd'`` (default): 11 Local Government Districts + NI total.
+            - ``'ward'``: Electoral Ward level.
+            - ``'soa'``: Super Output Area level.
+        force_refresh: If ``True``, bypass the local file cache and
+            re-download the source file.
+
+    Returns:
+        Long-format DataFrame.  For ``geo='lgd'`` the columns are:
+
+        - **year** (int): Reference year (e.g. 2008).
+        - **lgd_code** (str): LGD 2014 code (e.g. ``"N09000001"``).
+        - **lgd_name** (str): LGD name (e.g. ``"Antrim and Newtownabbey"``),
+          or ``"Northern Ireland"`` for the NI-wide total row.
+        - **converted_apartment** (int): Converted apartment dwellings.
+        - **purpose_built_apartment** (int): Purpose-built apartment dwellings.
+        - **detached** (int): Detached dwellings.
+        - **semi_detached** (int): Semi-detached dwellings.
+        - **terrace** (int): Terrace dwellings.
+        - **total** (int): Total housing stock.
+
+        Ward and SOA files share the same column schema but may have
+        additional geography columns.
+
+    Raises:
+        ValueError: If ``geo`` is not one of ``'lgd'``, ``'ward'``, ``'soa'``.
+        NISRADataNotFoundError: If the source file cannot be downloaded.
+
+    Example:
+        >>> df = get_latest_housing_stock(geo='lgd')
+        >>> set(df.columns) >= {'year', 'lgd_code', 'lgd_name', 'total'}
+        True
+    """
+    if geo not in _FALLBACK_URLS:
+        raise ValueError(f"Unknown geo type {geo!r}. Use 'lgd', 'ward', or 'soa'.")
+
+    url = get_latest_publication_url(geo)
+    file_path = download_file(url, cache_ttl_hours=24, force_refresh=force_refresh)
+
+    if geo == "lgd":
+        return parse_lgd_file(file_path)
+
+    # Ward and SOA files have a different multi-column layout; return raw for now
+    # (they are downloaded and cached; a future enhancement can parse them fully)
+    logger.warning(
+        "Full parsing for geo=%r is not yet implemented; returning raw sheet data from first data tab.",
+        geo,
+    )
+    xl = pd.ExcelFile(file_path, engine="openpyxl")
+    for sheet_name in xl.sheet_names:
+        if sheet_name in _SKIP_SHEETS or not sheet_name.startswith("Table"):
+            continue
+        return xl.parse(sheet_name, header=None)
+
+    return pd.DataFrame()
+
+
+def validate_housing_stock(df: pd.DataFrame) -> bool:
+    """Validate an LGD housing stock DataFrame.
+
+    Checks that the DataFrame has the expected structure and plausible values.
+
+    Args:
+        df: DataFrame returned by :func:`get_latest_housing_stock`.
+
+    Returns:
+        ``True`` if all checks pass.
+
+    Raises:
+        NISRAValidationError: If any check fails, with a descriptive message.
+
+    Example:
+        >>> df = get_latest_housing_stock()
+        >>> validate_housing_stock(df)
+        True
+    """
+    if df is None or df.empty:
+        raise NISRAValidationError("Housing stock DataFrame is empty")
+
+    required = {
+        "year",
+        "lgd_code",
+        "lgd_name",
+        "converted_apartment",
+        "purpose_built_apartment",
+        "detached",
+        "semi_detached",
+        "terrace",
+        "total",
+    }
+    missing = required - set(df.columns)
+    if missing:
+        raise NISRAValidationError(f"Missing required columns: {sorted(missing)}")
+
+    # At least 10 years of data (2008–2024+)
+    years = df["year"].dropna().unique()
+    if len(years) < 10:
+        raise NISRAValidationError(f"Too few years ({len(years)}); expected at least 10")
+
+    # No negative values in count columns
+    count_cols = ["converted_apartment", "purpose_built_apartment", "detached", "semi_detached", "terrace", "total"]
+    for col in count_cols:
+        vals = df[col].dropna()
+        if (vals < 0).any():
+            raise NISRAValidationError(f"Negative values found in column '{col}'")
+
+    # Total should be >= sum of known subtypes (it may also include unclassified)
+    numeric_cols = ["converted_apartment", "purpose_built_apartment", "detached", "semi_detached", "terrace"]
+    sub = df.dropna(subset=numeric_cols + ["total"])
+    if not sub.empty:
+        computed_sum = sub[numeric_cols].sum(axis=1)
+        # Total should be at least as large as sum of subtypes
+        mismatch = sub[sub["total"] < computed_sum * 0.95]
+        if not mismatch.empty:
+            raise NISRAValidationError(f"'total' is implausibly lower than sum of subtypes in {len(mismatch)} rows")
+
+    return True

--- a/tests/test_nisra_housing_stock_integrity.py
+++ b/tests/test_nisra_housing_stock_integrity.py
@@ -1,0 +1,250 @@
+"""Integrity tests for NISRA Housing Stock module.
+
+Validates real data quality, structure, and consistency for the NI Housing
+Stock statistics published by the Department of Finance / Land and Property
+Services (LPS).
+
+Data is sourced from Excel workbooks downloaded directly from:
+https://www.finance-ni.gov.uk/topics/housing-stock-statistics
+
+Coverage: annual, 2008–2026.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from bolster.data_sources.nisra import housing_stock
+from bolster.data_sources.nisra._base import NISRAValidationError
+
+# The 11 LGDs used since the 2014 boundary reform
+ELEVEN_LGDS = {
+    "Antrim and Newtownabbey",
+    "Ards and North Down",
+    "Armagh City, Banbridge and Craigavon",
+    "Belfast",
+    "Causeway Coast and Glens",
+    "Derry City and Strabane",
+    "Fermanagh and Omagh",
+    "Lisburn and Castlereagh",
+    "Mid and East Antrim",
+    "Mid Ulster",
+    "Newry, Mourne and Down",
+}
+
+# NI 2026 total from the source file (Table 1.19 / Table 1.20 NI row)
+_NI_TOTAL_2026 = 848_541
+_NI_TOTAL_TOLERANCE = 0.05  # ±5 %
+
+
+class TestHousingStockLGDIntegrity:
+    """Integrity tests for LGD-level housing stock data."""
+
+    @pytest.fixture(scope="class")
+    def df(self) -> pd.DataFrame:
+        return housing_stock.get_latest_housing_stock(geo="lgd", force_refresh=False)
+
+    # ── Structure ────────────────────────────────────────────────────────────
+
+    def test_returns_dataframe(self, df: pd.DataFrame) -> None:
+        assert isinstance(df, pd.DataFrame)
+        assert not df.empty
+
+    def test_required_columns(self, df: pd.DataFrame) -> None:
+        required = {
+            "year",
+            "lgd_code",
+            "lgd_name",
+            "converted_apartment",
+            "purpose_built_apartment",
+            "detached",
+            "semi_detached",
+            "terrace",
+            "total",
+        }
+        assert required.issubset(set(df.columns))
+
+    def test_year_column_is_numeric(self, df: pd.DataFrame) -> None:
+        assert pd.api.types.is_numeric_dtype(df["year"])
+
+    # ── Geographic coverage ──────────────────────────────────────────────────
+
+    def test_eleven_lgds_present(self, df: pd.DataFrame) -> None:
+        """All 11 LGDs must appear in the data."""
+        names = set(df["lgd_name"].dropna().unique())
+        missing = ELEVEN_LGDS - names
+        assert not missing, f"Missing LGDs: {missing}"
+
+    def test_ni_total_row_present(self, df: pd.DataFrame) -> None:
+        """A Northern Ireland aggregate row must be present each year."""
+        assert "Northern Ireland" in df["lgd_name"].values
+
+    def test_twelve_rows_per_year(self, df: pd.DataFrame) -> None:
+        """Each year should have exactly 12 rows (11 LGDs + NI total)."""
+        counts = df.groupby("year")["lgd_name"].count()
+        bad_years = counts[counts != 12]
+        assert bad_years.empty, f"Years with row count ≠ 12: {bad_years.to_dict()}"
+
+    # ── Temporal coverage ────────────────────────────────────────────────────
+
+    def test_historical_start_2008(self, df: pd.DataFrame) -> None:
+        assert 2008 in df["year"].values
+
+    def test_covers_2024(self, df: pd.DataFrame) -> None:
+        assert df["year"].max() >= 2024
+
+    def test_at_least_17_years(self, df: pd.DataFrame) -> None:
+        """Data should span at least 2008–2024 (17 years)."""
+        assert df["year"].nunique() >= 17
+
+    # ── Value integrity ──────────────────────────────────────────────────────
+
+    def test_no_negative_values(self, df: pd.DataFrame) -> None:
+        count_cols = [
+            "converted_apartment",
+            "purpose_built_apartment",
+            "detached",
+            "semi_detached",
+            "terrace",
+            "total",
+        ]
+        for col in count_cols:
+            vals = df[col].dropna()
+            assert (vals >= 0).all(), f"Negative values in column '{col}'"
+
+    def test_ni_total_sums_match_lgds(self, df: pd.DataFrame) -> None:
+        """NI total row 'total' should equal (or closely approximate) sum of the 11 LGD totals."""
+        for year, grp in df.groupby("year"):
+            lgd_rows = grp[grp["lgd_name"] != "Northern Ireland"]
+            ni_row = grp[grp["lgd_name"] == "Northern Ireland"]
+            if ni_row.empty or lgd_rows.empty:
+                continue
+            lgd_sum = lgd_rows["total"].sum()
+            ni_total = ni_row["total"].iloc[0]
+            assert abs(lgd_sum - ni_total) <= ni_total * 0.01, (
+                f"Year {year}: LGD sum ({lgd_sum:,}) differs from NI total ({ni_total:,}) by >1%"
+            )
+
+    def test_2026_ni_total_approx(self, df: pd.DataFrame) -> None:
+        """2026 NI total should be approximately 848,541 (within 5%)."""
+        ni_2026 = df[(df["year"] == 2026) & (df["lgd_name"] == "Northern Ireland")]
+        if ni_2026.empty:
+            pytest.skip("2026 data not present")
+        total = ni_2026["total"].iloc[0]
+        assert abs(total - _NI_TOTAL_2026) / _NI_TOTAL_2026 <= _NI_TOTAL_TOLERANCE, (
+            f"2026 NI total {total:,} not within 5% of expected {_NI_TOTAL_2026:,}"
+        )
+
+    def test_total_gte_subtypes_sum(self, df: pd.DataFrame) -> None:
+        """Total column should be >= sum of dwelling subtypes for each row."""
+        subtype_cols = [
+            "converted_apartment",
+            "purpose_built_apartment",
+            "detached",
+            "semi_detached",
+            "terrace",
+        ]
+        sub = df.dropna(subset=subtype_cols + ["total"])
+        computed = sub[subtype_cols].sum(axis=1)
+        bad = sub[sub["total"] < computed * 0.95]
+        assert bad.empty, f"{len(bad)} rows where 'total' < 95% of subtypes sum"
+
+    # ── Validation function ──────────────────────────────────────────────────
+
+    def test_validate_passes_on_real_data(self, df: pd.DataFrame) -> None:
+        assert housing_stock.validate_housing_stock(df) is True
+
+
+# ── Validation unit tests (no network calls) ─────────────────────────────────
+
+
+class TestValidationEdgeCases:
+    """Unit tests for validate_housing_stock() edge cases — no network calls."""
+
+    def _make_base_df(self) -> pd.DataFrame:
+        """Return a minimal valid synthetic DataFrame."""
+        rows = []
+        lgds = list(ELEVEN_LGDS) + ["Northern Ireland"]
+        for year in range(2008, 2026):
+            for lgd in lgds:
+                rows.append(
+                    {
+                        "year": year,
+                        "lgd_code": "N09000001" if lgd != "Northern Ireland" else "Northern Ireland",
+                        "lgd_name": lgd,
+                        "converted_apartment": 200,
+                        "purpose_built_apartment": 5000,
+                        "detached": 18000,
+                        "semi_detached": 14000,
+                        "terrace": 16000,
+                        "total": 53200,
+                    }
+                )
+        return pd.DataFrame(rows)
+
+    def test_validate_empty_dataframe(self) -> None:
+        with pytest.raises(NISRAValidationError, match="empty"):
+            housing_stock.validate_housing_stock(pd.DataFrame())
+
+    def test_validate_none(self) -> None:
+        with pytest.raises(NISRAValidationError, match="empty"):
+            housing_stock.validate_housing_stock(None)  # type: ignore[arg-type]
+
+    def test_validate_missing_columns(self) -> None:
+        df = self._make_base_df().drop(columns=["total"])
+        with pytest.raises(NISRAValidationError, match="Missing required columns"):
+            housing_stock.validate_housing_stock(df)
+
+    def test_validate_too_few_years(self) -> None:
+        df = self._make_base_df()
+        # Keep only 5 years
+        df = df[df["year"].isin(range(2008, 2013))].copy()
+        with pytest.raises(NISRAValidationError, match="Too few years"):
+            housing_stock.validate_housing_stock(df)
+
+    def test_validate_negative_values(self) -> None:
+        df = self._make_base_df()
+        df.loc[0, "detached"] = -1
+        with pytest.raises(NISRAValidationError, match="Negative"):
+            housing_stock.validate_housing_stock(df)
+
+    def test_validate_total_lower_than_subtypes(self) -> None:
+        df = self._make_base_df()
+        # Make total implausibly low (well below 95% of sum of subtypes)
+        df.loc[0, "total"] = 100
+        with pytest.raises(NISRAValidationError, match="total.*lower"):
+            housing_stock.validate_housing_stock(df)
+
+    def test_validate_passes_on_synthetic_valid_data(self) -> None:
+        assert housing_stock.validate_housing_stock(self._make_base_df()) is True
+
+
+# ── Helper function unit tests ────────────────────────────────────────────────
+
+
+class TestHelpers:
+    """Unit tests for internal helper functions — no network calls."""
+
+    def test_extract_year_from_title_april(self) -> None:
+        from bolster.data_sources.nisra.housing_stock import _extract_year_from_title
+
+        assert _extract_year_from_title("Number of Dwellings ... - April 2009") == 2009
+
+    def test_extract_year_from_title_may(self) -> None:
+        from bolster.data_sources.nisra.housing_stock import _extract_year_from_title
+
+        assert _extract_year_from_title("Number of Dwellings ... - May 2008") == 2008
+
+    def test_extract_year_from_title_no_year(self) -> None:
+        from bolster.data_sources.nisra.housing_stock import _extract_year_from_title
+
+        assert _extract_year_from_title("No year here") is None
+
+    def test_get_latest_publication_url_invalid_geo(self) -> None:
+        with pytest.raises(ValueError, match="Unknown geo type"):
+            housing_stock.get_latest_publication_url("invalid")
+
+    def test_get_latest_housing_stock_invalid_geo(self) -> None:
+        with pytest.raises(ValueError, match="Unknown geo type"):
+            housing_stock.get_latest_housing_stock(geo="invalid")


### PR DESCRIPTION
## Summary

Adds `src/bolster/data_sources/nisra/housing_stock.py` for NI dwelling stock by property type and geography (2008–2026), sourced from Department of Finance NI / Land & Property Services.

- `get_latest_housing_stock(geo='lgd')` — long-format DataFrame with year, LGD, property type counts
- `get_latest_publication_url()` — scrapes finance-ni.gov.uk for current year's Excel
- Ward/SOA geo modes available (raw data, full parsing future work)
- 2026 NI total: 848,541 dwellings confirmed

## CLI

```bash
bolster nisra housing-stock [--geo lgd|ward|soa] [--year YYYY]
```

## Test plan
- [x] 26 new tests passing
- [x] Full suite 1710 passing (no regressions)
- [x] Pre-commit clean

Closes #1883

🤖 Generated with [Claude Code](https://claude.com/claude-code)