### PR TITLE
revert(ci): back to single global pytest-all concurrency group

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -6,20 +6,13 @@ on:
     pull_request:
         branches: ["main"]
 
-# A newer push to the same branch/PR (e.g. a second auto-rebase before the
-# first one even started, or two pushes to main in quick succession) cancels
-# the whole PREVIOUS WORKFLOW RUN for that branch, instead of letting it run
-# to completion against a commit that's already been superseded.
-#
-# This is workflow-level (not job-level): a job-level group keyed by ref
-# would apply per matrix leg too, so each Python-version job would cancel
-# its sibling legs within the same run as they started — only the
-# last-starting leg would ever finish. Keeping this at the workflow level
-# means cancellation only ever targets a different (older) run, never a
-# sibling job in the same run, so all matrix legs run independently.
+# Only one PyTest run (across all branches/PRs) hits the live NISRA/NIAssembly
+# endpoints at a time, so a flaky upstream can't be hammered by a dozen
+# concurrent matrix jobs at once (e.g. after a mass PR-rebase). Runs queue
+# rather than cancel, so a slow run delays but doesn't drop later ones.
 concurrency:
-    group: pytest-${{ github.ref }}
-    cancel-in-progress: true
+    group: pytest-all
+    cancel-in-progress: false
 
 jobs:
     build:


### PR DESCRIPTION
## Summary

#1939 added same-branch staleness cancellation on top of #1938's global cross-branch serialization, then #1940 fixed a matrix-leg-cancellation bug that introduced — but the net effect across both changes was worse than the original noise problem: PRs are now seeing their entire CI run repeatedly cancelled and re-queued as the auto-rebase workflow and dependabot push updates, which is more confusing/noisy than occasionally running a stale-but-harmless queued test.

This reverts `pytest.yml`'s `concurrency` block to exactly #1938's original design:

```yaml
concurrency:
    group: pytest-all
    cancel-in-progress: false
```

- One global group across all branches/PRs — runs queue in order, protecting flaky upstream NISRA/NIAssembly endpoints from concurrent multi-branch load
- Nothing gets cancelled mid-flight — a run always completes, even if its result ends up being moot by the time it finishes
- No job-level or per-ref concurrency grouping at all

Net effect: goes back to the known-working behavior from earlier today, before #1939/#1940 tried to add staleness cancellation on top.

## Should this supersede #1939 and #1940?

Yes — recommend closing both without merging once this lands, since this PR fully reverts their net effect on `pytest.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)