### PR TITLE
ci: serialize PyTest workflow runs across all branches

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -6,6 +6,14 @@ on:
     pull_request:
         branches: ["main"]
 
+# Only one PyTest run (across all branches/PRs) hits the live NISRA/NIAssembly
+# endpoints at a time, so a flaky upstream can't be hammered by a dozen
+# concurrent matrix jobs at once (e.g. after a mass PR-rebase). Runs queue
+# rather than cancel, so a slow run delays but doesn't drop later ones.
+concurrency:
+    group: pytest-all
+    cancel-in-progress: false
+
 jobs:
     build:
         runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

You can currently see ~10 PyTest workflow runs in progress simultaneously right now — that's the `rebase.yml` auto-rebase workflow pushing to every open, non-conflicting PR within seconds of a merge to main (e.g. just happened after #1936 merged). Each push triggers its own full matrix run, and they all hit the same live `nisra.gov.uk` / `niassembly.gov.uk` endpoints at the same moment — directly undermining the point of #1936's download cache, since a dozen jobs racing for the same upstream resource is its own form of self-inflicted load.

- Adds a repo-wide `concurrency: group: pytest-all` with `cancel-in-progress: false`
- Only one PyTest workflow run (across *any* branch/PR/push) is active at a time; others queue behind it rather than running concurrently or being cancelled

**Tradeoff**: CI feedback becomes slower in aggregate during busy periods (e.g. a mass-rebase event) since runs now queue sequentially instead of fanning out. A single slow/stuck run delays everything behind it, not just its own PR. This is deliberate — the goal is reducing concurrent load on flaky upstream government APIs, not maximising CI throughput.

## Test plan

- [x] YAML validated, pre-commit clean
- [ ] Confirm in the Actions tab that queued runs show as "Queued" (not started) while another PyTest run is in progress, and that they start automatically once the prior run completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)