### PR TITLE
feat(nisra): add NI Multiple Deprivation Measure (NIMDM 2017) module

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ The [GOV.UK NISRA statistics RSS feed](https://www.gov.uk/search/research-and-st
 | NI Assembly — Questions (oral & written, 2007–present) | `niassembly.questions` | ✅ |
 | NI Assembly — Votes/Divisions (per-member records) | `niassembly.votes` | ✅ |
 | NI Business Register (IDBR, annual) | `nisra.business_register` | ✅ |
+| NI Multiple Deprivation Measure 2017 (NIMDM, SOA-level) | `nisra.deprivation` | ✅ |
 | Security Situation Statistics | - | ❌ Cloudflare-blocked |
 | Anti-social Behaviour | - | ❌ Cloudflare-blocked |
 | Domestic Abuse Incidents/Crimes | - | ❌ Cloudflare-blocked |

--- a/src/bolster/cli.py
+++ b/src/bolster/cli.py
@@ -33,6 +33,7 @@ from .data_sources.nisra import cancer_waiting_times as nisra_cancer
 from .data_sources.nisra import composite_index as nisra_composite
 from .data_sources.nisra import construction_output as nisra_construction
 from .data_sources.nisra import deaths as nisra_deaths
+from .data_sources.nisra import deprivation as nisra_deprivation
 from .data_sources.nisra import diagnostic_waiting_times as nisra_diagnostic
 from .data_sources.nisra import disease_prevalence as nisra_disease_prevalence
 from .data_sources.nisra import drug_related_deaths as nisra_drug_related_deaths
@@ -6324,6 +6325,107 @@ def nisra_public_confidence_cmd(breakdown, output_format, force_refresh, save):
             for _, row in data.iterrows():
                 rich_table.add_row(*[str(v) for v in row])
             console.print(rich_table)
+
+    except Exception as e:
+        console.print(f"[bold red]Error:[/bold red] {str(e)}", style="red")
+        console.print("\n[yellow]Troubleshooting:[/yellow]")
+        console.print("   - Check your internet connection")
+        console.print("   - Try again with --force-refresh to bypass cache")
+        raise click.Abort() from e
+
+
+@nisra.command(name="deprivation")
+@click.option("--lgd", default=None, help="Filter by Local Government District (case-insensitive substring match)")
+@click.option(
+    "--format",
+    "output_format",
+    type=click.Choice(["table", "csv", "json"], case_sensitive=False),
+    default="table",
+    help="Output format (default: table)",
+)
+@click.option("--force-refresh", is_flag=True, help="Force re-download even if cached")
+@click.option("--save", help="Save data to file (specify filename)")
+def nisra_deprivation_cmd(lgd, output_format, force_refresh, save):
+    """NI Multiple Deprivation Measure 2017 (NIMDM) - SOA-level deprivation ranks.
+
+    Ranks all 890 Super Output Areas on overall deprivation and seven domain
+    ranks (income, employment, health/disability, education, access to
+    services, living environment, crime/disorder). Rank 1 is the most
+    deprived SOA.
+
+    Examples:
+        Get all SOA deprivation ranks::
+
+            bolster nisra deprivation
+
+        Filter by Local Government District::
+
+            bolster nisra deprivation --lgd Belfast
+
+        Save to file::
+
+            bolster nisra deprivation --save deprivation.csv
+
+    Data Notes:
+        - Source: NIMDM 2017, NISRA
+        - 890 Super Output Areas (SOA2001 geography)
+        - Static publication; NIMDM2021 pending Census 2021 integration
+
+    Returns:
+        DataFrame with columns: lgd, urban_rural, soa_code, soa_name,
+        mdm_rank, income_rank, employment_rank, health_disability_rank,
+        education_rank, access_to_services_rank, living_environment_rank,
+        crime_disorder_rank.
+
+    Note:
+        Source: https://www.nisra.gov.uk/publications/nimdm17-soa-level-results
+    """
+    console = Console()
+
+    try:
+        with console.status("[bold green]Downloading NIMDM deprivation data..."):
+            data = nisra_deprivation.get_latest_data(force_refresh=force_refresh)
+
+        if lgd:
+            data = data[data["lgd"].str.contains(lgd, case=False, na=False)].reset_index(drop=True)
+
+        if data.empty:
+            console.print("[yellow]No data found for the specified filters[/yellow]")
+            return
+
+        console.print("[green]NIMDM deprivation data retrieved successfully[/green]")
+        console.print(f"[cyan]SOAs: {len(data)}[/cyan]")
+
+        if save:
+            try:
+                if output_format == "json" or save.endswith(".json"):
+                    data.to_json(save, orient="records", indent=2)
+                else:
+                    data.to_csv(save, index=False)
+                console.print(f"[green]Saved to: {save}[/green]")
+                return
+            except PermissionError:
+                console.print(f"[red]Error: Permission denied writing to {save}[/red]")
+                return
+            except Exception as e:
+                console.print(f"[red]Error saving file: {e}[/red]")
+                return
+
+        if output_format == "json":
+            click.echo(data.to_json(orient="records", indent=2))
+        elif output_format == "csv":
+            console.print(data.to_csv(index=False), end="")
+        else:
+            from rich.table import Table
+
+            rich_table = Table(title="NIMDM Deprivation Ranks")
+            for col in data.columns:
+                rich_table.add_column(col, style="white")
+            for _, row in data.head(20).iterrows():
+                rich_table.add_row(*[str(v) for v in row])
+            console.print(rich_table)
+            if len(data) > 20:
+                console.print(f"[dim]... and {len(data) - 20} more rows (use --format csv to see all)[/dim]")
 
     except Exception as e:
         console.print(f"[bold red]Error:[/bold red] {str(e)}", style="red")

--- a/src/bolster/data_sources/nisra/__init__.py
+++ b/src/bolster/data_sources/nisra/__init__.py
@@ -16,6 +16,7 @@ Available modules:
     - composite_index: Northern Ireland Composite Economic Index (experimental quarterly economic indicator)
     - construction_output: Quarterly construction output statistics (all work, new work, repair & maintenance)
     - deaths: Weekly death registrations with demographic, geographic, and place breakdowns
+    - deprivation: NI Multiple Deprivation Measure 2017 (NIMDM) — SOA-level overall and domain deprivation ranks
     - diagnostic_waiting_times: Quarterly diagnostic waiting times by HSC Trust, category, and service
     - disease_prevalence: Annual NI disease register sizes and prevalence per 1,000 patients (2004/05–present)
     - drug_related_deaths: Annual drug-related and drug misuse deaths by year, age, gender, and substance
@@ -69,6 +70,11 @@ Examples:
     >>> from bolster.data_sources.nisra import deaths
     >>> df = deaths.get_latest_deaths(dimension='demographics')
     >>> 'deaths' in df.columns
+    True
+
+    >>> from bolster.data_sources.nisra import deprivation
+    >>> df = deprivation.get_latest_data()
+    >>> 'mdm_rank' in df.columns
     True
 
     >>> from bolster.data_sources.nisra import index_of_services as ios
@@ -139,6 +145,7 @@ from . import (
     composite_index,
     construction_output,
     deaths,
+    deprivation,
     diagnostic_waiting_times,
     disease_prevalence,
     drug_related_deaths,
@@ -173,6 +180,7 @@ __all__ = [
     "composite_index",
     "construction_output",
     "deaths",
+    "deprivation",
     "diagnostic_waiting_times",
     "disease_prevalence",
     "drug_related_deaths",

--- a/src/bolster/data_sources/nisra/deprivation.py
+++ b/src/bolster/data_sources/nisra/deprivation.py
@@ -1,0 +1,159 @@
+"""NISRA Multiple Deprivation Measure (NIMDM 2017) Module.
+
+Provides access to the Northern Ireland Multiple Deprivation Measure 2017,
+which ranks all 890 Super Output Areas (SOAs) on overall deprivation and
+seven domain ranks. Rank 1 is the most deprived SOA in each domain.
+
+Domains:
+    - Income
+    - Employment
+    - Health Deprivation and Disability
+    - Education, Skills and Training
+    - Access to Services
+    - Living Environment
+    - Crime and Disorder
+
+Data Source:
+    Publication page: https://www.nisra.gov.uk/publications/nimdm17-soa-level-results
+    Direct file: https://www.nisra.gov.uk/files/nisra/publications/NIMDM17_SOAresults.xls
+
+Update Frequency:
+    Infrequent. NIMDM2017 is the current release; NIMDM2021 is pending
+    Census 2021 data integration. The download URL is stable and has no
+    year in the path, so it will need to be updated when NIMDM2021 publishes.
+
+Example:
+    >>> from bolster.data_sources.nisra import deprivation
+    >>> df = deprivation.get_latest_data()
+    >>> 'mdm_rank' in df.columns
+    True
+    >>> df['soa_code'].nunique()
+    890
+"""
+
+import logging
+
+import pandas as pd
+
+from ._base import NISRADataError, NISRAValidationError, download_file
+
+logger = logging.getLogger(__name__)
+
+NIMDM_SOA_URL = "https://www.nisra.gov.uk/files/nisra/publications/NIMDM17_SOAresults.xls"
+
+_SHEET_NAME = "MDM"
+
+_COLUMN_MAP = {
+    "LGD2014NAME": "lgd",
+    "2015 Default Urban/Rural ": "urban_rural",
+    "SOA2001": "soa_code",
+    "SOA2001_name": "soa_name",
+    "Multiple Deprivation Measure Rank \n(where 1 is most deprived)": "mdm_rank",
+    "Income Domain Rank \n(where 1 is most deprived)": "income_rank",
+    "Employment Domain Rank (where 1 is most deprived)": "employment_rank",
+    "Health Deprivation and Disability Domain Rank (where 1 is most deprived)": "health_disability_rank",
+    "Education, Skills and Training Domain Rank (where 1 is most deprived)": "education_rank",
+    "Access to Services Domain Rank (where 1 is most deprived)": "access_to_services_rank",
+    "Living Environment Domain Rank (where 1 is most deprived)": "living_environment_rank",
+    "Crime and Disorder Domain Rank (where 1 is most deprived)": "crime_disorder_rank",
+}
+
+_RANK_COLUMNS = [
+    "mdm_rank",
+    "income_rank",
+    "employment_rank",
+    "health_disability_rank",
+    "education_rank",
+    "access_to_services_rank",
+    "living_environment_rank",
+    "crime_disorder_rank",
+]
+
+
+def get_latest_data(force_refresh: bool = False) -> pd.DataFrame:
+    """Get the latest NIMDM SOA-level deprivation ranks.
+
+    Args:
+        force_refresh: Force re-download even if cached.
+
+    Returns:
+        DataFrame with columns: lgd, urban_rural, soa_code, soa_name,
+        mdm_rank, income_rank, employment_rank, health_disability_rank,
+        education_rank, access_to_services_rank, living_environment_rank,
+        crime_disorder_rank. Rank 1 is the most deprived SOA.
+
+    Raises:
+        NISRADataError: If the data file cannot be downloaded or parsed.
+
+    Example:
+        >>> df = get_latest_data()
+        >>> 'mdm_rank' in df.columns
+        True
+    """
+    path = download_file(NIMDM_SOA_URL, cache_ttl_hours=24 * 30, force_refresh=force_refresh)
+
+    try:
+        df = pd.read_excel(path, sheet_name=_SHEET_NAME, engine="xlrd")
+    except Exception as e:
+        raise NISRADataError(f"Failed to parse NIMDM SOA results: {e}") from e
+
+    df = df.rename(columns=_COLUMN_MAP)
+    df = df[[c for c in _COLUMN_MAP.values() if c in df.columns]]
+
+    for col in _RANK_COLUMNS:
+        if col in df.columns:
+            df[col] = pd.to_numeric(df[col], errors="coerce").astype("Int64")
+
+    return df.reset_index(drop=True)
+
+
+def validate_data(df: pd.DataFrame) -> bool:
+    """Validate the NIMDM DataFrame for internal consistency.
+
+    Args:
+        df: DataFrame as returned by :func:`get_latest_data`.
+
+    Returns:
+        True if all checks pass.
+
+    Raises:
+        NISRAValidationError: Describing the first failing check.
+
+    Example:
+        >>> import pandas as pd
+        >>> df = pd.DataFrame({
+        ...     "soa_code": ["95AA01S1"], "soa_name": ["Aldergrove_1"],
+        ...     "lgd": ["Antrim and Newtownabbey"], "urban_rural": ["Rural"],
+        ...     "mdm_rank": [516], "income_rank": [790],
+        ...     "employment_rank": [888], "health_disability_rank": [890],
+        ...     "education_rank": [254], "access_to_services_rank": [17],
+        ...     "living_environment_rank": [75], "crime_disorder_rank": [874],
+        ... })
+        >>> validate_data(df)
+        True
+    """
+    required = {"soa_code", "soa_name", "lgd", *_RANK_COLUMNS}
+    missing = required - set(df.columns)
+    if missing:
+        raise NISRAValidationError(f"Missing required columns: {missing}")
+
+    if df.empty:
+        raise NISRAValidationError("DataFrame is empty")
+
+    n_soa = df["soa_code"].nunique()
+    if n_soa < 800:
+        raise NISRAValidationError(f"Expected ~890 SOAs, got {n_soa}")
+
+    if df["soa_code"].duplicated().any():
+        dupes = df.loc[df["soa_code"].duplicated(), "soa_code"].tolist()
+        raise NISRAValidationError(f"Duplicate soa_code values found: {dupes[:5]}")
+
+    n_rows = len(df)
+    for col in _RANK_COLUMNS:
+        ranks = df[col].dropna()
+        if (ranks < 1).any() or (ranks > n_rows).any():
+            raise NISRAValidationError(f"{col} has values outside the expected 1-{n_rows} range")
+        if ranks.nunique() < n_rows * 0.95:
+            raise NISRAValidationError(f"{col} should be (near-)unique ranks, got {ranks.nunique()} unique values")
+
+    return True

--- a/src/bolster/data_sources/nisra/deprivation.py
+++ b/src/bolster/data_sources/nisra/deprivation.py
@@ -94,13 +94,13 @@ def get_latest_data(force_refresh: bool = False) -> pd.DataFrame:
 
     try:
         df = pd.read_excel(path, sheet_name=_SHEET_NAME, engine="xlrd")
-    except Exception as e:
+    except Exception as e:  # pragma: no cover - requires a corrupt upstream file to exercise
         raise NISRADataError(f"Failed to parse NIMDM SOA results: {e}") from e
 
     df = df.rename(columns=_COLUMN_MAP)
     df = df[[c for c in _COLUMN_MAP.values() if c in df.columns]]
 
-    for col in _RANK_COLUMNS:
+    for col in _RANK_COLUMNS:  # pragma: no branch - every rank column is always present in _COLUMN_MAP
         if col in df.columns:
             df[col] = pd.to_numeric(df[col], errors="coerce").astype("Int64")
 

--- a/tests/test_nisra_deprivation_integrity.py
+++ b/tests/test_nisra_deprivation_integrity.py
@@ -1,0 +1,138 @@
+"""Integrity and validation tests for nisra.deprivation.
+
+Network tests download the live NIMDM2017 SOA-level results file from NISRA.
+Validation unit tests run entirely in-process (no network calls).
+"""
+
+import pandas as pd
+import pytest
+
+from bolster.data_sources.nisra import deprivation
+from bolster.data_sources.nisra._base import NISRAValidationError
+
+
+class TestDeprivationIntegrity:
+    """Integration tests against the live NIMDM2017 SOA results file."""
+
+    @pytest.fixture(scope="class")
+    def latest_data(self) -> pd.DataFrame:
+        return deprivation.get_latest_data()
+
+    def test_required_columns(self, latest_data: pd.DataFrame) -> None:
+        required = {
+            "lgd",
+            "urban_rural",
+            "soa_code",
+            "soa_name",
+            "mdm_rank",
+            "income_rank",
+            "employment_rank",
+            "health_disability_rank",
+            "education_rank",
+            "access_to_services_rank",
+            "living_environment_rank",
+            "crime_disorder_rank",
+        }
+        assert required <= set(latest_data.columns), f"Missing columns: {required - set(latest_data.columns)}"
+
+    def test_not_empty(self, latest_data: pd.DataFrame) -> None:
+        assert len(latest_data) > 0
+
+    def test_soa_count(self, latest_data: pd.DataFrame) -> None:
+        assert latest_data["soa_code"].nunique() >= 880, (
+            f"Expected ~890 SOAs, got {latest_data['soa_code'].nunique()}"
+        )
+
+    def test_soa_codes_unique(self, latest_data: pd.DataFrame) -> None:
+        assert not latest_data["soa_code"].duplicated().any()
+
+    def test_mdm_rank_is_complete_permutation(self, latest_data: pd.DataFrame) -> None:
+        ranks = sorted(latest_data["mdm_rank"].dropna().tolist())
+        assert ranks == list(range(1, len(latest_data) + 1))
+
+    def test_domain_ranks_within_range(self, latest_data: pd.DataFrame) -> None:
+        n = len(latest_data)
+        domain_cols = [
+            "income_rank",
+            "employment_rank",
+            "health_disability_rank",
+            "education_rank",
+            "access_to_services_rank",
+            "living_environment_rank",
+            "crime_disorder_rank",
+        ]
+        for col in domain_cols:
+            values = latest_data[col].dropna()
+            assert values.min() >= 1
+            assert values.max() <= n
+
+    def test_multiple_lgds_present(self, latest_data: pd.DataFrame) -> None:
+        assert latest_data["lgd"].nunique() >= 8
+
+    def test_validate_data_passes(self, latest_data: pd.DataFrame) -> None:
+        assert deprivation.validate_data(latest_data) is True
+
+
+class TestValidation:
+    """Unit tests for validation edge cases - no network calls needed."""
+
+    def _valid_df(self, n: int = 890) -> pd.DataFrame:
+        return pd.DataFrame(
+            {
+                "soa_code": [f"SOA{i:04d}" for i in range(n)],
+                "soa_name": [f"Area_{i}" for i in range(n)],
+                "lgd": ["Belfast"] * n,
+                "urban_rural": ["Urban"] * n,
+                "mdm_rank": list(range(1, n + 1)),
+                "income_rank": list(range(1, n + 1)),
+                "employment_rank": list(range(1, n + 1)),
+                "health_disability_rank": list(range(1, n + 1)),
+                "education_rank": list(range(1, n + 1)),
+                "access_to_services_rank": list(range(1, n + 1)),
+                "living_environment_rank": list(range(1, n + 1)),
+                "crime_disorder_rank": list(range(1, n + 1)),
+            }
+        )
+
+    def test_validate_empty_dataframe(self) -> None:
+        df = self._valid_df(0)
+        with pytest.raises(NISRAValidationError, match="empty"):
+            deprivation.validate_data(df)
+
+    def test_validate_missing_columns(self) -> None:
+        df = self._valid_df().drop(columns=["mdm_rank"])
+        with pytest.raises(NISRAValidationError, match="Missing required columns"):
+            deprivation.validate_data(df)
+
+    def test_validate_too_few_soas(self) -> None:
+        df = self._valid_df(100)
+        with pytest.raises(NISRAValidationError, match="Expected ~890 SOAs"):
+            deprivation.validate_data(df)
+
+    def test_validate_duplicate_soa_codes(self) -> None:
+        df = self._valid_df()
+        df.loc[1, "soa_code"] = df.loc[0, "soa_code"]
+        with pytest.raises(NISRAValidationError, match="Duplicate soa_code"):
+            deprivation.validate_data(df)
+
+    def test_validate_rank_out_of_range(self) -> None:
+        df = self._valid_df()
+        df.loc[0, "mdm_rank"] = 0
+        with pytest.raises(NISRAValidationError, match="outside the expected"):
+            deprivation.validate_data(df)
+
+    def test_validate_rank_above_range(self) -> None:
+        df = self._valid_df()
+        df.loc[0, "mdm_rank"] = len(df) + 100
+        with pytest.raises(NISRAValidationError, match="outside the expected"):
+            deprivation.validate_data(df)
+
+    def test_validate_non_unique_ranks(self) -> None:
+        df = self._valid_df()
+        df["mdm_rank"] = 1
+        with pytest.raises(NISRAValidationError, match="near-.unique ranks"):
+            deprivation.validate_data(df)
+
+    def test_validate_valid_data_passes(self) -> None:
+        df = self._valid_df()
+        assert deprivation.validate_data(df) is True


### PR DESCRIPTION
## Summary

- Adds `bolster.data_sources.nisra.deprivation` providing SOA-level NIMDM2017 deprivation ranks (overall + 7 domains: income, employment, health/disability, education, access to services, living environment, crime/disorder)
- Static `.xls` download (no PxStat matrix available), parsed via `xlrd`, cached via the shared `_base.download_file()` utility
- Adds `bolster nisra deprivation` CLI command with `--lgd` filter and csv/json/table output
- Updates `__init__.py` exports/docstring and the README coverage table

Closes #1923

## Example insights

- 890 SOAs ranked 1 (most deprived) to 890 (least deprived) on overall MDM and each of 7 domains
- Enables joins with claimant counts, births/deaths, and crime data already in bolster by `soa_code` / `lgd`

## Test plan

- [x] `uv run pytest tests/test_nisra_deprivation_integrity.py -q --no-cov` — 16/16 passing (live download + validation unit tests)
- [x] `uv run pytest tests/ -q --no-cov` — full suite passes (1700 passed, 7 pre-existing skips)
- [x] `uv run pre-commit run --all-files` — clean
- [x] `bolster nisra deprivation --lgd Belfast --format csv` — manually verified output
- [x] Coverage on new module: 95% (cov.xml), `cli.py` confirmed absent from coverage report

🤖 Generated with [Claude Code](https://claude.com/claude-code)