### PR TITLE
fix(ci): scope pytest concurrency to workflow level, not job level

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -6,25 +6,24 @@ on:
     pull_request:
         branches: ["main"]
 
-# Only one PyTest run (across all branches/PRs) hits the live NISRA/NIAssembly
-# endpoints at a time, so a flaky upstream can't be hammered by a dozen
-# concurrent matrix jobs at once (e.g. after a mass PR-rebase). Runs queue
-# rather than cancel, so a slow run delays but doesn't drop later ones.
+# A newer push to the same branch/PR (e.g. a second auto-rebase before the
+# first one even started, or two pushes to main in quick succession) cancels
+# the whole PREVIOUS WORKFLOW RUN for that branch, instead of letting it run
+# to completion against a commit that's already been superseded.
+#
+# This is workflow-level (not job-level): a job-level group keyed by ref
+# would apply per matrix leg too, so each Python-version job would cancel
+# its sibling legs within the same run as they started — only the
+# last-starting leg would ever finish. Keeping this at the workflow level
+# means cancellation only ever targets a different (older) run, never a
+# sibling job in the same run, so all matrix legs run independently.
 concurrency:
-    group: pytest-all
-    cancel-in-progress: false
+    group: pytest-${{ github.ref }}
+    cancel-in-progress: true
 
 jobs:
     build:
         runs-on: ubuntu-latest
-        # A newer push to the same branch/PR (e.g. a second auto-rebase before
-        # the first one even started, or two pushes to main in quick succession)
-        # cancels this branch's own older queued or in-progress run, instead of
-        # letting it sit in the global queue only to become a moot/stale result
-        # once it finally starts.
-        concurrency:
-            group: pytest-branch-${{ github.ref }}
-            cancel-in-progress: true
         strategy:
             max-parallel: 4
             matrix:


### PR DESCRIPTION
## Summary

#1939's job-level concurrency group broke the PyTest matrix: only 1 of 4 Python-version legs ever completed per run.

**Root cause** (confirmed on [run 28291018197](https://github.com/andrewbolster/bolster/actions/runs/28291018197)): the job-level group `pytest-branch-${{ github.ref }}` didn't include `matrix.python-version` in its key, so every matrix leg in a single run computed the *same* group. With `cancel-in-progress: true`, each newly-started leg cancelled whichever sibling leg was already running/queued under that identical key — `3.10`, `3.11`, `3.12` all started and were cancelled at the same instant `3.13` started, leaving only the last leg to ever finish.

**Fix**: move the concurrency group to the **workflow level** (`concurrency:` at the top, not nested under `jobs.build`), still keyed by `${{ github.ref }}` with `cancel-in-progress: true`. At the workflow level, cancellation only ever targets a *different, older run* for the same ref — it can never target a sibling job within the same run, so all 4 matrix legs execute independently as intended.

**Tradeoff vs #1938's original goal**: GitHub Actions concurrency only supports one effective group per workflow, so this drops #1938's separate global `pytest-all` cross-branch serialization (which was protecting flaky upstream NISRA/NIAssembly endpoints from concurrent multi-branch load). Per discussion with the user: correctness (all matrix legs actually running) takes priority over that cross-branch protection. A newer push to the *same* branch still cleanly cancels that branch's stale run.

Closes the regression introduced by #1939.

## Test plan

- [x] YAML validated, pre-commit clean
- [ ] Confirm on the next run that all 4 matrix legs (3.10/3.11/3.12/3.13) start and run independently to completion
- [ ] Confirm a second push to the same branch while an earlier run is still in progress cancels that *whole run* cleanly (not just one leg)

🤖 Generated with [Claude Code](https://claude.com/claude-code)