### PR TITLE
feat(nisra): add NI Business Register (IDBR) module

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,7 @@ The [GOV.UK NISRA statistics RSS feed](https://www.gov.uk/search/research-and-st
 | NI Assembly — MLAs, Parties, Constituencies | `niassembly.members` | ✅ |
 | NI Assembly — Questions (oral & written, 2007–present) | `niassembly.questions` | ✅ |
 | NI Assembly — Votes/Divisions (per-member records) | `niassembly.votes` | ✅ |
+| NI Business Register (IDBR, annual) | `nisra.business_register` | ✅ |
 | Security Situation Statistics | - | ❌ Cloudflare-blocked |
 | Anti-social Behaviour | - | ❌ Cloudflare-blocked |
 | Domestic Abuse Incidents/Crimes | - | ❌ Cloudflare-blocked |

--- a/src/bolster/cli.py
+++ b/src/bolster/cli.py
@@ -28,6 +28,7 @@ from .data_sources.niassembly import votes as niassembly_votes
 from .data_sources.nisra import ashe as nisra_ashe
 from .data_sources.nisra import baby_names as nisra_baby_names
 from .data_sources.nisra import births as nisra_births
+from .data_sources.nisra import business_register as nisra_business_register
 from .data_sources.nisra import cancer_waiting_times as nisra_cancer
 from .data_sources.nisra import composite_index as nisra_composite
 from .data_sources.nisra import construction_output as nisra_construction
@@ -2027,6 +2028,108 @@ def nisra_labour_market_cmd(dimension, table_deprecated, output_format, force_re
         console.print("   • Check your internet connection")
         console.print("   • Try again with --force-refresh to bypass cache")
         console.print("   • Visit NISRA website to verify data availability")
+        raise click.Abort() from e
+
+
+@nisra.command(name="business-register")
+@click.option(
+    "--level",
+    type=click.Choice(["industry", "legal_status", "lgd"], case_sensitive=False),
+    default="industry",
+    show_default=True,
+    help="Breakdown level: industry group, legal status, or Local Government District",
+)
+@click.option(
+    "--format",
+    "output_format",
+    type=click.Choice(["table", "csv", "json"], case_sensitive=False),
+    default="table",
+    help="Output format (default: table)",
+)
+@click.option("--force-refresh", is_flag=True, help="Force re-download even if cached")
+@click.option("--save", help="Save data to file (specify filename)")
+def nisra_business_register_cmd(level, output_format, force_refresh, save):
+    """NI Business Register (IDBR) - annual VAT/PAYE registered business counts.
+
+    Annual count of VAT and/or PAYE registered businesses operating in
+    Northern Ireland, broken down by broad industry group, legal status,
+    or Local Government District.
+
+    Examples:
+        Get business counts by industry group::
+
+            bolster nisra business-register
+
+        Get business counts by Local Government District::
+
+            bolster nisra business-register --level lgd
+
+        Save to file::
+
+            bolster nisra business-register --level legal_status --save businesses.csv
+
+    Data Notes:
+        - Source: NISRA / Inter-Departmental Business Register (IDBR)
+        - Industry and legal status coverage: 2010-present
+        - LGD coverage: 2013-present
+        - Published annually in June
+
+    Returns:
+        DataFrame with columns depending on --level: year, businesses, plus
+        industry_group / (legal_status, sector) / lgd.
+
+    Note:
+        Source: https://www.nisra.gov.uk/publications/northern-ireland-business-activity-size-location-and-ownership
+    """
+    console = Console()
+
+    try:
+        with console.status("[bold green]Downloading NI Business Register data..."):
+            data = nisra_business_register.get_latest_data(force_refresh=force_refresh, level=level.lower())
+
+        if data.empty:
+            console.print("[yellow]No data found[/yellow]")
+            return
+
+        console.print("[green]NI Business Register data retrieved successfully[/green]")
+        console.print(f"[cyan]Rows: {len(data)}[/cyan]")
+
+        if save:
+            try:
+                if output_format == "json" or save.endswith(".json"):
+                    data.to_json(save, orient="records", indent=2)
+                else:
+                    data.to_csv(save, index=False)
+                console.print(f"[green]Saved to: {save}[/green]")
+                return
+            except PermissionError:
+                console.print(f"[red]Error: Permission denied writing to {save}[/red]")
+                return
+            except Exception as e:
+                console.print(f"[red]Error saving file: {e}[/red]")
+                return
+
+        if output_format == "json":
+            click.echo(data.to_json(orient="records", indent=2))
+        elif output_format == "csv":
+            console.print(data.to_csv(index=False), end="")
+        else:
+            from rich.table import Table
+
+            rich_table = Table(title=f"NI Business Register — {level}")
+            for col in data.columns:
+                rich_table.add_column(col, style="white")
+            for _, row in data.head(20).iterrows():
+                rich_table.add_row(*[str(v) for v in row])
+            console.print(rich_table)
+            if len(data) > 20:
+                console.print(f"[dim]... and {len(data) - 20} more rows (use --format csv to see all)[/dim]")
+
+    except Exception as e:
+        console.print(f"[bold red]Error:[/bold red] {str(e)}", style="red")
+        console.print("\n[yellow]Troubleshooting:[/yellow]")
+        console.print("   - Check your internet connection")
+        console.print("   - Try again with --force-refresh to bypass cache")
         raise click.Abort() from e
 
 

--- a/src/bolster/data_sources/nisra/__init__.py
+++ b/src/bolster/data_sources/nisra/__init__.py
@@ -7,6 +7,7 @@ and tourism statistics.
 Available modules:
     - ashe: Annual Survey of Hours and Earnings (employee earnings statistics)
     - births: Monthly birth registrations by registration and occurrence date
+    - business_register: NI Business Register (IDBR) — annual VAT/PAYE business counts by industry, legal status, LGD
     - claimant_count: Monthly Claimant Count (UC + JSA) by sex, age, and geography
     - cancer_waiting_times: Cancer treatment waiting times (14-day, 31-day, 62-day targets)
     - child_protection: Children's Social Care child protection statistics
@@ -120,12 +121,18 @@ Examples:
     >>> 'total_waiting' in df.columns
     True
 
+    >>> from bolster.data_sources.nisra import business_register
+    >>> df = business_register.get_latest_data()
+    >>> 'businesses' in df.columns
+    True
+
 """
 
 from . import (
     ashe,
     baby_names,
     births,
+    business_register,
     cancer_waiting_times,
     child_protection,
     claimant_count,
@@ -159,6 +166,7 @@ __all__ = [
     "ashe",
     "baby_names",
     "births",
+    "business_register",
     "cancer_waiting_times",
     "child_protection",
     "claimant_count",

--- a/src/bolster/data_sources/nisra/business_register.py
+++ b/src/bolster/data_sources/nisra/business_register.py
@@ -1,0 +1,278 @@
+"""NISRA NI Business Register (IDBR) Module.
+
+Provides access to the annual count of VAT and/or PAYE registered businesses
+operating in Northern Ireland, sourced from the Inter-Departmental Business
+Register (IDBR). This is the only structured time-series of NI business stock.
+
+Data Coverage:
+    - By broad industry group: 2010-present
+    - By legal status: 2010-present
+    - By Local Government District (LGD): 2013-present
+
+Data Source:
+    Publication page (year-specific):
+        https://www.nisra.gov.uk/publications/northern-ireland-business-activity-size-location-and-ownership-{year}
+    Direct file (year-specific):
+        https://www.nisra.gov.uk/system/files/statistics/{year}-06/IDBR-Publication-{year}.xlsx
+
+Update Frequency:
+    Annual, published in June.
+
+Example:
+    >>> from bolster.data_sources.nisra import business_register
+    >>> df = business_register.get_latest_data()
+    >>> 'businesses' in df.columns
+    True
+"""
+
+import logging
+from datetime import datetime
+
+import pandas as pd
+
+from bolster.utils.web import session
+
+from ._base import NISRADataError, NISRADataNotFoundError, NISRAValidationError, download_file
+
+logger = logging.getLogger(__name__)
+
+NISRA_BASE_URL = "https://www.nisra.gov.uk"
+PUBLICATION_PAGE_TEMPLATE = (
+    "https://www.nisra.gov.uk/publications/northern-ireland-business-activity-size-location-and-ownership-{year}"
+)
+FILE_URL_TEMPLATE = "https://www.nisra.gov.uk/system/files/statistics/{year}-06/IDBR-Publication-{year}.xlsx"
+
+_SHEET_INDUSTRY = "1.1"
+_SHEET_LEGAL_STATUS = "2.1"
+_SHEET_LGD = "3.1"
+
+
+def get_idbr_publication_url(year: int | None = None) -> tuple[str, int]:
+    """Find the IDBR publication Excel URL for a given (or latest) year.
+
+    Tries the direct, stable URL pattern first (year is incremented each
+    publication). Falls back to scraping the year-specific publication page
+    if the direct URL is not reachable.
+
+    Args:
+        year: Publication year to look for. Defaults to trying the current
+            year, then the previous year.
+
+    Returns:
+        Tuple of (excel_url, year).
+
+    Raises:
+        NISRADataNotFoundError: If no publication could be found.
+
+    Example:
+        >>> url, year = get_idbr_publication_url()
+        >>> url.startswith('https://')
+        True
+    """
+    candidate_years = [year] if year is not None else [datetime.now().year, datetime.now().year - 1]
+
+    for candidate_year in candidate_years:
+        direct_url = FILE_URL_TEMPLATE.format(year=candidate_year)
+        try:
+            response = session.head(direct_url, timeout=15, allow_redirects=True)
+            if response.status_code == 200:
+                return direct_url, candidate_year
+        except Exception as e:
+            logger.debug(f"HEAD request failed for {direct_url}: {e}")
+
+        pub_url = PUBLICATION_PAGE_TEMPLATE.format(year=candidate_year)
+        try:
+            response = session.get(pub_url, timeout=30)
+            response.raise_for_status()
+        except Exception as e:
+            logger.debug(f"Failed to fetch IDBR publication page {pub_url}: {e}")
+            continue
+
+        from bs4 import BeautifulSoup
+
+        soup = BeautifulSoup(response.content, "html.parser")
+        for a_tag in soup.find_all("a", href=True):
+            href = a_tag["href"]
+            if "idbr" in href.lower() and href.lower().endswith(".xlsx"):
+                excel_url = href if href.startswith("http") else f"{NISRA_BASE_URL}{href}"
+                return excel_url, candidate_year
+
+    raise NISRADataNotFoundError(
+        f"Could not find IDBR publication for years {candidate_years}. "
+        f"Check: {PUBLICATION_PAGE_TEMPLATE.format(year=candidate_years[0])}"
+    )
+
+
+def _wide_to_long(df: pd.DataFrame, id_col: str, id_label: str, value_label: str) -> pd.DataFrame:
+    """Pivot a wide year-columned table to tidy long format."""
+    year_cols = [c for c in df.columns if c != id_col]
+    long = df.melt(id_vars=[id_col], value_vars=year_cols, var_name="year", value_name=value_label)
+    long = long.rename(columns={id_col: id_label})
+    long["year"] = pd.to_numeric(long["year"], errors="coerce").astype("Int64")
+    long[value_label] = pd.to_numeric(long[value_label], errors="coerce")
+    return long.dropna(subset=["year"]).reset_index(drop=True)
+
+
+def get_businesses_by_industry(force_refresh: bool = False) -> pd.DataFrame:
+    """Get annual business counts by broad industry group (Table 1.1).
+
+    Args:
+        force_refresh: Force re-download even if cached.
+
+    Returns:
+        DataFrame with columns: year, industry_group, businesses.
+    """
+    url, _ = get_idbr_publication_url()
+    path = download_file(url, cache_ttl_hours=24 * 30, force_refresh=force_refresh)
+
+    try:
+        raw = pd.read_excel(path, sheet_name=_SHEET_INDUSTRY, engine="openpyxl", header=None)
+    except Exception as e:
+        raise NISRADataError(f"Failed to parse IDBR industry sheet: {e}") from e
+
+    header_row = raw.index[raw[0] == "Broad Industry Group"][0]
+    table = raw.iloc[header_row + 1 :].copy()
+    table.columns = raw.iloc[header_row]
+    table = table.rename(columns={"Broad Industry Group": "industry_group"})
+    table = table.dropna(subset=["industry_group"]).reset_index(drop=True)
+
+    return _wide_to_long(table, "industry_group", "industry_group", "businesses")
+
+
+def get_businesses_by_legal_status(force_refresh: bool = False) -> pd.DataFrame:
+    """Get annual business counts by legal status (Table 2.1).
+
+    Args:
+        force_refresh: Force re-download even if cached.
+
+    Returns:
+        DataFrame with columns: year, legal_status, sector, businesses.
+    """
+    url, _ = get_idbr_publication_url()
+    path = download_file(url, cache_ttl_hours=24 * 30, force_refresh=force_refresh)
+
+    try:
+        raw = pd.read_excel(path, sheet_name=_SHEET_LEGAL_STATUS, engine="openpyxl", header=None)
+    except Exception as e:
+        raise NISRADataError(f"Failed to parse IDBR legal status sheet: {e}") from e
+
+    header_row = raw.index[raw[0] == "Legal Status"][0]
+    table = raw.iloc[header_row + 1 :].copy()
+    table.columns = raw.iloc[header_row]
+    table = table.rename(columns={"Legal Status": "legal_status", "Public/Private Sector": "sector"})
+    table = table.dropna(subset=["legal_status"]).reset_index(drop=True)
+
+    year_cols = [c for c in table.columns if c not in ("legal_status", "sector")]
+    long = table.melt(
+        id_vars=["legal_status", "sector"], value_vars=year_cols, var_name="year", value_name="businesses"
+    )
+    long["year"] = pd.to_numeric(long["year"], errors="coerce").astype("Int64")
+    long["businesses"] = pd.to_numeric(long["businesses"], errors="coerce")
+    return long.dropna(subset=["year"]).reset_index(drop=True)
+
+
+def get_businesses_by_lgd(force_refresh: bool = False) -> pd.DataFrame:
+    """Get annual business counts by Local Government District (Table 3.1).
+
+    Args:
+        force_refresh: Force re-download even if cached.
+
+    Returns:
+        DataFrame with columns: year, lgd, businesses.
+    """
+    url, _ = get_idbr_publication_url()
+    path = download_file(url, cache_ttl_hours=24 * 30, force_refresh=force_refresh)
+
+    try:
+        raw = pd.read_excel(path, sheet_name=_SHEET_LGD, engine="openpyxl", header=None)
+    except Exception as e:
+        raise NISRADataError(f"Failed to parse IDBR LGD sheet: {e}") from e
+
+    header_row = raw.index[raw[0] == "Local Government District"][0]
+    table = raw.iloc[header_row + 1 :].copy()
+    table.columns = raw.iloc[header_row]
+    table = table.rename(columns={"Local Government District": "lgd"})
+    table = table.dropna(subset=["lgd"]).reset_index(drop=True)
+
+    return _wide_to_long(table, "lgd", "lgd", "businesses")
+
+
+def get_latest_data(force_refresh: bool = False, level: str = "industry") -> pd.DataFrame:
+    """Get the latest NI Business Register (IDBR) data.
+
+    Args:
+        force_refresh: Force re-download even if cached.
+        level: Breakdown level - 'industry' (default), 'legal_status', or 'lgd'.
+
+    Returns:
+        DataFrame for the requested breakdown level. See
+        :func:`get_businesses_by_industry`, :func:`get_businesses_by_legal_status`,
+        and :func:`get_businesses_by_lgd` for column details.
+
+    Raises:
+        ValueError: If level is not one of 'industry', 'legal_status', or 'lgd'.
+
+    Example:
+        >>> df = get_latest_data()
+        >>> 'businesses' in df.columns
+        True
+    """
+    if level == "industry":
+        return get_businesses_by_industry(force_refresh=force_refresh)
+    if level == "legal_status":
+        return get_businesses_by_legal_status(force_refresh=force_refresh)
+    if level == "lgd":
+        return get_businesses_by_lgd(force_refresh=force_refresh)
+    raise ValueError(f"level must be 'industry', 'legal_status', or 'lgd', got {level!r}")
+
+
+def validate_data(df: pd.DataFrame, level: str = "industry") -> bool:
+    """Validate the IDBR DataFrame for internal consistency.
+
+    Args:
+        df: DataFrame as returned by :func:`get_latest_data`.
+        level: Validation mode matching the breakdown level - 'industry'
+            (default), 'legal_status', or 'lgd'.
+
+    Returns:
+        True if all checks pass.
+
+    Raises:
+        NISRAValidationError: Describing the first failing check.
+        ValueError: If level is not a recognised value.
+
+    Example:
+        >>> import pandas as pd
+        >>> df = pd.DataFrame({
+        ...     "year": [2020, 2021], "industry_group": ["Retail", "Retail"],
+        ...     "businesses": [5890.0, 6040.0],
+        ... })
+        >>> validate_data(df)
+        True
+    """
+    if level not in ("industry", "legal_status", "lgd"):
+        raise ValueError(f"level must be 'industry', 'legal_status', or 'lgd', got {level!r}")
+
+    id_col = {"industry": "industry_group", "legal_status": "legal_status", "lgd": "lgd"}[level]
+    required = {"year", id_col, "businesses"}
+    missing = required - set(df.columns)
+    if missing:
+        raise NISRAValidationError(f"Missing required columns: {missing}")
+
+    if df.empty:
+        raise NISRAValidationError("DataFrame is empty")
+
+    min_year_expected = 2013 if level == "lgd" else 2010
+    min_year = df["year"].min()
+    if min_year > min_year_expected + 2:
+        raise NISRAValidationError(f"Expected coverage from ~{min_year_expected}, earliest year is {min_year}")
+
+    businesses = df["businesses"].dropna()
+    if (businesses < 0).any():
+        bad = businesses[businesses < 0]
+        raise NISRAValidationError(f"businesses has {len(bad)} negative values: {bad.head().tolist()}")
+
+    if df[id_col].nunique() < 3:
+        raise NISRAValidationError(f"Too few distinct {id_col} categories: {df[id_col].nunique()}")
+
+    return True

--- a/tests/test_nisra_business_register_integrity.py
+++ b/tests/test_nisra_business_register_integrity.py
@@ -1,0 +1,147 @@
+"""Integrity and validation tests for nisra.business_register.
+
+Network tests download the live IDBR publication Excel file from NISRA.
+Validation unit tests run entirely in-process (no network calls).
+"""
+
+import pandas as pd
+import pytest
+
+from bolster.data_sources.nisra import business_register
+from bolster.data_sources.nisra._base import NISRAValidationError
+
+
+class TestIndustryIntegrity:
+    """Integration tests against the live IDBR Table 1.1 (industry group)."""
+
+    @pytest.fixture(scope="class")
+    def latest_data(self) -> pd.DataFrame:
+        return business_register.get_businesses_by_industry()
+
+    def test_required_columns(self, latest_data: pd.DataFrame) -> None:
+        assert {"year", "industry_group", "businesses"} <= set(latest_data.columns)
+
+    def test_not_empty(self, latest_data: pd.DataFrame) -> None:
+        assert len(latest_data) > 0
+
+    def test_historical_coverage_back_to_2010(self, latest_data: pd.DataFrame) -> None:
+        assert latest_data["year"].min() <= 2010
+
+    def test_multiple_industries_present(self, latest_data: pd.DataFrame) -> None:
+        assert latest_data["industry_group"].nunique() >= 10
+
+    def test_businesses_non_negative(self, latest_data: pd.DataFrame) -> None:
+        assert (latest_data["businesses"].dropna() >= 0).all()
+
+    def test_validate_data_passes(self, latest_data: pd.DataFrame) -> None:
+        assert business_register.validate_data(latest_data, level="industry") is True
+
+
+class TestLegalStatusIntegrity:
+    """Integration tests against the live IDBR Table 2.1 (legal status)."""
+
+    @pytest.fixture(scope="class")
+    def latest_data(self) -> pd.DataFrame:
+        return business_register.get_businesses_by_legal_status()
+
+    def test_required_columns(self, latest_data: pd.DataFrame) -> None:
+        assert {"year", "legal_status", "sector", "businesses"} <= set(latest_data.columns)
+
+    def test_not_empty(self, latest_data: pd.DataFrame) -> None:
+        assert len(latest_data) > 0
+
+    def test_multiple_legal_statuses_present(self, latest_data: pd.DataFrame) -> None:
+        assert latest_data["legal_status"].nunique() >= 5
+
+    def test_validate_data_passes(self, latest_data: pd.DataFrame) -> None:
+        assert business_register.validate_data(latest_data, level="legal_status") is True
+
+
+class TestLgdIntegrity:
+    """Integration tests against the live IDBR Table 3.1 (LGD)."""
+
+    @pytest.fixture(scope="class")
+    def latest_data(self) -> pd.DataFrame:
+        return business_register.get_businesses_by_lgd()
+
+    def test_required_columns(self, latest_data: pd.DataFrame) -> None:
+        assert {"year", "lgd", "businesses"} <= set(latest_data.columns)
+
+    def test_not_empty(self, latest_data: pd.DataFrame) -> None:
+        assert len(latest_data) > 0
+
+    def test_historical_coverage_back_to_2013(self, latest_data: pd.DataFrame) -> None:
+        assert latest_data["year"].min() <= 2013
+
+    def test_lgds_present(self, latest_data: pd.DataFrame) -> None:
+        assert latest_data["lgd"].nunique() >= 11
+
+    def test_validate_data_passes(self, latest_data: pd.DataFrame) -> None:
+        assert business_register.validate_data(latest_data, level="lgd") is True
+
+
+class TestGetLatestData:
+    """Tests for the get_latest_data dispatcher."""
+
+    def test_default_level_is_industry(self) -> None:
+        data = business_register.get_latest_data()
+        assert "industry_group" in data.columns
+
+    def test_level_legal_status(self) -> None:
+        data = business_register.get_latest_data(level="legal_status")
+        assert "legal_status" in data.columns
+
+    def test_level_lgd(self) -> None:
+        data = business_register.get_latest_data(level="lgd")
+        assert "lgd" in data.columns
+
+    def test_invalid_level_raises(self) -> None:
+        with pytest.raises(ValueError, match="level must be"):
+            business_register.get_latest_data(level="bogus")
+
+
+class TestValidation:
+    """Unit tests for validation edge cases - no network calls needed."""
+
+    def _industry_df(self) -> pd.DataFrame:
+        return pd.DataFrame(
+            {
+                "year": [2010, 2011, 2012, 2013],
+                "industry_group": ["Retail", "Construction", "Production", "Wholesale"],
+                "businesses": [6630.0, 11495.0, 4455.0, 3385.0],
+            }
+        )
+
+    def test_validate_empty_dataframe(self) -> None:
+        df = self._industry_df().iloc[0:0]
+        with pytest.raises(NISRAValidationError, match="empty"):
+            business_register.validate_data(df, level="industry")
+
+    def test_validate_missing_columns(self) -> None:
+        df = self._industry_df().drop(columns=["businesses"])
+        with pytest.raises(NISRAValidationError, match="Missing required columns"):
+            business_register.validate_data(df, level="industry")
+
+    def test_validate_negative_values(self) -> None:
+        df = self._industry_df()
+        df.loc[0, "businesses"] = -5
+        with pytest.raises(NISRAValidationError, match="negative values"):
+            business_register.validate_data(df, level="industry")
+
+    def test_validate_too_few_categories(self) -> None:
+        df = self._industry_df().iloc[:2]
+        with pytest.raises(NISRAValidationError, match="Too few distinct"):
+            business_register.validate_data(df, level="industry")
+
+    def test_validate_late_coverage_start(self) -> None:
+        df = self._industry_df()
+        df["year"] = df["year"] + 20
+        with pytest.raises(NISRAValidationError, match="Expected coverage"):
+            business_register.validate_data(df, level="industry")
+
+    def test_validate_invalid_level_raises(self) -> None:
+        with pytest.raises(ValueError, match="level must be"):
+            business_register.validate_data(self._industry_df(), level="bogus")
+
+    def test_validate_valid_data_passes(self) -> None:
+        assert business_register.validate_data(self._industry_df(), level="industry") is True


### PR DESCRIPTION
## Summary

- Adds `bolster.data_sources.nisra.business_register` providing annual VAT/PAYE registered business counts from the IDBR publication, with three breakdowns: industry group (Table 1.1), legal status (Table 2.1), and Local Government District (Table 3.1)
- URL discovery tries the stable direct-file pattern first (current year, then previous year), falling back to scraping the year-specific publication page if needed
- Adds `bolster nisra business-register --level {industry,legal_status,lgd}` CLI command with csv/json/table output
- Updates `__init__.py` exports/docstring and the README coverage table

Closes #1921

## Example insights

- Industry group coverage 2010–2026, legal status 2010–2026, LGD 2013–2026
- Sole Proprietor business counts have steadily declined since 2010 while Company/LLP counts have more than doubled — a shift toward incorporation
- Enables joins with claimant counts and other NISRA economic indicators by LGD/year

## Test plan

- [x] `uv run pytest tests/test_nisra_business_register_integrity.py -q --no-cov` — 26/26 passing (live download + validation unit tests)
- [x] `uv run pytest tests/ -q --no-cov` — full suite passes (1710 passed, 7 pre-existing skips)
- [x] `uv run pre-commit run --all-files` — clean
- [x] `bolster nisra business-register --level lgd --format csv` — manually verified output
- [x] Coverage on new module: 80% (cov.xml), `cli.py` confirmed absent from coverage report

🤖 Generated with [Claude Code](https://claude.com/claude-code)