### PR TITLE
ci: cache ~/.cache/bolster downloads across PyTest matrix runs

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -29,6 +29,21 @@ jobs:
                   enable-cache: true
                   cache-dependency-glob: "uv.lock"
 
+            - name: Get current date
+              id: date
+              run: echo "date=$(date -u +%Y-%m-%d)" >> "$GITHUB_OUTPUT"
+
+            - name: Cache downloaded source data
+              uses: actions/cache@v4
+              with:
+                  path: ~/.cache/bolster
+                  # Key rotates daily so a successful download survives between
+                  # runs on the same day (shared across the whole matrix via
+                  # restore-keys) without caching stale/broken downloads forever.
+                  key: bolster-downloads-${{ runner.os }}-${{ steps.date.outputs.date }}
+                  restore-keys: |
+                      bolster-downloads-${{ runner.os }}-
+
             - name: Install the project
               run: uv sync --all-extras --dev
 


### PR DESCRIPTION
## Summary

Root-cause for PR #1935's `build (3.12)` job running 50+ minutes (eventually cancelled): every CI run starts with a completely cold `CachedDownloader` cache (`~/.cache/bolster/`), since only the `uv` dependency cache is currently configured (`enable-cache: true` in the `setup-uv` step). 

When `nisra.gov.uk` intermittently returns HTTP 503 under load, every test class in `tests/test_nisra_ashe_integrity.py` that needs `ASHE-2025-linked.xlsx` — there are ~20+ of them, each with its own `scope="class"` fixture per the project's documented testing convention — independently exhausts its own 5-retry budget against the same flaky URL, because nothing was ever cached from a prior class's attempt. In the offending run, `ASHE-2025-linked.xlsx` alone triggered **100 separate 503 retry attempts**.

- Adds an `actions/cache@v4` step caching `~/.cache/bolster` (the `CachedDownloader` cache root)
- Key rotates daily (`bolster-downloads-${{ runner.os }}-YYYY-MM-DD`), with a `restore-keys` prefix fallback to the most recent cached day
- Shared across the whole Python-version matrix — once any leg successfully downloads a file, the others reuse it instead of re-fetching
- Stale/broken downloads don't persist indefinitely since the key changes daily

This doesn't touch test fixture scoping (each `scope="class"` fixture remains as-is, consistent with the project's "no mocks, real data" testing philosophy) — it just means a cold *runner* no longer means a cold *cache* for files that were already successfully fetched earlier the same day.

## Test plan

- [x] YAML validated (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [x] `uv run pre-commit run --files .github/workflows/pytest.yml` — clean
- [ ] CI run — confirm cache step restores/saves correctly and a second run on the same day shows a cache hit

🤖 Generated with [Claude Code](https://claude.com/claude-code)