### PR TITLE
ci: cancel stale PyTest runs on the same branch

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -17,6 +17,14 @@ concurrency:
 jobs:
     build:
         runs-on: ubuntu-latest
+        # A newer push to the same branch/PR (e.g. a second auto-rebase before
+        # the first one even started, or two pushes to main in quick succession)
+        # cancels this branch's own older queued or in-progress run, instead of
+        # letting it sit in the global queue only to become a moot/stale result
+        # once it finally starts.
+        concurrency:
+            group: pytest-branch-${{ github.ref }}
+            cancel-in-progress: true
         strategy:
             max-parallel: 4
             matrix:


### PR DESCRIPTION
## Summary

After #1938 added a global `pytest-all` concurrency group to protect flaky upstream NISRA/NIAssembly endpoints from concurrent hammering, a different noise problem became visible: the auto-rebase workflow can push to ~10 open PR branches within seconds, queuing ~10 PyTest runs behind whatever's currently running. By the time those work through the global queue, a *later* merge to main triggers another rebase round, superseding the first batch's commits — but the already-queued runs for the old commits don't get cancelled (`cancel-in-progress: false` at the workflow level, by design, to protect upstream load). They just sit in the queue, eventually run, and produce a result nobody needed against code that's already gone.

- Adds a **job-level** concurrency group (`pytest-branch-${{ github.ref }}`, `cancel-in-progress: true`) alongside the existing **workflow-level** group (`pytest-all`, `cancel-in-progress: false`)
- These are independent, composable constraints: the workflow-level group still serializes runs *across different branches* (the upstream-load protection #1938 was for); the new job-level group cancels a *single branch's own* older queued/running job when a newer push to that same branch supersedes it
- Net effect: cross-branch serialization is preserved, but redundant same-branch queue churn (rebase-then-rebase-again, or two pushes to main in quick succession) gets cleaned up automatically instead of accumulating queued/cancelled noise

## Test plan

- [x] YAML validated, pre-commit clean
- [ ] Confirm in the Actions tab that a second push to the same branch while an earlier run for that branch is still queued shows the earlier one transition to "Cancelled" rather than running to completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)