### PR TITLE
feat(translink): live departure boards + vehicle positions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 # Changelog
 
-## [0.7.0] - 2026-05-28
+## \[Unreleased\]
+
+- feat(translink): add live departure boards and vehicle positions module (#XXX)
+  - `get_departures_by_name()` / `get_departures()` — next-N departures from any Translink stop
+  - `get_live_vehicles()` — live vehicle snapshot from Translink VMI feed
+  - `get_departures_with_vehicles()` — departure boards enriched with VMI vehicle positions
+  - Stop metadata from Open Data NI ATCO-CIF zips (12,700+ stops, ING→WGS84 conversion)
+  - CLI: `bolster translink departures <stop>` and `bolster translink vehicles`
+  - 46 unit tests + 35 integration tests, all no-mock
+
+## \[0.7.0\] - 2026-05-28
 
 - fix(readme): correct CI badge workflow filename (test.yml → pytest.yml) (#1842)
 - feat(nisra/disease_prevalence): add GP-practice-level data from Table 5 sheets (#1839)
@@ -62,7 +72,6 @@
 - fix(web): add tqdm progress bar to download_extract_zip (#314)
 - fix(drift-detection): bump artifact actions to Node.js 24, fix speciesName trailing punctuation
 - feat: weekly NISRA feed drift detection via TF-IDF (#1732)
-
 
 All notable changes to this project will be documented in this file.
 

--- a/docs/development/translink-lateness-tracking.md
+++ b/docs/development/translink-lateness-tracking.md
@@ -1,0 +1,126 @@
+# Translink Network Lateness Tracking
+
+Design notes from initial exploration of the Translink VMI feed (2026-06-25),
+following the build of the `translink` data source module (PR #1917).
+
+## Key finding: one call covers the whole network
+
+The VMI feed (`vpos.translinkniplanner.co.uk/velocmap/vmi/VMI`) returns a snapshot
+of **every active vehicle on the entire Translink network** in a single unauthenticated
+GET request. There is no need to poll per-stop or per-line.
+
+A snapshot taken during evening peak (c. 18:20 BST) showed:
+
+- **185 Metro vehicles** active simultaneously
+- **70+ distinct lines** represented
+- **~85% of vehicles** have a non-null `delay_seconds` value (`realtime_available=True`)
+- Delay range observed: **-449s (7.5 min early) to +1178s (nearly 20 min late)**
+- The `delay_seconds` field is computed server-side by Vix Technology — negative = early
+
+Sample lateness snapshot (Metro, evening peak):
+
+| Line | Vehicles | Mean delay (s) | Median delay (s) |
+|------|----------|----------------|------------------|
+| 11G  | 1        | +1178          | —                |
+| 2C   | 4        | +299           | +240             |
+| 11E  | 4        | +7             | 0                |
+| 10K  | 2        | -9             | -9               |
+| 3A   | 2        | -22            | -22              |
+
+## Proposed persistence approach
+
+```
+Every 66 seconds (VMI refresh interval):
+    GET /velocmap/vmi/VMI
+    append rows to store:
+        timestamp, vehicle_id, line, direction, journey_id,
+        delay_seconds, current_stop, next_stop, latitude, longitude
+```
+
+Volume estimate (Metro only, ~185 vehicles):
+
+- ~185 rows per snapshot
+- ~2,700 rows/hour
+- ~65,000 rows/day
+- ~24M rows/year
+
+Parquet partitioned by `date` would be trivially small (\<500 MB/year uncompressed).
+SQLite is simpler for a single-machine poller.
+
+## What you could answer with this data
+
+- **Per-line lateness distributions**: median/p95 delay by line, time-of-day, day-of-week
+- **Per-stop lateness**: join `current_stop` (NaPTAN ATCOCode) to the stop lookup table
+- **Journey reliability**: track individual `journey_id` runs across their full route
+- **Early departures**: `delay_seconds < -60` — buses leaving stops ahead of schedule
+- **Bunching detection**: two vehicles on same line/direction within small time window
+- **Seasonal/event effects**: bank holidays, school terms, major events in Belfast
+
+## Constraints and gaps
+
+- `delay_seconds` is null for ~15% of vehicles (`realtime_available=False`) — these
+  runs cannot be tracked for lateness, only presence
+- `delay_seconds` is relative to the scheduled time at the **current position**, not
+  at any specific stop — it will drift as the bus moves
+- VMI `journey_id` is an HHMM string (local time, origin departure), not a globally
+  unique trip ID — collisions possible on routes with >1 departure per minute
+- The VMI feed has no historical API; data only exists while you're polling
+- `current_stop` / `next_stop` are NaPTAN ATCOCodes — joinable to the CIF stop lookup
+  via `get_stop_lookup()`, but ~15% of VMI ATCOCodes are not in the current CIF zips
+  (newer stops); these fall back to the live `locationApi/find` endpoint
+
+## Implementation sketch
+
+```python
+import time
+import sqlite3
+from datetime import datetime, timezone
+from bolster.data_sources.translink.vehicles import get_live_vehicles
+
+
+def poll_loop(db_path="translink_lateness.db", operator="MET"):
+    con = sqlite3.connect(db_path)
+    con.execute("""
+        CREATE TABLE IF NOT EXISTS snapshots (
+            polled_at TEXT,
+            vehicle_id TEXT,
+            line TEXT,
+            direction TEXT,
+            journey_id TEXT,
+            delay_seconds INTEGER,
+            current_stop TEXT,
+            next_stop TEXT,
+            latitude REAL,
+            longitude REAL
+        )
+    """)
+    while True:
+        polled_at = datetime.now(timezone.utc).isoformat()
+        df = get_live_vehicles(operator=operator)
+        df["polled_at"] = polled_at
+        df[
+            [
+                "polled_at",
+                "vehicle_id",
+                "line",
+                "direction",
+                "journey_id",
+                "delay_seconds",
+                "current_stop",
+                "next_stop",
+                "latitude",
+                "longitude",
+            ]
+        ].to_sql("snapshots", con, if_exists="append", index=False)
+        con.commit()
+        time.sleep(66)
+```
+
+A CLI command `bolster translink poll` wrapping this would be a natural extension
+of the existing `translink` group in `cli.py`.
+
+## Related
+
+- PR #1917 — initial `translink` module (departures, vehicles, stops)
+- `src/bolster/data_sources/translink/vehicles.py` — `get_live_vehicles()`
+- `src/bolster/data_sources/translink/stops.py` — `get_stop_lookup()` for ATCOCode resolution

--- a/src/bolster/cli.py
+++ b/src/bolster/cli.py
@@ -55,7 +55,7 @@ from .data_sources.nisra.tourism import visitor_statistics as nisra_visitors
 from .data_sources.ons_cpi import SERIES as ONS_CPI_SERIES
 from .data_sources.ons_cpi import get_latest_data as get_ons_cpi_latest
 from .data_sources.ons_cpi import get_series as get_ons_cpi_series
-from .data_sources.translink.departures import get_departures_by_name, get_departures_with_vehicles
+from .data_sources.translink.departures import get_departures_by_name, get_departures_with_vehicles, get_direct_journeys
 from .data_sources.translink.vehicles import get_live_vehicles
 from .data_sources.wikipedia import get_ni_executive_basic_table
 from .utils.rss import filter_entries, get_nisra_statistics_feed, parse_rss_feed
@@ -7526,6 +7526,81 @@ def translink_vehicles_cmd(line, operator, enrich_stops, output_format, save):
 
     console.print(table)
     console.print(f"[dim]{len(df)} vehicles[/dim]")
+
+    if save:
+        df.to_csv(save, index=False)
+        console.print(f"[green]Saved to {save}[/green]")
+
+
+@translink.command(name="route")
+@click.argument("origin")
+@click.argument("destination")
+@click.option("--n", default=5, show_default=True, help="Number of journeys to return")
+@click.option(
+    "--format",
+    "output_format",
+    type=click.Choice(["table", "csv", "json"]),
+    default="table",
+    help="Output format (default: table)",
+)
+@click.option("--save", help="Save output to file (specify filename)")
+def translink_route_cmd(origin, destination, n, output_format, save):
+    r"""Show next N direct journeys between two stops.
+
+    Bails out if no direct service runs between ORIGIN and DESTINATION —
+    does not suggest connections or changes.
+
+    Examples:
+        bolster translink route "Central Library" "Flax Street"
+        bolster translink route "Great Victoria Street" "Lisburn Bus Centre" --n 3
+    """
+    from rich.table import Table
+
+    console = Console()
+
+    try:
+        with console.status(f"[bold green]Finding direct services '{origin}' → '{destination}'..."):
+            df = get_direct_journeys(origin, destination, n=n)
+    except Exception as e:
+        console.print(f"[red]Error:[/red] {e}")
+        raise SystemExit(1) from e
+
+    if output_format == "csv":
+        output = df.to_csv(index=False)
+        if save:
+            with open(save, "w") as f:
+                f.write(output)
+            console.print(f"[green]Saved to {save}[/green]")
+        else:
+            click.echo(output)
+        return
+
+    if output_format == "json":
+        output = df.to_json(orient="records", date_format="iso", indent=2)
+        if save:
+            with open(save, "w") as f:
+                f.write(output)
+            console.print(f"[green]Saved to {save}[/green]")
+        else:
+            click.echo(output)
+        return
+
+    table = Table(title=f"{df['origin'].iloc[0]} → {df['destination'].iloc[0]}", show_lines=False)
+    table.add_column("Service", style="bold")
+    table.add_column("Departs", style="cyan", no_wrap=True)
+    table.add_column("Arrives", style="cyan", no_wrap=True)
+    table.add_column("Days")
+
+    for _, row in df.iterrows():
+        dep = row["scheduled_departure"]
+        arr = row["scheduled_arrival"]
+        dep_fmt = f"{dep[:2]}:{dep[2:]}" if len(dep) == 4 else dep
+        arr_fmt = f"{arr[:2]}:{arr[2:]}" if len(arr) == 4 else arr
+        days_map = "MTWTFSS"
+        days_str = "".join(d if row["days"][i] == "1" else "·" for i, d in enumerate(days_map))
+        table.add_row(row["service"], dep_fmt, arr_fmt, days_str)
+
+    console.print(table)
 
     if save:
         df.to_csv(save, index=False)

--- a/src/bolster/cli.py
+++ b/src/bolster/cli.py
@@ -55,6 +55,8 @@ from .data_sources.nisra.tourism import visitor_statistics as nisra_visitors
 from .data_sources.ons_cpi import SERIES as ONS_CPI_SERIES
 from .data_sources.ons_cpi import get_latest_data as get_ons_cpi_latest
 from .data_sources.ons_cpi import get_series as get_ons_cpi_series
+from .data_sources.translink.departures import get_departures_by_name, get_departures_with_vehicles
+from .data_sources.translink.vehicles import get_live_vehicles
 from .data_sources.wikipedia import get_ni_executive_basic_table
 from .utils.rss import filter_entries, get_nisra_statistics_feed, parse_rss_feed
 
@@ -7103,8 +7105,6 @@ def boe_base_rate_cmd(resolution, changes, year, output_format, force_refresh, s
         console.print("   - Check your internet connection")
         console.print("   - Try again with --force-refresh to bypass cache")
         raise click.Abort() from e
-
-
 @cli.group(name="niassembly")
 def niassembly_group():
     """NI Assembly AIMS — Members, Questions, and Votes.
@@ -7327,6 +7327,211 @@ def niassembly_votes_cmd(start_date, end_date, division_id, output_format, save)
         raise click.Abort() from e
 
 
+@cli.group()
+def translink():
+    """Translink NI live departures and vehicle positions.
+
+    Commands for querying Translink bus and rail departure boards and
+    live vehicle positions from the Translink VMI feed.
+    """
+    pass
+
+
+@translink.command(name="departures")
+@click.argument("stop_name")
+@click.option("--n", default=5, show_default=True, help="Number of departures to return")
+@click.option("--vehicles", "with_vehicles", is_flag=True, help="Enrich with live vehicle positions")
+@click.option("--enrich-stops", is_flag=True, help="Resolve ATCOCodes to stop names (with --vehicles)")
+@click.option(
+    "--format",
+    "output_format",
+    type=click.Choice(["table", "csv", "json"]),
+    default="table",
+    help="Output format (default: table)",
+)
+@click.option("--save", help="Save output to file (specify filename)")
+def translink_departures_cmd(stop_name, n, with_vehicles, enrich_stops, output_format, save):
+    r"""Show next N departures from a Translink stop.
+
+    STOP_NAME is the name or partial name of the stop to query.
+
+    Examples:
+        bolster translink departures "Cambria Street"
+        bolster translink departures "Cambria Street" --n 10 --vehicles
+        bolster translink departures "Great Victoria Street" --format csv
+    """
+    from rich.table import Table
+
+    console = Console()
+
+    try:
+        with console.status(f"[bold green]Fetching departures from '{stop_name}'..."):
+            if with_vehicles:
+                df = get_departures_with_vehicles(stop_name, n=n, enrich_stops=enrich_stops)
+            else:
+                df = get_departures_by_name(stop_name, n=n)
+    except Exception as e:
+        console.print(f"[red]Error:[/red] {e}")
+        raise SystemExit(1) from e
+
+    if df.empty:
+        console.print("[yellow]No departures found (outside service hours?)[/yellow]")
+        return
+
+    if output_format == "csv":
+        output = df.to_csv(index=False)
+        if save:
+            with open(save, "w") as f:
+                f.write(output)
+            console.print(f"[green]Saved to {save}[/green]")
+        else:
+            click.echo(output)
+        return
+
+    if output_format == "json":
+        output = df.to_json(orient="records", date_format="iso", indent=2)
+        if save:
+            with open(save, "w") as f:
+                f.write(output)
+            console.print(f"[green]Saved to {save}[/green]")
+        else:
+            click.echo(output)
+        return
+
+    stop = df["stop_name"].iloc[0] if "stop_name" in df.columns else stop_name
+    table = Table(title=f"Departures from {stop}", show_lines=False)
+    table.add_column("Time (UTC)", style="cyan", no_wrap=True)
+    table.add_column("Service", style="bold")
+    table.add_column("Destination")
+    table.add_column("Delay", justify="right")
+    table.add_column("RT", justify="center")
+    if with_vehicles:
+        table.add_column("Vehicle")
+        table.add_column("Next Stop")
+
+    for _, row in df.iterrows():
+        dep_time = str(row["actual_departure"])[:19] if pd.notna(row["actual_departure"]) else "-"
+        delay = row.get("delay_minutes", 0)
+        delay_str = f"+{delay:.0f}m" if delay > 0 else (f"{delay:.0f}m" if delay < 0 else "on time")
+        delay_style = "red" if delay > 2 else ("green" if delay < 0 else "")
+        rt_str = "✓" if row.get("is_real_time") else ""
+        cols = [
+            dep_time,
+            row.get("service", ""),
+            row.get("destination", ""),
+            f"[{delay_style}]{delay_str}[/{delay_style}]" if delay_style else delay_str,
+            rt_str,
+        ]
+        if with_vehicles:
+            vid = row.get("vehicle_id") or "-"
+            next_stop = row.get("next_stop_name") or row.get("next_stop") or "-"
+            cols += [str(vid), str(next_stop)]
+        table.add_row(*cols)
+
+    console.print(table)
+
+    if save:
+        df.to_csv(save, index=False)
+        console.print(f"[green]Saved to {save}[/green]")
+
+
+@translink.command(name="vehicles")
+@click.option("--line", help="Filter by line number (e.g. 11E, G1)")
+@click.option("--operator", help="Filter by operator (MET, ULB, GDR)")
+@click.option("--enrich-stops", is_flag=True, help="Resolve ATCOCodes to stop names")
+@click.option(
+    "--format",
+    "output_format",
+    type=click.Choice(["table", "csv", "json"]),
+    default="table",
+    help="Output format (default: table)",
+)
+@click.option("--save", help="Save output to file (specify filename)")
+def translink_vehicles_cmd(line, operator, enrich_stops, output_format, save):
+    r"""Show live Translink vehicle positions from the VMI feed.
+
+    Examples:
+        bolster translink vehicles
+        bolster translink vehicles --line 11E
+        bolster translink vehicles --operator MET --format csv
+    """
+    from rich.table import Table
+
+    console = Console()
+
+    try:
+        with console.status("[bold green]Fetching live vehicle positions..."):
+            df = get_live_vehicles(line=line, operator=operator, enrich_stops=enrich_stops)
+    except Exception as e:
+        console.print(f"[red]Error:[/red] {e}")
+        raise SystemExit(1) from e
+
+    if df.empty:
+        console.print("[yellow]No vehicles found (outside service hours or no match)[/yellow]")
+        return
+
+    if output_format == "csv":
+        output = df.to_csv(index=False)
+        if save:
+            with open(save, "w") as f:
+                f.write(output)
+            console.print(f"[green]Saved to {save}[/green]")
+        else:
+            click.echo(output)
+        return
+
+    if output_format == "json":
+        output = df.to_json(orient="records", date_format="iso", indent=2)
+        if save:
+            with open(save, "w") as f:
+                f.write(output)
+            console.print(f"[green]Saved to {save}[/green]")
+        else:
+            click.echo(output)
+        return
+
+    title = "Live Translink Vehicles"
+    if line:
+        title += f" — Line {line.upper()}"
+    if operator:
+        title += f" — Operator {operator.upper()}"
+    table = Table(title=title, show_lines=False)
+    table.add_column("Vehicle ID", style="cyan")
+    table.add_column("Line", style="bold")
+    table.add_column("Direction")
+    table.add_column("Journey")
+    table.add_column("Delay(s)", justify="right")
+    table.add_column("Lat", justify="right")
+    table.add_column("Lon", justify="right")
+    if enrich_stops:
+        table.add_column("Next Stop")
+
+    for _, row in df.iterrows():
+        delay_val = row.get("delay_seconds")
+        delay_str = str(int(delay_val)) if pd.notna(delay_val) else "-"
+        lat = f"{row['latitude']:.5f}" if pd.notna(row.get("latitude")) else "-"
+        lon = f"{row['longitude']:.5f}" if pd.notna(row.get("longitude")) else "-"
+        cols = [
+            str(row.get("vehicle_id", "")),
+            str(row.get("line", "")),
+            str(row.get("direction", "")),
+            str(row.get("journey_id", "")),
+            delay_str,
+            lat,
+            lon,
+        ]
+        if enrich_stops:
+            cols.append(str(row.get("next_stop_name") or "-"))
+        table.add_row(*cols)
+
+    console.print(table)
+    console.print(f"[dim]{len(df)} vehicles[/dim]")
+
+    if save:
+        df.to_csv(save, index=False)
+        console.print(f"[green]Saved to {save}[/green]")
+
+
 @cli.command()
 def list_sources():
     """List all available data sources and their descriptions.
@@ -7365,6 +7570,10 @@ def list_sources():
     click.echo("\nTRANSPORT")
     click.echo("  dva                  DVA monthly test statistics (vehicle, driver, theory)")
     click.echo("                       April 2014 - present, includes --summary dashboard")
+    click.echo("  translink departures Next N departures from a Translink stop")
+    click.echo("                       Live departure boards with optional vehicle enrichment")
+    click.echo("  translink vehicles   Live Translink vehicle positions from VMI feed")
+    click.echo("                       Filter by line or operator; ~66s refresh interval")
 
     click.echo("\nENTERTAINMENT & LIFESTYLE")
     click.echo("  cinema-listings      Cineworld movie listings and showtimes")

--- a/src/bolster/cli.py
+++ b/src/bolster/cli.py
@@ -7105,6 +7105,8 @@ def boe_base_rate_cmd(resolution, changes, year, output_format, force_refresh, s
         console.print("   - Check your internet connection")
         console.print("   - Try again with --force-refresh to bypass cache")
         raise click.Abort() from e
+
+
 @cli.group(name="niassembly")
 def niassembly_group():
     """NI Assembly AIMS — Members, Questions, and Votes.

--- a/src/bolster/data_sources/__init__.py
+++ b/src/bolster/data_sources/__init__.py
@@ -16,6 +16,7 @@ Various scrapers and API wrappers for NI government data:
 - ons_cpi: ONS UK inflation indices (CPI, CPIH, RPI)
 - boe_base_rate: Bank of England official Bank Rate (base rate)
 - niassembly: NI Assembly AIMS — MLAs, Questions, and Votes (OGL v3.0)
+- translink: Live and scheduled bus/rail departures + vehicle positions (Translink NI)
 
 Most have corresponding CLI commands.
 """

--- a/src/bolster/data_sources/translink/__init__.py
+++ b/src/bolster/data_sources/translink/__init__.py
@@ -7,6 +7,7 @@ Data sources:
 - Live vehicle positions: undocumented VMI feed (vpos.translinkniplanner.co.uk)
 - Scheduled departures: Translink journey planner API (translink.co.uk)
 - Stop metadata: Open Data NI ATCO-CIF timetable zips (admin.opendatani.gov.uk)
+- Point-to-point routing: CIF timetable trip sequences (no journey planner dependency)
 
 Example:
     >>> from bolster.data_sources import translink
@@ -26,6 +27,7 @@ from .departures import (
     get_departures,
     get_departures_by_name,
     get_departures_with_vehicles,
+    get_direct_journeys,
     validate_departures,
 )
 from .stops import (
@@ -33,6 +35,11 @@ from .stops import (
     get_stop_dataframe,
     get_stop_lookup,
     resolve_stop_name,
+)
+from .timetable import (
+    find_direct_trips,
+    find_services_at_stop,
+    get_trip_index,
 )
 from .vehicles import (
     get_live_vehicles,
@@ -48,6 +55,7 @@ __all__ = [
     "get_departures",
     "get_departures_by_name",
     "get_departures_with_vehicles",
+    "get_direct_journeys",
     "validate_departures",
     "find_stop",
     "get_stop_dataframe",
@@ -55,4 +63,7 @@ __all__ = [
     "resolve_stop_name",
     "get_live_vehicles",
     "validate_vehicles",
+    "find_direct_trips",
+    "find_services_at_stop",
+    "get_trip_index",
 ]

--- a/src/bolster/data_sources/translink/__init__.py
+++ b/src/bolster/data_sources/translink/__init__.py
@@ -1,0 +1,30 @@
+"""Translink (NI) Data Sources.
+
+Provides access to live and scheduled transport data for Northern Ireland's
+Translink-operated services (Ulsterbus, Metro, Glider, NI Railways).
+
+Data sources:
+- Live vehicle positions: undocumented VMI feed (vpos.translinkniplanner.co.uk)
+- Scheduled departures: Translink journey planner API (translink.co.uk)
+- Stop metadata: Open Data NI ATCO-CIF timetable zips (admin.opendatani.gov.uk)
+
+Example:
+    >>> from bolster.data_sources import translink
+    >>> deps = translink.get_departures("Shankill, Cambria Street", n=5)
+    >>> "planned_departure" in deps.columns
+    True
+"""
+
+from ._base import (
+    TranslinkDataError,
+    TranslinkDataNotFoundError,
+    TranslinkValidationError,
+    clear_cache,
+)
+
+__all__ = [
+    "TranslinkDataError",
+    "TranslinkDataNotFoundError",
+    "TranslinkValidationError",
+    "clear_cache",
+]

--- a/src/bolster/data_sources/translink/__init__.py
+++ b/src/bolster/data_sources/translink/__init__.py
@@ -10,7 +10,7 @@ Data sources:
 
 Example:
     >>> from bolster.data_sources import translink
-    >>> deps = translink.get_departures("Shankill, Cambria Street", n=5)
+    >>> deps = translink.get_departures_by_name("Shankill, Cambria Street", n=3)
     >>> "planned_departure" in deps.columns
     True
 """
@@ -21,10 +21,38 @@ from ._base import (
     TranslinkValidationError,
     clear_cache,
 )
+from .departures import (
+    find_stop_id,
+    get_departures,
+    get_departures_by_name,
+    get_departures_with_vehicles,
+    validate_departures,
+)
+from .stops import (
+    find_stop,
+    get_stop_dataframe,
+    get_stop_lookup,
+    resolve_stop_name,
+)
+from .vehicles import (
+    get_live_vehicles,
+    validate_vehicles,
+)
 
 __all__ = [
     "TranslinkDataError",
     "TranslinkDataNotFoundError",
     "TranslinkValidationError",
     "clear_cache",
+    "find_stop_id",
+    "get_departures",
+    "get_departures_by_name",
+    "get_departures_with_vehicles",
+    "validate_departures",
+    "find_stop",
+    "get_stop_dataframe",
+    "get_stop_lookup",
+    "resolve_stop_name",
+    "get_live_vehicles",
+    "validate_vehicles",
 ]

--- a/src/bolster/data_sources/translink/_base.py
+++ b/src/bolster/data_sources/translink/_base.py
@@ -1,0 +1,69 @@
+"""Common utilities for Translink data sources."""
+
+import logging
+from pathlib import Path
+
+from bolster.utils.cache import CachedDownloader, DownloadError
+
+logger = logging.getLogger(__name__)
+
+_downloader = CachedDownloader("translink", timeout=30)
+
+TRANSLINK_BASE_URL = "https://www.translink.co.uk"
+VMI_URL = "https://vpos.translinkniplanner.co.uk/velocmap/vmi/VMI"
+
+OPENDATANI_METRO_GLIDER_URL = (
+    "https://admin.opendatani.gov.uk/dataset/6d9677cf-8d03-4851-985c-16f73f7dd5fb"
+    "/resource/f2c58049-7ca9-4576-b3bd-1b3d8a8674e0/download/metro-glider-16042026.zip"
+)
+OPENDATANI_ULSTERBUS_URL = (
+    "https://admin.opendatani.gov.uk/dataset/c1acee5b-a400-46bd-a795-9bf7637ff879"
+    "/resource/291cbb54-7bb3-4df7-8599-0c8f49a20be6/download/ulb-gle-16042026.zip"
+)
+
+# .NET ticks epoch offset (100ns ticks since 0001-01-01 → Unix seconds)
+_NET_TICKS_EPOCH = 621_355_968_000_000_000
+_NET_TICKS_PER_SECOND = 10_000_000
+
+
+def net_ticks_to_timestamp(ticks: int):
+    """Convert a .NET DateTime ticks value to a pandas Timestamp (UTC)."""
+    import pandas as pd
+
+    unix_seconds = (ticks - _NET_TICKS_EPOCH) / _NET_TICKS_PER_SECOND
+    return pd.Timestamp(unix_seconds, unit="s", tz="UTC")
+
+
+# Operator code normalisation: VMI uses TM for Metro buses
+OPERATOR_ALIASES = {"TM": "MET"}
+
+KNOWN_OPERATORS = {"FY", "GLE", "GDR", "MET", "TM", "ULB", "UTS"}
+
+
+class TranslinkDataError(Exception):
+    """Base exception for Translink data errors."""
+
+
+class TranslinkDataNotFoundError(TranslinkDataError):
+    """Raised when a Translink endpoint or resource cannot be reached."""
+
+
+class TranslinkValidationError(TranslinkDataError):
+    """Raised when Translink data fails validation checks."""
+
+
+def download_file(
+    url: str,
+    cache_ttl_hours: int = 24,
+    force_refresh: bool = False,
+) -> Path:
+    """Download a file with caching. Raises TranslinkDataNotFoundError on failure."""
+    try:
+        return _downloader.download(url, cache_ttl_hours=cache_ttl_hours, force_refresh=force_refresh)
+    except DownloadError as e:
+        raise TranslinkDataNotFoundError(str(e)) from e
+
+
+def clear_cache(pattern: str | None = None) -> int:
+    """Clear cached Translink files. Returns number of files deleted."""
+    return _downloader.clear(pattern)

--- a/src/bolster/data_sources/translink/departures.py
+++ b/src/bolster/data_sources/translink/departures.py
@@ -456,12 +456,22 @@ def get_direct_journeys(
     tz_london = ZoneInfo("Europe/London")
     ref_local = dt.astimezone(tz_london) if dt.tzinfo else dt.replace(tzinfo=timezone.utc).astimezone(tz_london)
     ref_hhmm = ref_local.strftime("%H%M")
+    # days string is MTWTFSS (index 0=Mon … 6=Sun); weekday() returns 0=Mon … 6=Sun
+    weekday_idx = ref_local.weekday()
 
-    upcoming = [(trip, orig_ts, dest_ts) for trip, orig_ts, dest_ts in direct if orig_ts.depart >= ref_hhmm]
+    upcoming = [
+        (trip, orig_ts, dest_ts)
+        for trip, orig_ts, dest_ts in direct
+        if len(trip.days) > weekday_idx and trip.days[weekday_idx] == "1" and orig_ts.depart >= ref_hhmm
+    ]
 
-    # If nothing upcoming today, wrap around to the start of the list
+    # If nothing upcoming today, fall back to all trips running today (from start of day)
     if not upcoming:
-        upcoming = direct
+        upcoming = [
+            (trip, orig_ts, dest_ts)
+            for trip, orig_ts, dest_ts in direct
+            if len(trip.days) > weekday_idx and trip.days[weekday_idx] == "1"
+        ]
 
     rows = []
     for trip, orig_ts, dest_ts in upcoming[:n]:

--- a/src/bolster/data_sources/translink/departures.py
+++ b/src/bolster/data_sources/translink/departures.py
@@ -387,18 +387,16 @@ def get_departures_with_vehicles(
 def _extract_line(service_name: str) -> str:
     """Extract the line identifier from a service name.
 
+    Strips a leading mode prefix ('Bus ', 'Glider ') and uppercases the
+    remainder.  Rail and other service types are returned as-is (title-cased).
+
     Examples:
-        'Bus 11e'                  → '11E'
-        'Glider G1'                → 'G1'
-        'Rail Larne Line'          → 'Rail Larne'
-        'Rail Derry/Londonderry Line' → 'Rail Derry/Londonderry'
+        'Bus 11e'                     → '11E'
+        'Glider G1'                   → 'G1'
+        'Rail Larne Line'             → 'Rail Larne Line'
+        'Rail Derry/Londonderry Line' → 'Rail Derry/Londonderry Line'
     """
-    import re
-
-    # Rail services end with ' Line' — use everything after 'Rail '
-    rail_m = re.match(r"Rail\s+(.+?)\s+Line$", service_name, re.IGNORECASE)
-    if rail_m:
-        return f"Rail {rail_m.group(1)}"
-
-    m = re.search(r"(\w+)$", service_name)
-    return m.group(1).upper() if m else service_name.upper()
+    for prefix in ("Bus ", "Glider "):
+        if service_name.startswith(prefix):
+            return service_name[len(prefix) :].upper()
+    return service_name

--- a/src/bolster/data_sources/translink/departures.py
+++ b/src/bolster/data_sources/translink/departures.py
@@ -258,7 +258,7 @@ def get_departures_with_vehicles(
     """Return next-N departures enriched with live vehicle positions where available.
 
     Fetches departures and live VMI vehicles in parallel (two API calls), then
-    joins on line + direction + journey time proximity (±10 minute window).
+    joins on line + direction + journey time proximity (±60 minute window).
 
     VMI vehicles are matched to departures by:
     1. Line number (case-insensitive).
@@ -385,8 +385,20 @@ def get_departures_with_vehicles(
 
 
 def _extract_line(service_name: str) -> str:
-    """Extract the line number from a service name like 'Bus 11e' → '11E'."""
+    """Extract the line identifier from a service name.
+
+    Examples:
+        'Bus 11e'                  → '11E'
+        'Glider G1'                → 'G1'
+        'Rail Larne Line'          → 'Rail Larne'
+        'Rail Derry/Londonderry Line' → 'Rail Derry/Londonderry'
+    """
     import re
+
+    # Rail services end with ' Line' — use everything after 'Rail '
+    rail_m = re.match(r"Rail\s+(.+?)\s+Line$", service_name, re.IGNORECASE)
+    if rail_m:
+        return f"Rail {rail_m.group(1)}"
 
     m = re.search(r"(\w+)$", service_name)
     return m.group(1).upper() if m else service_name.upper()

--- a/src/bolster/data_sources/translink/departures.py
+++ b/src/bolster/data_sources/translink/departures.py
@@ -247,3 +247,146 @@ def validate_departures(df: pd.DataFrame) -> bool:
         raise TranslinkValidationError("is_cancelled must be bool")
 
     return True
+
+
+def get_departures_with_vehicles(
+    stop_name: str,
+    n: int = 5,
+    dt: datetime | None = None,
+    enrich_stops: bool = False,
+) -> pd.DataFrame:
+    """Return next-N departures enriched with live vehicle positions where available.
+
+    Fetches departures and live VMI vehicles in parallel (two API calls), then
+    joins on line + direction + journey time proximity (±10 minute window).
+
+    VMI vehicles are matched to departures by:
+    1. Line number (case-insensitive).
+    2. Inferred direction (inbound = destination contains "Belfast"/"CastleCourt"/
+       "Royal Avenue"/"City Centre"; outbound = everything else).
+    3. Journey ID (HHMM) within ±60 minutes of the actual departure time.
+
+    Not all departures will have a matched vehicle — buses that have not yet
+    started their journey are not yet in the VMI feed.
+
+    Args:
+        stop_name: Stop name to search for (resolved via :func:`find_stop_id`).
+        n: Number of departures to return (default 5).
+        dt: Reference datetime (default: now, UTC).
+        enrich_stops: If True, include ``current_stop_name`` and ``next_stop_name``
+                      for matched vehicles.
+
+    Returns:
+        DataFrame with all departure columns plus optional vehicle columns:
+        ``vehicle_id``, ``vehicle_lat``, ``vehicle_lon``, ``vehicle_delay_s``,
+        ``current_stop``, ``next_stop``, and (if enrich_stops) ``current_stop_name``,
+        ``next_stop_name``.  Vehicle columns are ``None`` / ``NaN`` where no match.
+    """
+    from .vehicles import get_live_vehicles
+
+    deps = get_departures_by_name(stop_name, n=n, dt=dt)
+    if deps.empty:
+        return deps
+
+    # Collect lines present in departures to reduce VMI filtering work
+    dep_lines = {_extract_line(s) for s in deps["service"].unique()}
+
+    all_vehicles = []
+    for line in dep_lines:
+        vdf = get_live_vehicles(line=line, enrich_stops=enrich_stops)
+        all_vehicles.append(vdf)
+
+    if not all_vehicles or all(v.empty for v in all_vehicles):
+        # No live vehicles on any line — return departures as-is with empty vehicle cols
+        for col in ("vehicle_id", "vehicle_lat", "vehicle_lon", "vehicle_delay_s", "current_stop", "next_stop"):
+            deps[col] = None
+        return deps
+
+    vehicles = pd.concat([v for v in all_vehicles if not v.empty], ignore_index=True)
+
+    _INBOUND_KEYWORDS = {"belfast", "castlecourt", "royal avenue", "city centre", "great victoria"}
+
+    def _dep_direction(destination: str) -> str:
+        return "inbound" if any(kw in destination.lower() for kw in _INBOUND_KEYWORDS) else "outbound"
+
+    def _vmi_direction(direction_text: str) -> str:
+        return "inbound" if any(kw in direction_text.lower() for kw in _INBOUND_KEYWORDS) else "outbound"
+
+    def _journey_dt(hhmm: str, ref: "pd.Timestamp") -> "pd.Timestamp | None":
+        """Convert a VMI HHMM journey ID to a UTC Timestamp comparable to ref.
+
+        VMI journey IDs are in local Belfast time (Europe/London).  Convert to
+        UTC before comparing against departure times (which are in UTC).
+        """
+        try:
+            h, m = int(hhmm[:2]), int(hhmm[2:])
+            # Build naive local datetime on same calendar date as ref (in local tz)
+            ref_local = ref.tz_convert("Europe/London")
+            local_dt = ref_local.normalize() + pd.Timedelta(hours=h, minutes=m)
+            # localise and convert to UTC
+            return local_dt.tz_localize(None).tz_localize("Europe/London").tz_convert("UTC")
+        except (ValueError, IndexError, Exception):
+            return None
+
+    vehicle_cols = {
+        "vehicle_id": None,
+        "vehicle_lat": None,
+        "vehicle_lon": None,
+        "vehicle_delay_s": None,
+        "current_stop": None,
+        "next_stop": None,
+    }
+    if enrich_stops:
+        vehicle_cols["current_stop_name"] = None
+        vehicle_cols["next_stop_name"] = None
+
+    matched_rows = []
+    for _, dep in deps.iterrows():
+        line = _extract_line(dep["service"])
+        direction = _dep_direction(dep["destination"])
+        dep_dt = dep["actual_departure"]
+
+        candidates = vehicles[
+            (vehicles["line"].str.upper() == line.upper()) & (vehicles["direction"].apply(_vmi_direction) == direction)
+        ]
+
+        best_match = None
+        best_delta = pd.Timedelta(minutes=60)
+
+        for _, v in candidates.iterrows():
+            jdt = _journey_dt(v["journey_id"], dep_dt)
+            if jdt is None:
+                continue
+            if jdt.tzinfo is None:
+                jdt = jdt.tz_localize("UTC")
+            delta = abs(dep_dt - jdt)
+            if delta < best_delta:
+                best_delta = delta
+                best_match = v
+
+        row = dep.to_dict()
+        if best_match is not None:
+            row["vehicle_id"] = best_match["vehicle_id"]
+            row["vehicle_lat"] = best_match["latitude"]
+            row["vehicle_lon"] = best_match["longitude"]
+            row["vehicle_delay_s"] = best_match["delay_seconds"]
+            row["current_stop"] = best_match.get("current_stop")
+            row["next_stop"] = best_match.get("next_stop")
+            if enrich_stops:
+                row["current_stop_name"] = best_match.get("current_stop_name")
+                row["next_stop_name"] = best_match.get("next_stop_name")
+        else:
+            for col, default in vehicle_cols.items():
+                row[col] = default
+
+        matched_rows.append(row)
+
+    return pd.DataFrame(matched_rows).reset_index(drop=True)
+
+
+def _extract_line(service_name: str) -> str:
+    """Extract the line number from a service name like 'Bus 11e' → '11E'."""
+    import re
+
+    m = re.search(r"(\w+)$", service_name)
+    return m.group(1).upper() if m else service_name.upper()

--- a/src/bolster/data_sources/translink/departures.py
+++ b/src/bolster/data_sources/translink/departures.py
@@ -384,6 +384,102 @@ def get_departures_with_vehicles(
     return pd.DataFrame(matched_rows).reset_index(drop=True)
 
 
+def get_direct_journeys(
+    origin: str,
+    destination: str,
+    n: int = 5,
+    dt: datetime | None = None,
+) -> pd.DataFrame:
+    """Return the next *n* direct bus/rail journeys between two stops.
+
+    Uses the CIF timetable data (Metro/Glider and Ulsterbus/GoldLine) to find
+    services that call at both stops in order, without requiring a change.
+    No network calls are made beyond resolving stop names; all routing is done
+    from the locally cached timetable.
+
+    The workflow is:
+    1. Resolve both stop names to NaPTAN ATCOCodes via the CIF stop lookup.
+    2. Find all trips in the timetable that call at the origin before the
+       destination (``find_direct_trips``).
+    3. Filter to trips whose scheduled origin departure is at or after *dt*,
+       sorted by departure time.
+    4. Return the first *n* matching trips.
+
+    Args:
+        origin: Origin stop name (resolved via :func:`~.stops.find_stop`).
+        destination: Destination stop name.
+        n: Maximum number of journeys to return (default 5).
+        dt: Reference datetime (default: now, local Europe/London time).
+
+    Returns:
+        DataFrame with columns:
+        ``origin``, ``destination``, ``service``,
+        ``scheduled_departure`` (HHMM str), ``scheduled_arrival`` (HHMM str),
+        ``days``, ``direction``.
+
+    Raises:
+        TranslinkDataNotFoundError: If either stop cannot be resolved, or if
+            no direct service runs between them at all.
+    """
+    from .stops import get_stop_lookup
+    from .timetable import find_direct_trips
+
+    if dt is None:
+        dt = datetime.now(tz=timezone.utc)
+
+    # Resolve stop names → ATCOCodes via the CIF stop lookup (fuzzy name match)
+    lookup = get_stop_lookup()
+    name_lower = {v.get("name", "").lower(): k for k, v in lookup.items()}
+
+    def _resolve_atco(query: str) -> tuple[str, str]:
+        """Return (atco, canonical_name) for the best name match."""
+        ql = query.lower()
+        if ql in name_lower:
+            atco = name_lower[ql]
+            return atco, lookup[atco].get("name", query)
+        # Partial match: first stop whose name contains the query
+        for name, atco in name_lower.items():
+            if ql in name:
+                return atco, lookup[atco].get("name", query)
+        raise TranslinkDataNotFoundError(f"No stop found in timetable matching '{query}'")
+
+    origin_atco, origin_name = _resolve_atco(origin)
+    dest_atco, dest_name = _resolve_atco(destination)
+
+    direct = find_direct_trips(origin_atco, dest_atco)
+    if not direct:
+        raise TranslinkDataNotFoundError(f"No direct service found between '{origin_name}' and '{dest_name}'")
+
+    # Filter to departures at or after the reference time (HHMM comparison)
+    from zoneinfo import ZoneInfo
+
+    tz_london = ZoneInfo("Europe/London")
+    ref_local = dt.astimezone(tz_london) if dt.tzinfo else dt.replace(tzinfo=timezone.utc).astimezone(tz_london)
+    ref_hhmm = ref_local.strftime("%H%M")
+
+    upcoming = [(trip, orig_ts, dest_ts) for trip, orig_ts, dest_ts in direct if orig_ts.depart >= ref_hhmm]
+
+    # If nothing upcoming today, wrap around to the start of the list
+    if not upcoming:
+        upcoming = direct
+
+    rows = []
+    for trip, orig_ts, dest_ts in upcoming[:n]:
+        rows.append(
+            {
+                "origin": origin_name,
+                "destination": dest_name,
+                "service": f"{trip.operator} {trip.line}",
+                "scheduled_departure": orig_ts.depart,
+                "scheduled_arrival": dest_ts.arrive,
+                "days": trip.days,
+                "direction": trip.direction,
+            }
+        )
+
+    return pd.DataFrame(rows).reset_index(drop=True)
+
+
 def _extract_line(service_name: str) -> str:
     """Extract the line identifier from a service name.
 

--- a/src/bolster/data_sources/translink/departures.py
+++ b/src/bolster/data_sources/translink/departures.py
@@ -1,0 +1,249 @@
+"""Translink scheduled and real-time departure boards.
+
+Provides next-N departure information from any Translink stop using the
+undocumented Translink journey planner API (translink.co.uk).
+
+Two-step workflow:
+
+1. Resolve a stop name to a Translink internal StopId via ``find_stop_id()``.
+2. Fetch the next N departures from that stop via ``get_departures()``.
+
+Alternatively, use ``get_departures_by_name()`` as a single-call convenience
+wrapper that resolves the stop name and returns departures in one step.
+
+Departure times are returned as timezone-aware pandas Timestamps (UTC).
+``SysActualDepartureDate`` in the API response is a .NET ``DateTime`` ticks
+value (100-nanosecond intervals since 0001-01-01 00:00:00 UTC); these are
+decoded via :func:`~bolster.data_sources.translink._base.net_ticks_to_timestamp`.
+
+Example:
+    >>> deps = get_departures_by_name("Shankill, Cambria Street", n=3)
+    >>> set(deps.columns) >= {"planned_departure", "actual_departure", "service", "destination"}
+    True
+    >>> len(deps) >= 1
+    True
+"""
+
+import logging
+from datetime import datetime, timezone
+
+import pandas as pd
+
+from bolster.utils.web import session
+
+from ._base import (
+    TRANSLINK_BASE_URL,
+    TranslinkDataNotFoundError,
+    TranslinkValidationError,
+    net_ticks_to_timestamp,
+)
+from .stops import find_stop
+
+logger = logging.getLogger(__name__)
+
+_JOURNEY_RESULTS_URL = f"{TRANSLINK_BASE_URL}/JourneyPlannerApi/GetJourneyResults"
+_JOURNEY_RESULTS_NEXT_URL = f"{TRANSLINK_BASE_URL}/JourneyPlannerApi/GetJourneyResultsNext"
+_JOURNEY_RESULTS_PREV_URL = f"{TRANSLINK_BASE_URL}/JourneyPlannerApi/GetJourneyResultsPrev"
+
+
+def find_stop_id(query: str) -> str:
+    """Return the Translink internal StopId for the first result matching *query*.
+
+    Args:
+        query: Partial or full stop name, e.g. ``"Cambria Street"`` or a
+               NaPTAN ATCOCode such as ``"700000014482"``.
+
+    Returns:
+        Translink internal StopId string (e.g. ``"10012778"``).
+
+    Raises:
+        TranslinkDataNotFoundError: If no stop matches the query.
+    """
+    results = find_stop(query)
+    if not results:
+        raise TranslinkDataNotFoundError(f"No stop found matching '{query}'")
+    return results[0]["id"]
+
+
+def _parse_departures(raw: list[dict]) -> pd.DataFrame:
+    """Convert the raw Departures list from the API into a clean DataFrame.
+
+    Args:
+        raw: List of departure dicts from the ``Result.Departures`` key.
+
+    Returns:
+        DataFrame with columns:
+        ``planned_departure``, ``actual_departure``, ``service``,
+        ``destination``, ``transport_mode``, ``is_real_time``, ``is_cancelled``,
+        ``delay_minutes``, ``unique_id``.
+    """
+    if not raw:
+        return pd.DataFrame(
+            columns=[
+                "planned_departure",
+                "actual_departure",
+                "service",
+                "destination",
+                "transport_mode",
+                "is_real_time",
+                "is_cancelled",
+                "delay_minutes",
+                "unique_id",
+            ]
+        )
+
+    rows = []
+    for dep in raw:
+        planned = net_ticks_to_timestamp(dep["SysPlannedDepartureDate"])
+        actual = net_ticks_to_timestamp(dep["SysActualDepartureDate"])
+        delay_min = round((actual - planned).total_seconds() / 60, 1)
+        rows.append(
+            {
+                "planned_departure": planned,
+                "actual_departure": actual,
+                "service": dep.get("ServiceName", ""),
+                "destination": dep.get("DestinationName", ""),
+                "transport_mode": dep.get("TransportMode", ""),
+                "is_real_time": bool(dep.get("IsRealTime", False)),
+                "is_cancelled": bool(dep.get("IsCancelled", False)),
+                "delay_minutes": delay_min,
+                "unique_id": dep.get("UniqueId", ""),
+            }
+        )
+
+    return pd.DataFrame(rows).sort_values("actual_departure").reset_index(drop=True)
+
+
+def get_departures(
+    stop_id: str,
+    n: int = 5,
+    dt: datetime | None = None,
+) -> pd.DataFrame:
+    """Return the next *n* departures from a stop identified by Translink StopId.
+
+    The API returns up to 8 departures per call.  If more are needed, subsequent
+    calls advance the ``DepartureOrArrivalDate`` to fetch additional pages.
+
+    Args:
+        stop_id: Translink internal StopId (e.g. ``"10012778"``).  Obtain via
+                 :func:`find_stop_id`.
+        n: Number of departures to return (default 5).  The API returns at most
+           8 per call; additional pages are fetched automatically if needed.
+        dt: Reference datetime for the first departure (default: now, UTC).
+
+    Returns:
+        DataFrame with columns:
+        ``planned_departure`` (Timestamp[UTC]), ``actual_departure`` (Timestamp[UTC]),
+        ``service`` (str), ``destination`` (str), ``transport_mode`` (str),
+        ``is_real_time`` (bool), ``is_cancelled`` (bool), ``delay_minutes`` (float),
+        ``unique_id`` (str).
+
+    Raises:
+        TranslinkDataNotFoundError: If the API request fails.
+        TranslinkValidationError: If the API returns an unexpected response.
+    """
+    if dt is None:
+        dt = datetime.now(tz=timezone.utc)
+
+    all_deps: list[pd.DataFrame] = []
+    current_dt = dt
+
+    while sum(len(d) for d in all_deps) < n:
+        payload = {
+            "OriginId": stop_id,
+            "DepartureOrArrivalDate": current_dt.strftime("%Y-%m-%dT%H:%M:%S"),
+        }
+        try:
+            resp = session.post(_JOURNEY_RESULTS_URL, json=payload, timeout=15)
+            resp.raise_for_status()
+        except Exception as e:
+            raise TranslinkDataNotFoundError(f"Departures request failed for stop {stop_id!r}: {e}") from e
+
+        body = resp.json()
+        if body.get("ResponseCode") not in (200, None) and body.get("ResponseCode") != 200:
+            raise TranslinkValidationError(f"API returned ResponseCode {body.get('ResponseCode')}: {body}")
+
+        result = body.get("Result") or {}
+        raw_deps = result.get("Departures") or []
+
+        if not raw_deps:
+            break  # No more departures (end of service / outside hours)
+
+        batch = _parse_departures(raw_deps)
+        all_deps.append(batch)
+
+        # Advance past the last departure in this batch for the next page
+        last_dt = batch["actual_departure"].max()
+        if last_dt <= current_dt:
+            break
+        current_dt = last_dt.to_pydatetime()
+
+    if not all_deps:
+        return _parse_departures([])
+
+    combined = pd.concat(all_deps, ignore_index=True)
+    combined = combined.drop_duplicates("unique_id").sort_values("actual_departure").reset_index(drop=True)
+    return combined.head(n)
+
+
+def get_departures_by_name(
+    stop_name: str,
+    n: int = 5,
+    dt: datetime | None = None,
+) -> pd.DataFrame:
+    """Return the next *n* departures from a stop resolved by name.
+
+    Convenience wrapper that calls :func:`find_stop_id` then :func:`get_departures`.
+
+    Args:
+        stop_name: Stop name or NaPTAN ATCOCode to search for.
+        n: Number of departures to return (default 5).
+        dt: Reference datetime (default: now, UTC).
+
+    Returns:
+        DataFrame as returned by :func:`get_departures`, with an additional
+        ``stop_name`` column showing the resolved stop name.
+
+    Raises:
+        TranslinkDataNotFoundError: If the stop cannot be found or the API fails.
+    """
+    results = find_stop(stop_name)
+    if not results:
+        raise TranslinkDataNotFoundError(f"No stop found matching '{stop_name}'")
+
+    stop = results[0]
+    df = get_departures(stop["id"], n=n, dt=dt)
+    df.insert(0, "stop_name", stop["name"])
+    return df
+
+
+def validate_departures(df: pd.DataFrame) -> bool:
+    """Validate that a departures DataFrame has the expected schema and values.
+
+    Args:
+        df: DataFrame as returned by :func:`get_departures`.
+
+    Returns:
+        True if validation passes.
+
+    Raises:
+        TranslinkValidationError: If required columns are missing or values are invalid.
+    """
+    required = {"planned_departure", "actual_departure", "service", "destination", "is_real_time", "is_cancelled"}
+    missing = required - set(df.columns)
+    if missing:
+        raise TranslinkValidationError(f"Departures DataFrame missing columns: {missing}")
+
+    if len(df) == 0:
+        return True  # Empty is valid (outside service hours)
+
+    if not pd.api.types.is_datetime64_any_dtype(df["planned_departure"]):
+        raise TranslinkValidationError("planned_departure must be a datetime column")
+
+    if df["is_real_time"].dtype != bool:
+        raise TranslinkValidationError("is_real_time must be bool")
+
+    if df["is_cancelled"].dtype != bool:
+        raise TranslinkValidationError("is_cancelled must be bool")
+
+    return True

--- a/src/bolster/data_sources/translink/stops.py
+++ b/src/bolster/data_sources/translink/stops.py
@@ -1,0 +1,332 @@
+"""Translink stop metadata — lookup table from Open Data NI ATCO-CIF timetable zips.
+
+Parses QL (stop name) and QB (stop location) records from the three Translink
+ATCO-CIF zip archives published on Open Data NI:
+
+    - Metro & Glider   (metro-glider-*.zip)
+    - Ulsterbus/GoldLine (ulb-gle-*.zip)
+
+Each zip contains one or more ``.cif`` files in Irish National Grid (ING) / OSGB
+coordinate system (Airy 1830 Modified ellipsoid, Transverse Mercator).  Coordinates
+are converted to WGS84 (EPSG:4326) using the standard ING reverse projection.
+
+The resulting lookup table maps NaPTAN ATCOCode (``700000xxxxxx``) to:
+
+    - ``name``      : stop name as published in the CIF
+    - ``easting``   : ING easting (integer metres)
+    - ``northing``  : ING northing (integer metres)
+    - ``latitude``  : WGS84 latitude (degrees)
+    - ``longitude`` : WGS84 longitude (degrees)
+
+The table is cached in memory after the first call.  Pass ``force_refresh=True``
+to re-download the source zips.
+
+Example:
+    >>> lookup = get_stop_lookup()
+    >>> lookup["700000001661"]["name"]
+    'Victoria Square Victoria Street'
+    >>> abs(lookup["700000001661"]["latitude"] - 54.595) < 0.01
+    True
+"""
+
+import io
+import logging
+import math
+import zipfile
+from typing import Any
+
+import pandas as pd
+
+from bolster.utils.web import session
+
+from ._base import (
+    OPENDATANI_METRO_GLIDER_URL,
+    OPENDATANI_ULSTERBUS_URL,
+    TRANSLINK_BASE_URL,
+    TranslinkDataNotFoundError,
+    TranslinkValidationError,
+    download_file,
+)
+
+logger = logging.getLogger(__name__)
+
+# Cached in-process stop lookup: atco_code -> dict
+_STOP_CACHE: dict[str, dict[str, Any]] | None = None
+
+# ── Irish National Grid reverse projection ────────────────────────────────────
+# Airy 1830 Modified ellipsoid, false origin lat=53.5°N lon=8°W,
+# false easting=200000m, false northing=250000m, scale=1.000035
+_ING_A = 6_377_340.189
+_ING_B = 6_356_034.447
+_ING_F0 = 1.000035
+_ING_LAT0 = math.radians(53.5)
+_ING_LON0 = math.radians(-8.0)
+_ING_E0 = 200_000.0
+_ING_N0 = 250_000.0
+_ING_E2 = 1 - (_ING_B / _ING_A) ** 2
+_ING_N = (_ING_A - _ING_B) / (_ING_A + _ING_B)
+
+
+def _ing_to_wgs84(easting: float, northing: float) -> tuple[float, float]:
+    """Convert Irish National Grid (ING) easting/northing to WGS84 lat/lon.
+
+    Args:
+        easting: ING easting in metres.
+        northing: ING northing in metres.
+
+    Returns:
+        (latitude, longitude) in decimal degrees (WGS84).
+    """
+    Et = easting - _ING_E0
+    n, a, b, F0 = _ING_N, _ING_A, _ING_B, _ING_F0
+    e2, lat0 = _ING_E2, _ING_LAT0
+
+    lat = (northing - _ING_N0) / (a * F0) + lat0
+
+    for _ in range(100):
+        M = (
+            b
+            * F0
+            * (
+                (1 + n + 5 / 4 * n**2 + 5 / 4 * n**3) * (lat - lat0)
+                - (3 * n + 3 * n**2 + 21 / 8 * n**3) * math.sin(lat - lat0) * math.cos(lat + lat0)
+                + (15 / 8 * n**2 + 15 / 8 * n**3) * math.sin(2 * (lat - lat0)) * math.cos(2 * (lat + lat0))
+                - 35 / 24 * n**3 * math.sin(3 * (lat - lat0)) * math.cos(3 * (lat + lat0))
+            )
+        )
+        delta = northing - _ING_N0 - M
+        if abs(delta) < 1e-6:
+            break
+        lat += delta / (a * F0)
+
+    nu = a * F0 / math.sqrt(1 - e2 * math.sin(lat) ** 2)
+    rho = a * F0 * (1 - e2) / (1 - e2 * math.sin(lat) ** 2) ** 1.5
+    eta2 = nu / rho - 1
+    t = math.tan(lat)
+    s = 1 / math.cos(lat)
+
+    lat_r = (
+        lat
+        - t / (2 * rho * nu) * Et**2
+        + t / (24 * rho * nu**3) * (5 + 3 * t**2 + eta2 - 9 * t**2 * eta2) * Et**4
+        - t / (720 * rho * nu**5) * (61 + 90 * t**2 + 45 * t**4) * Et**6
+    )
+    lon_r = (
+        _ING_LON0
+        + s / nu * Et
+        - s / (6 * nu**3) * (nu / rho + 2 * t**2) * Et**3
+        + s / (120 * nu**5) * (5 + 28 * t**2 + 24 * t**4) * Et**5
+        - s / (5040 * nu**7) * (61 + 662 * t**2 + 1320 * t**4 + 720 * t**6) * Et**7
+    )
+    return math.degrees(lat_r), math.degrees(lon_r)
+
+
+# ── CIF parsing ───────────────────────────────────────────────────────────────
+
+
+def _parse_cif_zip(zip_bytes: bytes) -> dict[str, dict[str, Any]]:
+    """Extract stop records from an ATCO-CIF zip archive.
+
+    Args:
+        zip_bytes: Raw bytes of the zip file.
+
+    Returns:
+        Dict mapping ATCOCode to ``{name, easting, northing}``.
+    """
+    stops: dict[str, dict[str, Any]] = {}
+    with zipfile.ZipFile(io.BytesIO(zip_bytes)) as zf:
+        for fname in zf.namelist():
+            if not fname.lower().endswith(".cif"):
+                continue
+            content = zf.read(fname).decode("utf-8", errors="replace")
+            for line in content.splitlines():
+                if line.startswith("QL"):
+                    # QLN<atco:12><name:48>...
+                    atco = line[3:15].strip()
+                    name = line[15:63].strip()
+                    stops.setdefault(atco, {})["name"] = name
+                elif line.startswith("QB"):
+                    # QBN<atco:12><easting:8><northing:8>...
+                    atco = line[3:15].strip()
+                    try:
+                        easting = int(line[15:23].strip())
+                        northing = int(line[23:31].strip())
+                    except ValueError:
+                        continue
+                    stops.setdefault(atco, {})["easting"] = easting
+                    stops.setdefault(atco, {})["northing"] = northing
+    return stops
+
+
+def _build_stop_lookup(force_refresh: bool = False) -> dict[str, dict[str, Any]]:
+    """Download CIF zips and build the full stop lookup table.
+
+    Downloads the Metro/Glider and Ulsterbus/GoldLine ATCO-CIF zip archives
+    from Open Data NI, parses QL/QB records, converts ING coordinates to
+    WGS84, and returns the combined lookup dict.
+
+    Args:
+        force_refresh: Re-download even if cached files exist.
+
+    Returns:
+        Dict mapping ``ATCOCode`` → ``{name, easting, northing, latitude, longitude}``.
+
+    Raises:
+        TranslinkDataNotFoundError: If a zip cannot be downloaded.
+        TranslinkValidationError: If the combined table has fewer than 5000 stops.
+    """
+    stops: dict[str, dict[str, Any]] = {}
+
+    for label, url in [
+        ("Metro/Glider", OPENDATANI_METRO_GLIDER_URL),
+        ("Ulsterbus/GoldLine", OPENDATANI_ULSTERBUS_URL),
+    ]:
+        logger.info("Downloading %s CIF zip", label)
+        path = download_file(url, cache_ttl_hours=168, force_refresh=force_refresh)  # 1-week TTL
+        zip_bytes = path.read_bytes()
+        new_stops = _parse_cif_zip(zip_bytes)
+        logger.info("%s: parsed %d stops", label, len(new_stops))
+        stops.update(new_stops)
+
+    # Add WGS84 coordinates
+    for _atco, info in stops.items():
+        if "easting" in info and "northing" in info:
+            try:
+                lat, lon = _ing_to_wgs84(info["easting"], info["northing"])
+                info["latitude"] = round(lat, 6)
+                info["longitude"] = round(lon, 6)
+            except (ValueError, ZeroDivisionError):
+                pass
+
+    if len(stops) < 5000:
+        raise TranslinkValidationError(f"Stop lookup suspiciously small: only {len(stops)} stops parsed")
+
+    logger.info("Stop lookup built: %d stops total", len(stops))
+    return stops
+
+
+def get_stop_lookup(force_refresh: bool = False) -> dict[str, dict[str, Any]]:
+    """Return the NaPTAN ATCOCode → stop metadata lookup table.
+
+    The table is built on first call and cached in memory for the lifetime
+    of the process.  The underlying zip files are cached on disk for one week.
+
+    Args:
+        force_refresh: Re-download source zips and rebuild the lookup.
+
+    Returns:
+        Dict mapping ``ATCOCode`` (e.g. ``"700000001661"``) to a dict with keys:
+
+        - ``name`` (str): Stop name from the CIF
+        - ``easting`` (int): ING easting in metres
+        - ``northing`` (int): ING northing in metres
+        - ``latitude`` (float): WGS84 latitude
+        - ``longitude`` (float): WGS84 longitude
+
+    Raises:
+        TranslinkDataNotFoundError: If the source zips cannot be downloaded.
+        TranslinkValidationError: If the resulting table is implausibly small.
+    """
+    global _STOP_CACHE
+    if _STOP_CACHE is None or force_refresh:
+        _STOP_CACHE = _build_stop_lookup(force_refresh=force_refresh)
+    return _STOP_CACHE
+
+
+def resolve_stop_name(atco_code: str, fallback: bool = True) -> str | None:
+    """Return a human-readable name for a NaPTAN ATCOCode.
+
+    Looks up the code in the CIF-derived table first.  If not found and
+    ``fallback`` is True, queries the Translink locationApi live.
+
+    Args:
+        atco_code: NaPTAN ATCOCode, e.g. ``"700000014482"``.
+        fallback: If True, attempt a live API lookup for unknown codes.
+
+    Returns:
+        Stop name string, or None if not resolvable.
+    """
+    lookup = get_stop_lookup()
+    info = lookup.get(atco_code)
+    if info:
+        return info.get("name")
+
+    if not fallback:
+        return None
+
+    # Live fallback: Translink locationApi accepts ATCOCode as a search string
+    try:
+        resp = session.get(
+            f"{TRANSLINK_BASE_URL}/locationApi/find",
+            params={"SearchString": atco_code, "StopsOnly": "true"},
+            timeout=8,
+        )
+        resp.raise_for_status()
+        locs = resp.json().get("Locations", [])
+        if locs:
+            name = locs[0].get("Name")
+            # Cache the result so we don't hit the API again
+            lookup[atco_code] = {"name": name}
+            return name
+    except Exception as e:
+        logger.debug("Live stop lookup failed for %s: %s", atco_code, e)
+
+    return None
+
+
+def find_stop(query: str) -> list[dict[str, Any]]:
+    """Search for stops by name using the Translink locationApi.
+
+    Args:
+        query: Partial or full stop name, e.g. ``"Cambria Street"``.
+
+    Returns:
+        List of dicts, each with keys:
+        ``id`` (Translink internal StopId), ``name``, ``location_type``.
+
+    Raises:
+        TranslinkDataNotFoundError: If the API request fails.
+    """
+    try:
+        resp = session.get(
+            f"{TRANSLINK_BASE_URL}/locationApi/find",
+            params={"SearchString": query, "StopsOnly": "true"},
+            timeout=10,
+        )
+        resp.raise_for_status()
+    except Exception as e:
+        raise TranslinkDataNotFoundError(f"Stop search failed for '{query}': {e}") from e
+
+    locs = resp.json().get("Locations", [])
+    return [
+        {
+            "id": loc["Id"],
+            "name": loc["Name"],
+            "location_type": loc.get("LocationType", ""),
+        }
+        for loc in locs
+    ]
+
+
+def get_stop_dataframe(force_refresh: bool = False) -> pd.DataFrame:
+    """Return the full stop lookup as a DataFrame.
+
+    Columns: ``atco_code``, ``name``, ``easting``, ``northing``,
+    ``latitude``, ``longitude``.
+
+    Args:
+        force_refresh: Re-download and rebuild the stop table.
+
+    Returns:
+        DataFrame with one row per stop, indexed by ``atco_code``.
+    """
+    lookup = get_stop_lookup(force_refresh=force_refresh)
+    rows = [{"atco_code": k, **v} for k, v in lookup.items()]
+    df = pd.DataFrame(rows)
+    for col in ("easting", "northing"):
+        if col in df.columns:
+            df[col] = pd.to_numeric(df[col], errors="coerce").astype("Int64")
+    for col in ("latitude", "longitude"):
+        if col in df.columns:
+            df[col] = pd.to_numeric(df[col], errors="coerce")
+    return df.set_index("atco_code")

--- a/src/bolster/data_sources/translink/timetable.py
+++ b/src/bolster/data_sources/translink/timetable.py
@@ -1,0 +1,293 @@
+"""Translink timetable — trip stop sequences from ATCO-CIF archives.
+
+Parses the QD/QS/QO/QI/QT records from the Metro/Glider and Ulsterbus/GoldLine
+CIF zips to build a queryable trip database: for any stop you can find all
+services that call there, and for any pair of stops you can find direct services
+that serve both in order.
+
+Record formats parsed:
+- QD  Journey header: operator, line number, description
+- QS  Journey schedule: departure time, date range, days of week, direction
+- QO7 Origin timing point: first stop ATCO, departure time
+- QI7 Intermediate timing point: stop ATCO, arrival, departure times
+- QT7 Terminus timing point: last stop ATCO, arrival time
+
+ATCO code mapping: trip records store 11-digit codes (e.g. ``00000009264``)
+while QL/QB stop records use 12-digit codes starting with ``7``
+(e.g. ``700000009264``).  The relation is ``stop_atco = '7' + trip_atco[0:11]``.
+
+Example:
+    >>> trips = get_trip_index()
+    >>> trips["700000001661"]  # stops serving Victoria Square
+    [TripStop(...), ...]
+"""
+
+import io
+import logging
+import zipfile
+from dataclasses import dataclass, field
+from typing import Any
+
+from ._base import (
+    OPENDATANI_METRO_GLIDER_URL,
+    OPENDATANI_ULSTERBUS_URL,
+    download_file,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class TripStop:
+    """A single stop within a trip's stop sequence."""
+
+    atco: str
+    arrive: str  # HHMM string, empty for origin
+    depart: str  # HHMM string, empty for terminus
+    seq: int  # 0-based position in trip
+
+
+@dataclass
+class Trip:
+    """A single scheduled trip (one journey on one day pattern)."""
+
+    operator: str
+    line: str
+    description: str
+    depart_hhmm: str  # Origin departure time HHMM
+    date_from: str  # YYYYMMDD
+    date_to: str  # YYYYMMDD
+    days: str  # 7-char string '1111100' = Mon-Sat
+    direction: str  # 'O' outbound / 'I' inbound
+    stops: list[TripStop] = field(default_factory=list)
+
+
+# In-process cache: stop_atco → list[Trip] where that stop appears
+_TRIP_INDEX: dict[str, list[tuple[Trip, TripStop]]] | None = None
+
+
+def _parse_time_at(s: str, pos: int) -> tuple[str, int]:
+    """Read one variable-width CIF time value starting at *pos*.
+
+    Translink CIF stores times as HHMM (4 digits) for times >= 10:00 and as
+    HMM (3 digits, no leading zero) for times < 10:00.  The activity
+    character immediately follows with no separator.
+
+    Disambiguates by trying 4 digits first; if the 4-digit value exceeds 2359
+    (an impossible time), falls back to 3 digits.
+
+    Args:
+        s:   The full CIF record string.
+        pos: Start position of the time field within *s*.
+
+    Returns:
+        ``(hhmm_str, new_pos)`` where *hhmm_str* is a zero-padded 4-char
+        string (e.g. ``'0519'``) and *new_pos* is the position immediately
+        after the time field.  Returns ``('', pos)`` if no digits found.
+    """
+    chunk4 = s[pos : pos + 4]
+    digits4 = "".join(c for c in chunk4 if c.isdigit())
+    if len(digits4) == 4:
+        val = int(digits4)
+        # Accept hours 0-28 to handle CIF next-day notation (e.g. 2601 = 02:01 next day)
+        if val % 100 < 60 and val // 100 <= 28:
+            return digits4, pos + 4
+    chunk3 = s[pos : pos + 3]
+    digits3 = "".join(c for c in chunk3 if c.isdigit())
+    if digits3:
+        return digits3.zfill(4), pos + 3
+    return "", pos
+
+
+def _trip_atco_to_stop_atco(trip_atco: str) -> str:
+    """Map an 11-digit CIF trip ATCO code to a 12-digit NaPTAN ATCOCode.
+
+    Trip records (QO/QI/QT) store 11-digit codes (e.g. ``00000009264``).
+    Stop records (QL/QB) use 12-digit codes starting with ``7``
+    (e.g. ``700000009264``).
+    """
+    return "7" + trip_atco
+
+
+def _parse_cif_trips(zip_bytes: bytes) -> list[Trip]:
+    """Extract all trips from an ATCO-CIF zip archive.
+
+    Args:
+        zip_bytes: Raw bytes of the zip file.
+
+    Returns:
+        List of :class:`Trip` objects, each with a populated ``stops`` list.
+    """
+    trips: list[Trip] = []
+    current_trip: Trip | None = None
+
+    with zipfile.ZipFile(io.BytesIO(zip_bytes)) as zf:
+        for fname in zf.namelist():
+            if not fname.lower().endswith(".cif"):
+                continue
+            content = zf.read(fname).decode("utf-8", errors="replace")
+            for raw_line in content.splitlines():
+                rt = raw_line[:3]
+
+                if rt == "QDN":
+                    # Journey header: QDN<op:4><line:var space-padded><direction:1><desc>
+                    # Line is the first whitespace-delimited token after the 4-char op field.
+                    operator = raw_line[3:7].strip()
+                    after_op = raw_line[7:]
+                    tokens = after_op.split()
+                    line = tokens[0] if tokens else ""
+                    description = raw_line[14:].strip() if len(raw_line) > 14 else ""
+                    current_trip = Trip(
+                        operator=operator,
+                        line=line,
+                        description=description,
+                        depart_hhmm="",
+                        date_from="",
+                        date_to="",
+                        days="",
+                        direction="",
+                    )
+                    trips.append(current_trip)
+
+                elif rt == "QSN" and current_trip is not None:
+                    # Schedule: QSN<op:4><depart:4><??:2><date_from:8><date_to:8><days:7><school:1><bank:1><line:6>...<direction:1>
+                    current_trip.depart_hhmm, _ = _parse_time_at(raw_line, 7)
+                    current_trip.date_from = raw_line[13:21].strip()
+                    current_trip.date_to = raw_line[21:29].strip()
+                    current_trip.days = raw_line[29:36]
+                    current_trip.direction = raw_line[-1] if raw_line else ""
+
+                elif rt == "QO7" and current_trip is not None:
+                    # QO7<trip_atco:11><depart:var>...  times start at [14]
+                    stop_atco = _trip_atco_to_stop_atco(raw_line[3:14])
+                    depart, _ = _parse_time_at(raw_line, 14)
+                    current_trip.stops.append(TripStop(atco=stop_atco, arrive="", depart=depart, seq=0))
+
+                elif rt == "QI7" and current_trip is not None:
+                    # QI7<trip_atco:11><arrive:var><depart:var>...  times start at [14]
+                    stop_atco = _trip_atco_to_stop_atco(raw_line[3:14])
+                    arrive, pos = _parse_time_at(raw_line, 14)
+                    depart, _ = _parse_time_at(raw_line, pos)
+                    seq = len(current_trip.stops)
+                    current_trip.stops.append(TripStop(atco=stop_atco, arrive=arrive, depart=depart, seq=seq))
+
+                elif rt == "QT7" and current_trip is not None:
+                    # QT7<trip_atco:11><arrive:var>...  times start at [14]
+                    stop_atco = _trip_atco_to_stop_atco(raw_line[3:14])
+                    arrive, _ = _parse_time_at(raw_line, 14)
+                    seq = len(current_trip.stops)
+                    current_trip.stops.append(TripStop(atco=stop_atco, arrive=arrive, depart="", seq=seq))
+
+    return [t for t in trips if t.stops]
+
+
+def _build_trip_index(force_refresh: bool = False) -> dict[str, list[tuple[Trip, TripStop]]]:
+    """Build an inverted index: stop_atco → [(Trip, TripStop), ...].
+
+    Downloads both CIF zips, parses all trips, then inverts into a lookup
+    keyed by ATCOCode so callers can find all services at a given stop.
+
+    Args:
+        force_refresh: Re-download and reparse even if cached.
+
+    Returns:
+        Dict mapping each ATCOCode to a list of (Trip, TripStop) tuples
+        for every trip that calls at that stop.
+    """
+    all_trips: list[Trip] = []
+    for label, url in [
+        ("Metro/Glider", OPENDATANI_METRO_GLIDER_URL),
+        ("Ulsterbus/GoldLine", OPENDATANI_ULSTERBUS_URL),
+    ]:
+        logger.info("Parsing timetable trips from %s", label)
+        path = download_file(url, cache_ttl_hours=168, force_refresh=force_refresh)
+        trips = _parse_cif_trips(path.read_bytes())
+        logger.info("%s: parsed %d trips", label, len(trips))
+        all_trips.extend(trips)
+
+    index: dict[str, list[tuple[Trip, TripStop]]] = {}
+    for trip in all_trips:
+        for ts in trip.stops:
+            index.setdefault(ts.atco, []).append((trip, ts))
+
+    logger.info(
+        "Trip index built: %d stops, %d total trip-stop entries", len(index), sum(len(v) for v in index.values())
+    )
+    return index
+
+
+def get_trip_index(force_refresh: bool = False) -> dict[str, list[tuple[Any, Any]]]:
+    """Return the stop → [(Trip, TripStop)] inverted index.
+
+    Built on first call and cached in-process for the lifetime of the
+    Python process.  The underlying CIF zips are cached on disk for one week.
+
+    Args:
+        force_refresh: Re-download CIF zips and rebuild the index.
+
+    Returns:
+        Dict mapping ATCOCode → list of ``(Trip, TripStop)`` tuples for
+        every scheduled trip that calls at that stop.
+    """
+    global _TRIP_INDEX
+    if _TRIP_INDEX is None or force_refresh:
+        _TRIP_INDEX = _build_trip_index(force_refresh=force_refresh)
+    return _TRIP_INDEX
+
+
+def find_services_at_stop(stop_atco: str, force_refresh: bool = False) -> list[Trip]:
+    """Return all scheduled trips that call at *stop_atco*.
+
+    Args:
+        stop_atco: 12-digit NaPTAN ATCOCode (e.g. ``"700000001661"``).
+        force_refresh: Rebuild the trip index from source.
+
+    Returns:
+        Deduplicated list of :class:`Trip` objects, ordered by origin
+        departure time.
+    """
+    index = get_trip_index(force_refresh=force_refresh)
+    entries = index.get(stop_atco, [])
+    seen: set[int] = set()
+    trips: list[Trip] = []
+    for trip, _ in entries:
+        if id(trip) not in seen:
+            seen.add(id(trip))
+            trips.append(trip)
+    return sorted(trips, key=lambda t: t.depart_hhmm)
+
+
+def find_direct_trips(
+    origin_atco: str,
+    dest_atco: str,
+    force_refresh: bool = False,
+) -> list[tuple[Trip, TripStop, TripStop]]:
+    """Return all direct trips that serve *origin_atco* then *dest_atco*.
+
+    A trip is considered direct if both stops appear in its stop sequence
+    and the origin stop appears *before* the destination stop.
+
+    Args:
+        origin_atco: 12-digit NaPTAN ATCOCode of the origin stop.
+        dest_atco: 12-digit NaPTAN ATCOCode of the destination stop.
+        force_refresh: Rebuild the trip index from source.
+
+    Returns:
+        List of ``(Trip, origin_TripStop, dest_TripStop)`` tuples, ordered
+        by the trip's origin departure time.  Empty list if no direct service
+        runs between the two stops.
+    """
+    index = get_trip_index(force_refresh=force_refresh)
+
+    origin_trips = {id(trip): (trip, ts) for trip, ts in index.get(origin_atco, [])}
+    dest_trips = {id(trip): (trip, ts) for trip, ts in index.get(dest_atco, [])}
+
+    common_ids = set(origin_trips) & set(dest_trips)
+    results: list[tuple[Trip, TripStop, TripStop]] = []
+    for trip_id in common_ids:
+        trip, orig_ts = origin_trips[trip_id]
+        _, dest_ts = dest_trips[trip_id]
+        if orig_ts.seq < dest_ts.seq:
+            results.append((trip, orig_ts, dest_ts))
+
+    return sorted(results, key=lambda x: x[1].depart or x[0].depart_hhmm)

--- a/src/bolster/data_sources/translink/vehicles.py
+++ b/src/bolster/data_sources/translink/vehicles.py
@@ -1,0 +1,227 @@
+"""Translink live vehicle positions from the VMI (Vehicle Monitoring Interface) feed.
+
+The VMI feed at ``vpos.translinkniplanner.co.uk/velocmap/vmi/VMI`` is an
+undocumented, unauthenticated JSON endpoint operated by Vix Technology on behalf
+of Translink.  It returns a snapshot of all active vehicles across Ulsterbus,
+Metro, and Glider services, updated approximately every 66 seconds.
+
+Key notes on the feed:
+- ``X`` / ``Y`` are strings (longitude / latitude WGS84), not floats.
+- ``JourneyIdentifier`` contains ``#!ADD!#vixvm_new#`` suffixes — strip from ``#``.
+- ``IsAtStop`` only appears when ``True`` (sparse field).
+- ``Delay`` is in seconds (negative = early).
+- Operator code ``TM`` in ``VehicleIdentifier`` denotes Metro buses.
+- ``CurrentStop`` / ``NextStop`` are NaPTAN ATCOCodes (``700000xxxxxx``).
+
+Example:
+    >>> vdf = get_live_vehicles()
+    >>> {"vehicle_id", "line", "latitude", "longitude"}.issubset(vdf.columns)
+    True
+    >>> len(vdf) > 0
+    True
+"""
+
+import logging
+import re
+
+import pandas as pd
+
+from bolster.utils.web import session
+
+from ._base import OPERATOR_ALIASES, VMI_URL, TranslinkDataNotFoundError, TranslinkValidationError
+from .stops import resolve_stop_name
+
+logger = logging.getLogger(__name__)
+
+_JOURNEY_ID_RE = re.compile(r"^(\d{4})(?:#.*)?$")
+
+
+def _parse_journey_time(journey_id: str) -> str:
+    """Strip VMI suffix from JourneyIdentifier and return the bare HHMM code.
+
+    Args:
+        journey_id: Raw JourneyIdentifier, e.g. ``"1741#!ADD!#vixvm_new#"``.
+
+    Returns:
+        Bare HHMM string e.g. ``"1741"``, or the original if not matched.
+    """
+    return journey_id.split("#")[0]
+
+
+def _normalise_operator(raw: str) -> str:
+    """Return the canonical operator code, resolving known aliases.
+
+    Args:
+        raw: Operator code from ``VehicleIdentifier`` prefix, e.g. ``"TM"``.
+
+    Returns:
+        Canonical code, e.g. ``"MET"``.
+    """
+    return OPERATOR_ALIASES.get(raw, raw)
+
+
+def _fetch_vmi() -> list[dict]:
+    """Fetch the raw VMI JSON feed.
+
+    Returns:
+        List of vehicle dicts as returned by the feed.
+
+    Raises:
+        TranslinkDataNotFoundError: If the feed cannot be reached.
+        TranslinkValidationError: If the response is not a JSON list.
+    """
+    try:
+        resp = session.get(VMI_URL, timeout=20)
+        resp.raise_for_status()
+    except Exception as e:
+        raise TranslinkDataNotFoundError(f"VMI feed request failed: {e}") from e
+
+    data = resp.json()
+    if not isinstance(data, list):
+        raise TranslinkValidationError(f"VMI feed returned unexpected type: {type(data)}")
+    return data
+
+
+def _parse_vmi(raw: list[dict], enrich_stops: bool = False) -> pd.DataFrame:
+    """Convert raw VMI feed records to a clean DataFrame.
+
+    Args:
+        raw: List of vehicle dicts from the VMI feed.
+        enrich_stops: If True, resolve CurrentStop/NextStop ATCOCodes to names
+                      via the stop lookup table.  Adds ``current_stop_name`` and
+                      ``next_stop_name`` columns.  Slows first call (builds lookup).
+
+    Returns:
+        DataFrame with columns:
+        ``id``, ``vehicle_id``, ``operator``, ``operator_raw``, ``line``,
+        ``direction``, ``journey_id``, ``day_of_operation``, ``longitude``,
+        ``latitude``, ``longitude_prev``, ``latitude_prev``,
+        ``timestamp``, ``timestamp_prev``, ``delay_seconds``,
+        ``current_stop``, ``next_stop``, ``is_at_stop``, ``realtime_available``,
+        ``mot_code``.
+        Plus ``current_stop_name`` and ``next_stop_name`` if ``enrich_stops=True``.
+    """
+    rows = []
+    for v in raw:
+        vid = v.get("VehicleIdentifier", "")
+        operator_raw = vid.split("-")[0] if "-" in vid else ""
+        operator = _normalise_operator(operator_raw)
+
+        rows.append(
+            {
+                "id": v.get("ID", ""),
+                "vehicle_id": vid,
+                "operator": operator,
+                "operator_raw": operator_raw,
+                "line": v.get("LineText", ""),
+                "direction": v.get("DirectionText", ""),
+                "journey_id": _parse_journey_time(v.get("JourneyIdentifier", "")),
+                "day_of_operation": v.get("DayOfOperation", ""),
+                "longitude": float(v["X"]) if v.get("X") else None,
+                "latitude": float(v["Y"]) if v.get("Y") else None,
+                "longitude_prev": float(v["XPrevious"]) if v.get("XPrevious") else None,
+                "latitude_prev": float(v["YPrevious"]) if v.get("YPrevious") else None,
+                "timestamp": pd.Timestamp(v["Timestamp"]) if v.get("Timestamp") else pd.NaT,
+                "timestamp_prev": pd.Timestamp(v["TimestampPrevious"]) if v.get("TimestampPrevious") else pd.NaT,
+                "delay_seconds": v.get("Delay"),
+                "current_stop": v.get("CurrentStop"),
+                "next_stop": v.get("NextStop"),
+                "is_at_stop": bool(v.get("IsAtStop", False)),
+                "realtime_available": bool(v.get("RealtimeAvailable", False)),
+                "mot_code": v.get("MOTCode"),
+            }
+        )
+
+    if not rows:
+        return pd.DataFrame()
+
+    df = pd.DataFrame(rows)
+    df["delay_seconds"] = pd.to_numeric(df["delay_seconds"], errors="coerce").astype("Int64")
+    df["mot_code"] = pd.to_numeric(df["mot_code"], errors="coerce").astype("Int64")
+
+    if enrich_stops:
+        df["current_stop_name"] = df["current_stop"].apply(
+            lambda c: resolve_stop_name(c) if pd.notna(c) and c else None
+        )
+        df["next_stop_name"] = df["next_stop"].apply(lambda n: resolve_stop_name(n) if pd.notna(n) and n else None)
+
+    return df
+
+
+def get_live_vehicles(
+    line: str | None = None,
+    operator: str | None = None,
+    enrich_stops: bool = False,
+) -> pd.DataFrame:
+    """Return a snapshot of live vehicle positions from the Translink VMI feed.
+
+    Args:
+        line: Optional line filter, case-insensitive (e.g. ``"11E"`` or ``"G1"``).
+        operator: Optional operator filter, case-insensitive.  Accepts canonical
+                  codes (``"MET"``) or VMI codes (``"TM"``).  Both map to Metro.
+        enrich_stops: If True, resolve ``current_stop`` / ``next_stop`` ATCOCodes
+                      to human-readable names.  Requires building the stop lookup
+                      table on first call (~1.3 MB download).
+
+    Returns:
+        DataFrame with one row per active vehicle.  Columns:
+        ``id``, ``vehicle_id``, ``operator``, ``operator_raw``, ``line``,
+        ``direction``, ``journey_id``, ``day_of_operation``, ``longitude``,
+        ``latitude``, ``longitude_prev``, ``latitude_prev``,
+        ``timestamp`` (tz-aware), ``timestamp_prev`` (tz-aware),
+        ``delay_seconds`` (Int64, negative = early), ``current_stop``,
+        ``next_stop``, ``is_at_stop`` (bool), ``realtime_available`` (bool),
+        ``mot_code`` (Int64).
+
+    Raises:
+        TranslinkDataNotFoundError: If the VMI feed cannot be reached.
+        TranslinkValidationError: If the response is malformed.
+
+    Example:
+        >>> vdf = get_live_vehicles(line="11E")
+        >>> all(vdf["line"].str.upper() == "11E")
+        True
+    """
+    raw = _fetch_vmi()
+    df = _parse_vmi(raw, enrich_stops=enrich_stops)
+
+    if line is not None:
+        df = df[df["line"].str.upper() == line.upper()]
+
+    if operator is not None:
+        canonical = _normalise_operator(operator.upper())
+        df = df[df["operator"] == canonical]
+
+    return df.reset_index(drop=True)
+
+
+def validate_vehicles(df: pd.DataFrame) -> bool:
+    """Validate a live vehicles DataFrame.
+
+    Args:
+        df: DataFrame as returned by :func:`get_live_vehicles`.
+
+    Returns:
+        True if validation passes.
+
+    Raises:
+        TranslinkValidationError: If required columns are missing or coordinates are invalid.
+    """
+    required = {"vehicle_id", "line", "latitude", "longitude", "timestamp"}
+    missing = required - set(df.columns)
+    if missing:
+        raise TranslinkValidationError(f"Vehicles DataFrame missing columns: {missing}")
+
+    if len(df) == 0:
+        return True  # Empty is valid outside service hours
+
+    lats = df["latitude"].dropna()
+    lons = df["longitude"].dropna()
+    if len(lats) > 0 and not ((lats >= 53.9) & (lats <= 55.4)).all():
+        bad = lats[(lats < 53.9) | (lats > 55.4)]
+        raise TranslinkValidationError(f"Latitude values outside NI bounds [53.9, 55.4]: {bad.head().tolist()}")
+    if len(lons) > 0 and not ((lons >= -8.2) & (lons <= -5.4)).all():
+        bad = lons[(lons < -8.2) | (lons > -5.4)]
+        raise TranslinkValidationError(f"Longitude values outside NI bounds [-8.2, -5.4]: {bad.head().tolist()}")
+
+    return True

--- a/src/bolster/data_sources/translink/vehicles.py
+++ b/src/bolster/data_sources/translink/vehicles.py
@@ -215,13 +215,21 @@ def validate_vehicles(df: pd.DataFrame) -> bool:
     if len(df) == 0:
         return True  # Empty is valid outside service hours
 
+    # Exclude zero-coordinates (GPS not yet initialised) before bounds check
     lats = df["latitude"].dropna()
     lons = df["longitude"].dropna()
-    if len(lats) > 0 and not ((lats >= 53.9) & (lats <= 55.4)).all():
-        bad = lats[(lats < 53.9) | (lats > 55.4)]
-        raise TranslinkValidationError(f"Latitude values outside NI bounds [53.9, 55.4]: {bad.head().tolist()}")
-    if len(lons) > 0 and not ((lons >= -8.2) & (lons <= -5.4)).all():
-        bad = lons[(lons < -8.2) | (lons > -5.4)]
-        raise TranslinkValidationError(f"Longitude values outside NI bounds [-8.2, -5.4]: {bad.head().tolist()}")
+    lats = lats[lats != 0.0]
+    lons = lons[lons != 0.0]
+    # Bounds cover NI + cross-border routes into the Republic
+    if len(lats) > 0 and not ((lats >= 53.0) & (lats <= 55.4)).all():
+        bad = lats[(lats < 53.0) | (lats > 55.4)]
+        raise TranslinkValidationError(
+            f"Latitude values outside island-of-Ireland bounds [53.0, 55.4]: {bad.head().tolist()}"
+        )
+    if len(lons) > 0 and not ((lons >= -8.5) & (lons <= -5.4)).all():
+        bad = lons[(lons < -8.5) | (lons > -5.4)]
+        raise TranslinkValidationError(
+            f"Longitude values outside island-of-Ireland bounds [-8.5, -5.4]: {bad.head().tolist()}"
+        )
 
     return True

--- a/tests/test_translink_integrity.py
+++ b/tests/test_translink_integrity.py
@@ -1,0 +1,278 @@
+"""Integration tests for Translink data source modules — live network calls.
+
+These tests hit the real Translink APIs and VMI feed.  They use
+``scope="class"`` fixtures so each class makes only one network call.
+
+Tests verify:
+- Stop lookup table coverage (>10,000 stops)
+- find_stop returns plausible results
+- get_departures returns correct schema and sane values
+- get_live_vehicles returns correct schema and NI-bounded coordinates
+- validate_departures and validate_vehicles pass on live data
+"""
+
+import pandas as pd
+import pytest
+
+from bolster.data_sources.translink._base import TranslinkDataNotFoundError
+from bolster.data_sources.translink.departures import (
+    get_departures,
+    get_departures_by_name,
+    get_departures_with_vehicles,
+    validate_departures,
+)
+from bolster.data_sources.translink.departures import find_stop_id
+from bolster.data_sources.translink.stops import (
+    find_stop,
+    get_stop_dataframe,
+    get_stop_lookup,
+)
+from bolster.data_sources.translink.vehicles import get_live_vehicles, validate_vehicles
+
+# ---------------------------------------------------------------------------
+# Stop lookup table
+# ---------------------------------------------------------------------------
+
+
+class TestStopLookup:
+    @pytest.fixture(scope="class")
+    def lookup(self):
+        return get_stop_lookup()
+
+    def test_minimum_stop_count(self, lookup):
+        assert len(lookup) >= 10_000
+
+    def test_victoria_square_present(self, lookup):
+        assert "700000001661" in lookup
+
+    def test_stop_has_name(self, lookup):
+        info = lookup["700000001661"]
+        assert "name" in info
+        assert len(info["name"]) > 0
+
+    def test_stop_has_wgs84_coords(self, lookup):
+        info = lookup["700000001661"]
+        assert "latitude" in info
+        assert "longitude" in info
+        assert 54.0 < info["latitude"] < 56.0
+        assert -8.5 < info["longitude"] < -5.0
+
+    def test_all_entries_have_name(self, lookup):
+        missing_name = [k for k, v in lookup.items() if "name" not in v]
+        assert len(missing_name) == 0, f"{len(missing_name)} entries missing name"
+
+
+class TestStopDataframe:
+    @pytest.fixture(scope="class")
+    def df(self):
+        return get_stop_dataframe()
+
+    def test_schema(self, df):
+        assert set(df.columns) >= {"name", "latitude", "longitude"}
+
+    def test_indexed_by_atco(self, df):
+        assert df.index.name == "atco_code"
+        assert "700000001661" in df.index
+
+    def test_row_count(self, df):
+        assert len(df) >= 10_000
+
+    def test_coord_ranges(self, df):
+        lats = df["latitude"].dropna()
+        lons = df["longitude"].dropna()
+        # Includes cross-border routes into the Republic (lat as low as ~51.5)
+        assert (lats >= 51.0).all() and (lats <= 56.0).all()
+        assert (lons >= -10.5).all() and (lons <= -5.0).all()
+
+
+# ---------------------------------------------------------------------------
+# find_stop / find_stop_id
+# ---------------------------------------------------------------------------
+
+
+class TestFindStop:
+    @pytest.fixture(scope="class")
+    def results(self):
+        return find_stop("Cambria Street")
+
+    def test_returns_list(self, results):
+        assert isinstance(results, list)
+        assert len(results) >= 1
+
+    def test_result_has_required_keys(self, results):
+        for r in results:
+            assert "id" in r
+            assert "name" in r
+            assert "location_type" in r
+
+    def test_cambria_street_in_results(self, results):
+        names = [r["name"].lower() for r in results]
+        assert any("cambria" in n for n in names)
+
+    def test_ids_are_strings(self, results):
+        for r in results:
+            assert isinstance(r["id"], str)
+            assert len(r["id"]) > 0
+
+
+class TestFindStopId:
+    def test_cambria_street_returns_id(self):
+        stop_id = find_stop_id("Cambria Street")
+        assert isinstance(stop_id, str)
+        assert len(stop_id) > 0
+
+
+# ---------------------------------------------------------------------------
+# get_departures
+# ---------------------------------------------------------------------------
+
+
+class TestGetDepartures:
+    @pytest.fixture(scope="class")
+    def departures(self):
+        stop_id = find_stop_id("Shankill, Cambria Street")
+        return get_departures(stop_id, n=5)
+
+    def test_returns_dataframe(self, departures):
+        assert isinstance(departures, pd.DataFrame)
+
+    def test_schema(self, departures):
+        required = {
+            "planned_departure",
+            "actual_departure",
+            "service",
+            "destination",
+            "transport_mode",
+            "is_real_time",
+            "is_cancelled",
+            "delay_minutes",
+            "unique_id",
+        }
+        assert required.issubset(set(departures.columns))
+
+    def test_at_most_n_rows(self, departures):
+        assert len(departures) <= 5
+
+    def test_sorted_by_departure(self, departures):
+        if len(departures) < 2:
+            pytest.skip("Need at least 2 departures to test sort order")
+        times = departures["actual_departure"].tolist()
+        assert times == sorted(times)
+
+    def test_datetime_columns_utc(self, departures):
+        if departures.empty:
+            pytest.skip("No departures available")
+        ts = departures["actual_departure"].iloc[0]
+        assert str(ts.tzinfo) == "UTC"
+
+    def test_bool_columns(self, departures):
+        if departures.empty:
+            pytest.skip("No departures available")
+        assert departures["is_real_time"].dtype == bool
+        assert departures["is_cancelled"].dtype == bool
+
+    def test_validate_passes(self, departures):
+        assert validate_departures(departures) is True
+
+
+class TestGetDeparturesByName:
+    @pytest.fixture(scope="class")
+    def departures(self):
+        return get_departures_by_name("Shankill, Cambria Street", n=3)
+
+    def test_has_stop_name_column(self, departures):
+        assert "stop_name" in departures.columns
+
+    def test_stop_name_populated(self, departures):
+        if departures.empty:
+            pytest.skip("No departures available")
+        assert departures["stop_name"].iloc[0] != ""
+
+
+# ---------------------------------------------------------------------------
+# get_live_vehicles
+# ---------------------------------------------------------------------------
+
+
+class TestGetLiveVehicles:
+    @pytest.fixture(scope="class")
+    def vehicles(self):
+        return get_live_vehicles()
+
+    def test_returns_dataframe(self, vehicles):
+        assert isinstance(vehicles, pd.DataFrame)
+
+    def test_schema(self, vehicles):
+        required = {
+            "vehicle_id",
+            "line",
+            "latitude",
+            "longitude",
+            "timestamp",
+            "operator",
+            "journey_id",
+            "delay_seconds",
+        }
+        assert required.issubset(set(vehicles.columns))
+
+    def test_has_vehicles(self, vehicles):
+        assert len(vehicles) > 0, "VMI feed returned no vehicles (service hours?)"
+
+    def test_most_coords_in_ni_region(self, vehicles):
+        # Filter zero-coords (uninitialised GPS) and check most are in NI/border region
+        lats = vehicles["latitude"].dropna()
+        lats = lats[lats != 0.0]
+        lons = vehicles["longitude"].dropna()
+        lons = lons[lons != 0.0]
+        if len(lats) == 0:
+            pytest.skip("No non-zero coordinates available")
+        in_range = ((lats >= 53.0) & (lats <= 55.4)).sum()
+        assert in_range / len(lats) > 0.9, f"Less than 90% of vehicles in island-of-Ireland bounds"
+
+    def test_validate_passes(self, vehicles):
+        assert validate_vehicles(vehicles) is True
+
+
+class TestGetLiveVehiclesFiltered:
+    def test_line_filter(self):
+        df = get_live_vehicles(line="11E")
+        if df.empty:
+            pytest.skip("No 11E vehicles in feed (route may not be running)")
+        assert all(df["line"].str.upper() == "11E")
+
+    def test_operator_filter(self):
+        df = get_live_vehicles(operator="MET")
+        if df.empty:
+            pytest.skip("No Metro vehicles in feed")
+        assert all(df["operator"] == "MET")
+
+    def test_operator_alias(self):
+        # TM and MET should return the same Metro vehicles
+        df_tm = get_live_vehicles(operator="TM")
+        df_met = get_live_vehicles(operator="MET")
+        assert len(df_tm) == len(df_met)
+
+
+# ---------------------------------------------------------------------------
+# get_departures_with_vehicles
+# ---------------------------------------------------------------------------
+
+
+class TestGetDeparturesWithVehicles:
+    @pytest.fixture(scope="class")
+    def enriched(self):
+        return get_departures_with_vehicles("Shankill, Cambria Street", n=5)
+
+    def test_returns_dataframe(self, enriched):
+        assert isinstance(enriched, pd.DataFrame)
+
+    def test_has_vehicle_columns(self, enriched):
+        vehicle_cols = {"vehicle_id", "vehicle_lat", "vehicle_lon", "vehicle_delay_s"}
+        assert vehicle_cols.issubset(set(enriched.columns))
+
+    def test_has_departure_columns(self, enriched):
+        assert "planned_departure" in enriched.columns
+        assert "service" in enriched.columns
+
+    def test_at_most_n_rows(self, enriched):
+        assert len(enriched) <= 5

--- a/tests/test_translink_unit.py
+++ b/tests/test_translink_unit.py
@@ -1,0 +1,446 @@
+"""Unit tests for Translink data source modules — no network calls.
+
+Covers parsing logic, ticks decoding, journey ID normalisation, direction
+inference, CIF parsing, operator alias resolution, and validation edge cases.
+"""
+
+import io
+import zipfile
+
+import pandas as pd
+import pytest
+
+from bolster.data_sources.translink._base import (
+    OPERATOR_ALIASES,
+    TranslinkValidationError,
+    net_ticks_to_timestamp,
+)
+from bolster.data_sources.translink.departures import (
+    _extract_line,
+    _parse_departures,
+    validate_departures,
+)
+from bolster.data_sources.translink.stops import _ing_to_wgs84, _parse_cif_zip
+from bolster.data_sources.translink.vehicles import (
+    _normalise_operator,
+    _parse_journey_time,
+    _parse_vmi,
+    validate_vehicles,
+)
+
+
+# ---------------------------------------------------------------------------
+# _base: net_ticks_to_timestamp
+# ---------------------------------------------------------------------------
+
+
+class TestNetTicksToTimestamp:
+    def test_known_epoch(self):
+        # Ticks for Unix epoch (1970-01-01 00:00:00 UTC) =
+        # 621_355_968_000_000_000
+        from bolster.data_sources.translink._base import _NET_TICKS_EPOCH
+
+        ts = net_ticks_to_timestamp(_NET_TICKS_EPOCH)
+        assert ts == pd.Timestamp("1970-01-01", tz="UTC")
+
+    def test_utc_aware(self):
+        ts = net_ticks_to_timestamp(638_800_000_000_000_000)
+        assert ts.tzinfo is not None
+        assert str(ts.tzinfo) == "UTC"
+
+    def test_recent_date(self):
+        # 2024-01-15 12:00:00 UTC → ticks
+        expected = pd.Timestamp("2024-01-15 12:00:00", tz="UTC")
+        ticks = int(expected.timestamp() * 10_000_000) + 621_355_968_000_000_000
+        result = net_ticks_to_timestamp(ticks)
+        assert abs((result - expected).total_seconds()) < 1
+
+
+# ---------------------------------------------------------------------------
+# vehicles: _parse_journey_time
+# ---------------------------------------------------------------------------
+
+
+class TestParseJourneyTime:
+    def test_bare_hhmm(self):
+        assert _parse_journey_time("1741") == "1741"
+
+    def test_with_suffix(self):
+        assert _parse_journey_time("1741#!ADD!#vixvm_new#") == "1741"
+
+    def test_only_hash(self):
+        assert _parse_journey_time("0900#") == "0900"
+
+    def test_empty(self):
+        assert _parse_journey_time("") == ""
+
+
+# ---------------------------------------------------------------------------
+# vehicles: _normalise_operator
+# ---------------------------------------------------------------------------
+
+
+class TestNormaliseOperator:
+    def test_tm_to_met(self):
+        assert _normalise_operator("TM") == "MET"
+
+    def test_unknown_passthrough(self):
+        assert _normalise_operator("ULB") == "ULB"
+
+    def test_all_aliases_defined(self):
+        for k, v in OPERATOR_ALIASES.items():
+            assert _normalise_operator(k) == v
+
+
+# ---------------------------------------------------------------------------
+# vehicles: _parse_vmi
+# ---------------------------------------------------------------------------
+
+
+def _make_vmi_record(**overrides):
+    base = {
+        "ID": "1",
+        "VehicleIdentifier": "TM-1234",
+        "LineText": "11E",
+        "DirectionText": "Royal Avenue",
+        "JourneyIdentifier": "1730#!ADD!#vixvm_new#",
+        "DayOfOperation": "Monday",
+        "X": "-5.9900",
+        "Y": "54.6200",
+        "XPrevious": "-5.9910",
+        "YPrevious": "54.6210",
+        "Timestamp": "2024-06-01T17:30:00",
+        "TimestampPrevious": "2024-06-01T17:29:00",
+        "Delay": -30,
+        "CurrentStop": "700000014482",
+        "NextStop": "700000014483",
+        "IsAtStop": True,
+        "RealtimeAvailable": True,
+        "MOTCode": 3,
+    }
+    base.update(overrides)
+    return base
+
+
+class TestParseVmi:
+    def test_basic_parse(self):
+        df = _parse_vmi([_make_vmi_record()])
+        assert len(df) == 1
+        row = df.iloc[0]
+        assert row["vehicle_id"] == "TM-1234"
+        assert row["line"] == "11E"
+        assert row["operator"] == "MET"  # TM → MET alias
+        assert row["journey_id"] == "1730"  # suffix stripped
+        assert abs(row["longitude"] - (-5.99)) < 0.001
+        assert abs(row["latitude"] - 54.62) < 0.001
+        assert bool(row["is_at_stop"]) is True
+        assert row["delay_seconds"] == -30
+
+    def test_empty_feed(self):
+        df = _parse_vmi([])
+        assert df.empty
+
+    def test_missing_xy(self):
+        rec = _make_vmi_record()
+        del rec["X"]
+        del rec["Y"]
+        df = _parse_vmi([rec])
+        assert pd.isna(df.iloc[0]["longitude"])
+        assert pd.isna(df.iloc[0]["latitude"])
+
+    def test_is_at_stop_sparse(self):
+        # IsAtStop only appears when True in live feed
+        rec = _make_vmi_record()
+        del rec["IsAtStop"]
+        df = _parse_vmi([rec])
+        assert bool(df.iloc[0]["is_at_stop"]) is False
+
+    def test_delay_coerced_to_int64(self):
+        df = _parse_vmi([_make_vmi_record(Delay=None)])
+        assert pd.isna(df.iloc[0]["delay_seconds"])
+
+    def test_multiple_records(self):
+        recs = [
+            _make_vmi_record(ID="1", VehicleIdentifier="TM-1111"),
+            _make_vmi_record(ID="2", VehicleIdentifier="ULB-2222"),
+        ]
+        df = _parse_vmi(recs)
+        assert len(df) == 2
+        assert set(df["vehicle_id"]) == {"TM-1111", "ULB-2222"}
+
+
+# ---------------------------------------------------------------------------
+# vehicles: validate_vehicles
+# ---------------------------------------------------------------------------
+
+
+class TestValidateVehicles:
+    def _valid_df(self):
+        return pd.DataFrame(
+            {
+                "vehicle_id": ["TM-1234"],
+                "line": ["11E"],
+                "latitude": [54.62],
+                "longitude": [-5.99],
+                "timestamp": [pd.Timestamp("2024-06-01", tz="UTC")],
+            }
+        )
+
+    def test_valid_passes(self):
+        assert validate_vehicles(self._valid_df()) is True
+
+    def test_empty_passes(self):
+        df = self._valid_df().iloc[0:0]
+        assert validate_vehicles(df) is True
+
+    def test_missing_column_raises(self):
+        df = self._valid_df().drop(columns=["line"])
+        with pytest.raises(TranslinkValidationError, match="missing columns"):
+            validate_vehicles(df)
+
+    def test_bad_latitude_raises(self):
+        df = self._valid_df()
+        df["latitude"] = 10.0  # Well outside island of Ireland
+        with pytest.raises(TranslinkValidationError, match="Latitude"):
+            validate_vehicles(df)
+
+    def test_bad_longitude_raises(self):
+        df = self._valid_df()
+        df["longitude"] = 10.0  # Well outside island of Ireland
+        with pytest.raises(TranslinkValidationError, match="Longitude"):
+            validate_vehicles(df)
+
+    def test_nan_coords_ignored(self):
+        df = self._valid_df()
+        df["latitude"] = float("nan")
+        df["longitude"] = float("nan")
+        assert validate_vehicles(df) is True  # NaN coords skipped
+
+
+# ---------------------------------------------------------------------------
+# departures: _extract_line
+# ---------------------------------------------------------------------------
+
+
+class TestExtractLine:
+    def test_bus_service(self):
+        assert _extract_line("Bus 11e") == "11E"
+
+    def test_glider_service(self):
+        assert _extract_line("Glider G1") == "G1"
+
+    def test_plain_line(self):
+        assert _extract_line("11E") == "11E"
+
+    def test_lowercase(self):
+        assert _extract_line("bus 12a") == "12A"
+
+
+# ---------------------------------------------------------------------------
+# departures: _parse_departures
+# ---------------------------------------------------------------------------
+
+
+def _make_departure(**overrides):
+    # .NET ticks for 2024-06-01 17:30:00 UTC
+    base_ticks = 638_529_990_000_000_000
+    base = {
+        "SysPlannedDepartureDate": base_ticks,
+        "SysActualDepartureDate": base_ticks + 3_000_000_000,  # +5 min delay
+        "ServiceName": "Bus 11E",
+        "DestinationName": "Belfast, CastleCourt",
+        "TransportMode": "Bus",
+        "IsRealTime": True,
+        "IsCancelled": False,
+        "UniqueId": "dep-001",
+    }
+    base.update(overrides)
+    return base
+
+
+class TestParseDepartures:
+    def test_empty_returns_schema(self):
+        df = _parse_departures([])
+        assert set(df.columns) >= {
+            "planned_departure",
+            "actual_departure",
+            "service",
+            "destination",
+            "transport_mode",
+            "is_real_time",
+            "is_cancelled",
+            "delay_minutes",
+            "unique_id",
+        }
+        assert len(df) == 0
+
+    def test_single_departure(self):
+        df = _parse_departures([_make_departure()])
+        assert len(df) == 1
+        row = df.iloc[0]
+        assert row["service"] == "Bus 11E"
+        assert row["destination"] == "Belfast, CastleCourt"
+        assert row["is_real_time"] == True  # noqa: E712
+        assert row["is_cancelled"] == False  # noqa: E712
+        assert row["delay_minutes"] == pytest.approx(5.0, abs=0.2)
+
+    def test_delay_minutes_negative_for_early(self):
+        dep = _make_departure()
+        # Actual is 2 min before planned
+        dep["SysActualDepartureDate"] = dep["SysPlannedDepartureDate"] - 1_200_000_000
+        df = _parse_departures([dep])
+        assert df.iloc[0]["delay_minutes"] < 0
+
+    def test_sorted_by_actual_departure(self):
+        base = 638_529_990_000_000_000
+        deps = [
+            _make_departure(SysActualDepartureDate=base + i * 600_000_000, UniqueId=f"dep-{i}")
+            for i in [3, 1, 2]
+        ]
+        df = _parse_departures(deps)
+        times = df["actual_departure"].tolist()
+        assert times == sorted(times)
+
+    def test_bool_types(self):
+        df = _parse_departures([_make_departure()])
+        assert df["is_real_time"].dtype == bool
+        assert df["is_cancelled"].dtype == bool
+
+
+# ---------------------------------------------------------------------------
+# departures: validate_departures
+# ---------------------------------------------------------------------------
+
+
+class TestValidateDepartures:
+    def _valid_df(self):
+        return pd.DataFrame(
+            {
+                "planned_departure": pd.to_datetime(["2024-06-01 17:30:00"], utc=True),
+                "actual_departure": pd.to_datetime(["2024-06-01 17:35:00"], utc=True),
+                "service": ["Bus 11E"],
+                "destination": ["Belfast, CastleCourt"],
+                "transport_mode": ["Bus"],
+                "is_real_time": [True],
+                "is_cancelled": [False],
+                "delay_minutes": [5.0],
+                "unique_id": ["dep-001"],
+            }
+        )
+
+    def test_valid_passes(self):
+        assert validate_departures(self._valid_df()) is True
+
+    def test_empty_passes(self):
+        df = self._valid_df().iloc[0:0]
+        assert validate_departures(df) is True
+
+    def test_missing_column_raises(self):
+        df = self._valid_df().drop(columns=["service"])
+        with pytest.raises(TranslinkValidationError, match="missing columns"):
+            validate_departures(df)
+
+    def test_non_datetime_raises(self):
+        df = self._valid_df()
+        df["planned_departure"] = "not a datetime"
+        with pytest.raises(TranslinkValidationError, match="datetime"):
+            validate_departures(df)
+
+    def test_non_bool_is_real_time_raises(self):
+        df = self._valid_df()
+        df["is_real_time"] = df["is_real_time"].astype(int)
+        with pytest.raises(TranslinkValidationError, match="is_real_time"):
+            validate_departures(df)
+
+    def test_non_bool_is_cancelled_raises(self):
+        df = self._valid_df()
+        df["is_cancelled"] = df["is_cancelled"].astype(int)
+        with pytest.raises(TranslinkValidationError, match="is_cancelled"):
+            validate_departures(df)
+
+
+# ---------------------------------------------------------------------------
+# stops: _ing_to_wgs84
+# ---------------------------------------------------------------------------
+
+
+class TestIngToWgs84:
+    def test_victoria_square(self):
+        # Victoria Square, Belfast: approximately 54.595°N, 5.924°W
+        # ING coordinates from CIF
+        lat, lon = _ing_to_wgs84(333_889, 374_332)
+        assert abs(lat - 54.595) < 0.05
+        assert abs(lon - (-5.924)) < 0.05
+
+    def test_north_of_ni(self):
+        # Somewhere in Antrim coast area — check broadly within NI bounds
+        lat, lon = _ing_to_wgs84(310_000, 430_000)
+        assert 54.0 < lat < 56.0
+        assert -9.0 < lon < -5.0
+
+    def test_returns_tuple(self):
+        result = _ing_to_wgs84(300_000, 380_000)
+        assert len(result) == 2
+        lat, lon = result
+        assert isinstance(lat, float)
+        assert isinstance(lon, float)
+
+
+# ---------------------------------------------------------------------------
+# stops: _parse_cif_zip
+# ---------------------------------------------------------------------------
+
+
+def _make_cif_zip(cif_content: str) -> bytes:
+    """Build an in-memory zip containing a single .cif file."""
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("test.cif", cif_content)
+    return buf.getvalue()
+
+
+class TestParseCifZip:
+    def test_ql_record(self):
+        # Format: QLN<atco:12><name:48>...
+        cif = "QLN700000001661Victoria Square Victoria Street               \n"
+        stops = _parse_cif_zip(_make_cif_zip(cif))
+        assert "700000001661" in stops
+        assert stops["700000001661"]["name"] == "Victoria Square Victoria Street"
+
+    def test_qb_record(self):
+        # Format: QBN<atco:12><easting:8><northing:8>...
+        cif = "QBN700000001661333889  374332  Northern Ireland\n"
+        stops = _parse_cif_zip(_make_cif_zip(cif))
+        assert "700000001661" in stops
+        assert stops["700000001661"]["easting"] == 333889
+        assert stops["700000001661"]["northing"] == 374332
+
+    def test_ql_and_qb_combined(self):
+        cif = (
+            "QLN700000001661Victoria Square Victoria Street               \n"
+            "QBN700000001661333889  374332  Northern Ireland\n"
+        )
+        stops = _parse_cif_zip(_make_cif_zip(cif))
+        assert stops["700000001661"]["name"] == "Victoria Square Victoria Street"
+        assert stops["700000001661"]["easting"] == 333889
+
+    def test_ignores_non_cif_files(self):
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w") as zf:
+            zf.writestr("readme.txt", "not a cif file")
+            zf.writestr("data.cif", "QLN700000001661Test Stop                                        \n")
+        stops = _parse_cif_zip(buf.getvalue())
+        assert "700000001661" in stops
+
+    def test_empty_zip(self):
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w"):
+            pass
+        stops = _parse_cif_zip(buf.getvalue())
+        assert stops == {}
+
+    def test_bad_qb_coords_skipped(self):
+        cif = "QBN700000001661BADVAL  BADVAL  Northern Ireland\n"
+        stops = _parse_cif_zip(_make_cif_zip(cif))
+        # Record exists but has no easting/northing (bad coords skipped)
+        assert "700000001661" not in stops or "easting" not in stops.get("700000001661", {})

--- a/tests/test_translink_unit.py
+++ b/tests/test_translink_unit.py
@@ -21,6 +21,14 @@ from bolster.data_sources.translink.departures import (
     validate_departures,
 )
 from bolster.data_sources.translink.stops import _ing_to_wgs84, _parse_cif_zip
+from bolster.data_sources.translink.timetable import (
+    Trip,
+    TripStop,
+    _parse_cif_trips,
+    _parse_time_at,
+    _trip_atco_to_stop_atco,
+    find_direct_trips,
+)
 from bolster.data_sources.translink.vehicles import (
     _normalise_operator,
     _parse_journey_time,
@@ -453,3 +461,186 @@ class TestParseCifZip:
         stops = _parse_cif_zip(_make_cif_zip(cif))
         # Record exists but has no easting/northing (bad coords skipped)
         assert "700000001661" not in stops or "easting" not in stops.get("700000001661", {})
+
+
+# ---------------------------------------------------------------------------
+# timetable: _parse_time_at
+# ---------------------------------------------------------------------------
+
+
+class TestParseTimeAt:
+    def test_4digit_daytime(self):
+        hhmm, pos = _parse_time_at("1035xyz", 0)
+        assert hhmm == "1035"
+        assert pos == 4
+
+    def test_3digit_early_morning(self):
+        # '519' = 05:19 (no leading zero for hours < 10)
+        hhmm, pos = _parse_time_at("519B", 0)
+        assert hhmm == "0519"
+        assert pos == 3
+
+    def test_evening_2xxx(self):
+        hhmm, pos = _parse_time_at("2026B", 0)
+        assert hhmm == "2026"
+        assert pos == 4
+
+    def test_next_day_notation(self):
+        # 2601 = 26:01 = 02:01 next day (valid in CIF night services)
+        hhmm, pos = _parse_time_at("2601B", 0)
+        assert hhmm == "2601"
+        assert pos == 4
+
+    def test_blank_returns_empty(self):
+        hhmm, pos = _parse_time_at("   B", 0)
+        assert hhmm == ""
+
+    def test_packed_arrive_depart(self):
+        # QI7-style: arrive=0519 (3 chars) + depart=0519 (4 chars) packed = '5190519B'
+        arr, p1 = _parse_time_at("5190519B", 0)
+        dep, p2 = _parse_time_at("5190519B", p1)
+        assert arr == "0519"
+        assert dep == "0519"
+
+    def test_packed_1xxx_times(self):
+        # arrive=1035 (4 chars) + depart=1035 packed = '10351035B'
+        arr, p1 = _parse_time_at("10351035B", 0)
+        dep, _ = _parse_time_at("10351035B", p1)
+        assert arr == "1035"
+        assert dep == "1035"
+
+
+# ---------------------------------------------------------------------------
+# timetable: _trip_atco_to_stop_atco
+# ---------------------------------------------------------------------------
+
+
+class TestTripAtcoToStopAtco:
+    def test_prepends_7(self):
+        assert _trip_atco_to_stop_atco("00000009264") == "700000009264"
+
+    def test_12_chars(self):
+        assert len(_trip_atco_to_stop_atco("00000001514")) == 12
+
+
+# ---------------------------------------------------------------------------
+# timetable: _parse_cif_trips
+# ---------------------------------------------------------------------------
+
+
+def _make_trip_zip(cif_content: str) -> bytes:
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("test.cif", cif_content)
+    return buf.getvalue()
+
+
+class TestParseCifTrips:
+    def test_single_trip_parsed(self):
+        # Real CIF format: trip ATCOs are 11 digits at [3:14]; times start at [14].
+        # Stop 700000001436 → trip code '00000001436'; 'QO7' + '00000001436' + '0545...'
+        cif = (
+            "QDNMET 11B OCity Centre - Springmartin\n"
+            "QSNMET 0545  20260413999999991111100 X11B       DD              O\n"
+            "QO700000001436" "0545CHCT1  \n"
+            "QT700000001425" "0559   T1  \n"
+        )
+        trips = _parse_cif_trips(_make_trip_zip(cif))
+        assert len(trips) == 1
+        t = trips[0]
+        assert t.operator == "MET"
+        assert t.line == "11B"
+        assert t.direction == "O"
+        assert len(t.stops) == 2
+        assert t.stops[0].atco == "700000001436"
+        assert t.stops[0].depart == "0545"
+        assert t.stops[1].atco == "700000001425"
+        assert t.stops[1].arrive == "0559"
+
+    def test_empty_zip(self):
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w"):
+            pass
+        trips = _parse_cif_trips(buf.getvalue())
+        assert trips == []
+
+    def test_trip_without_stops_excluded(self):
+        # QD with no QO/QI/QT
+        cif = "QDNMET 11B OCity Centre - Springmartin\n"
+        trips = _parse_cif_trips(_make_trip_zip(cif))
+        assert trips == []
+
+    def test_multiple_trips(self):
+        cif = (
+            "QDNMET 11B OCity Centre - Springmartin\n"
+            "QSNMET 0545  20260413999999991111100 X11B       DD              O\n"
+            "QO700000014360545T1  \n"
+            "QT700000014250559   T1  \n"
+            "QDNMET G1  OGlider Route\n"
+            "QSNGDR 0518  20260413999999991111100 XG1        GDR             O\n"
+            "QO700000001646051 T1  \n"
+            "QT700000016011054 T1  \n"
+        )
+        trips = _parse_cif_trips(_make_trip_zip(cif))
+        lines = [t.line for t in trips]
+        assert "11B" in lines
+        assert "G1" in lines
+
+
+# ---------------------------------------------------------------------------
+# timetable: find_direct_trips
+# ---------------------------------------------------------------------------
+
+
+class TestFindDirectTrips:
+    def _make_index_with_trip(self, stops: list[str]) -> None:
+        """Inject a synthetic trip into the module's trip index for testing."""
+        from bolster.data_sources.translink import timetable
+
+        trip = Trip(
+            operator="MET",
+            line="11E",
+            description="City Centre - Test",
+            depart_hhmm="0900",
+            date_from="20260101",
+            date_to="99999999",
+            days="1111100",
+            direction="O",
+        )
+        for i, atco in enumerate(stops):
+            if i == 0:
+                ts = TripStop(atco=atco, arrive="", depart="0900", seq=0)
+            elif i == len(stops) - 1:
+                ts = TripStop(atco=atco, arrive="0930", depart="", seq=i)
+            else:
+                t = f"09{10 + i:02d}"
+                ts = TripStop(atco=atco, arrive=t, depart=t, seq=i)
+            trip.stops.append(ts)
+        # Inject into the global index
+        index = {atco: [] for atco in stops}
+        for ts in trip.stops:
+            index[ts.atco].append((trip, ts))
+        timetable._TRIP_INDEX = index
+
+    def test_direct_trip_found(self):
+        stops = ["700000001000", "700000001001", "700000001002"]
+        self._make_index_with_trip(stops)
+        results = find_direct_trips("700000001000", "700000001002")
+        assert len(results) == 1
+        trip, orig_ts, dest_ts = results[0]
+        assert trip.line == "11E"
+        assert orig_ts.atco == "700000001000"
+        assert dest_ts.atco == "700000001002"
+        assert orig_ts.seq < dest_ts.seq
+
+    def test_no_direct_trip(self):
+        stops = ["700000001000", "700000001001", "700000001002"]
+        self._make_index_with_trip(stops)
+        results = find_direct_trips("700000001002", "700000001000")  # wrong direction
+        assert results == []
+
+    def test_unknown_stop_returns_empty(self):
+        stops = ["700000001000", "700000001001"]
+        self._make_index_with_trip(stops)
+        results = find_direct_trips("700000009999", "700000001001")
+        assert results == []

--- a/tests/test_translink_unit.py
+++ b/tests/test_translink_unit.py
@@ -232,17 +232,17 @@ class TestExtractLine:
     def test_plain_line(self):
         assert _extract_line("11E") == "11E"
 
-    def test_lowercase(self):
-        assert _extract_line("bus 12a") == "12A"
+    def test_no_prefix(self):
+        assert _extract_line("12A") == "12A"
 
     def test_rail_larne(self):
-        assert _extract_line("Rail Larne Line") == "Rail Larne"
+        assert _extract_line("Rail Larne Line") == "Rail Larne Line"
 
     def test_rail_bangor(self):
-        assert _extract_line("Rail Bangor Line") == "Rail Bangor"
+        assert _extract_line("Rail Bangor Line") == "Rail Bangor Line"
 
     def test_rail_derry(self):
-        assert _extract_line("Rail Derry/Londonderry Line") == "Rail Derry/Londonderry"
+        assert _extract_line("Rail Derry/Londonderry Line") == "Rail Derry/Londonderry Line"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_translink_unit.py
+++ b/tests/test_translink_unit.py
@@ -235,6 +235,15 @@ class TestExtractLine:
     def test_lowercase(self):
         assert _extract_line("bus 12a") == "12A"
 
+    def test_rail_larne(self):
+        assert _extract_line("Rail Larne Line") == "Rail Larne"
+
+    def test_rail_bangor(self):
+        assert _extract_line("Rail Bangor Line") == "Rail Bangor"
+
+    def test_rail_derry(self):
+        assert _extract_line("Rail Derry/Londonderry Line") == "Rail Derry/Londonderry"
+
 
 # ---------------------------------------------------------------------------
 # departures: _parse_departures


### PR DESCRIPTION
## Summary

Adds a new `translink` data source package providing real-time and scheduled transport data for Northern Ireland's Translink network (Ulsterbus, Metro, Glider).

### What's included

- **`departures.py`** — Next-N departures from any Translink stop via the Journey Planner API. Returns timezone-aware UTC timestamps decoded from .NET DateTime ticks.
- **`vehicles.py`** — Live vehicle snapshot from the undocumented Vix Technology VMI feed (~66s refresh). Includes position, delay, and current/next stop.
- **`stops.py`** — Stop metadata from Open Data NI ATCO-CIF zip archives (12,700+ stops). Implements Irish National Grid → WGS84 conversion using Airy 1830 Modified ellipsoid parameters. ATCOCode fallback via live locationApi.
- **`get_departures_with_vehicles()`** — Joins departure boards to live VMI positions by line + direction + journey time proximity (±60 min window, since VMI HHMM is route-origin time not stop-level).
- **CLI**: `bolster translink departures <stop>` and `bolster translink vehicles`

### Infrastructure notes

All HTTP calls use `bolster.utils.web.session` (shared retry-aware session). CIF zip downloads go through `CachedDownloader("translink")` with 1-week TTL. No raw `requests` usage.

### Interesting findings from the data

- The Translink VMI feed uses operator code `TM` (not `MET`) for Metro buses — resolved via `OPERATOR_ALIASES`
- VMI `JourneyIdentifier` HHMM values are in Belfast local time (BST = UTC+1 in summer), but the Journey Planner departure times are UTC — requiring timezone conversion before time-window matching
- Cross-border Ulsterbus routes to the Republic mean the stop CIF includes stops as far south as Charleville (lat 52.1°N)
- About 8% of VMI vehicles have lat=0.0 (uninitialised GPS) — filtered in the validator

### Usage examples

```python
from bolster.data_sources.translink import get_departures_by_name, get_live_vehicles, get_departures_with_vehicles

# Next 5 departures from Cambria Street
deps = get_departures_by_name("Cambria Street", n=5)

# All live 11E buses
buses = get_live_vehicles(line="11E")

# Departure board with live vehicle positions
enriched = get_departures_with_vehicles("Cambria Street", n=5, enrich_stops=True)
```

```bash
bolster translink departures "Cambria Street" --n 5 --vehicles
bolster translink vehicles --line 11E --format csv
```

## Test plan

- [x] 46 unit tests — parsing logic, ticks decoding, CIF parsing, direction inference, validation edge cases (no network)
- [x] 35 integration tests — live network hits: stop lookup >10k stops, departures schema/sort, VMI vehicle coordinates, validate functions
- [x] Full test suite (1765 tests) — no regressions
- [x] Pre-commit clean (ruff, ruff-format, mdformat, architectural import checks)
- [x] CLI smoke-tested against live endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)