### PR TITLE
fix(metoffice): add explicit timeout to session.get() calls

### DIFF
--- a/src/bolster/data_sources/metoffice.py
+++ b/src/bolster/data_sources/metoffice.py
@@ -57,7 +57,7 @@ def get_order_latest(order_name: str) -> dict:
     """Get the latest status for a Met Office data order."""
     url = f"{BASE_URL}/orders/{order_name.lower()}/latest"  # pragma: no cover
     # TODO: Network integration testing - requires valid Met Office API key and order
-    response = session.get(url, headers=_api_headers)  # pragma: no cover
+    response = session.get(url, headers=_api_headers, timeout=30)  # pragma: no cover
     if response.status_code == 200:  # pragma: no cover
         return response.json()  # pragma: no cover
     # pragma: no cover
@@ -70,7 +70,7 @@ def get_file_meta(order_name: str, file_id: str) -> dict:
     """Get metadata for a specific file in a Met Office order."""
     url = f"{BASE_URL}/orders/{order_name.lower()}/latest/{quote(file_id)}"  # To handle + in the file_id  # pragma: no cover
     # TODO: Network integration testing - requires valid Met Office API key and order
-    response = session.get(url, headers=_api_headers)  # pragma: no cover
+    response = session.get(url, headers=_api_headers, timeout=30)  # pragma: no cover
     if response.status_code == 200:  # pragma: no cover
         return response.json()  # pragma: no cover
     # pragma: no cover
@@ -84,7 +84,9 @@ def get_file(order_name: str, file_id: str) -> bytes:
     """Download and cache a file from a Met Office order."""
     url = f"{BASE_URL}/orders/{order_name.lower()}/latest/{quote(file_id)}/data"  # To handle + in the file_id  # pragma: no cover
     # TODO: Network integration testing - requires valid Met Office API key and order
-    response = session.get(url, headers={**_api_headers, **{"Accept": "application/octet-stream"}})  # pragma: no cover
+    response = session.get(
+        url, headers={**_api_headers, **{"Accept": "application/octet-stream"}}, timeout=30
+    )  # pragma: no cover
     if response.status_code == 200:  # pragma: no cover
         return response.content  # pragma: no cover
     # pragma: no cover


### PR DESCRIPTION
## Summary

Spotted in [run 28291994908](https://github.com/andrewbolster/bolster/actions/runs/28291994908/job/83825782228): a single test stalled for ~9 minutes between retries against `data.hub.api.metoffice.gov.uk`.

**Root cause**: `get_order_latest`, `get_file_meta`, and `get_file` in `metoffice.py` call `session.get()` without an explicit `timeout=`, so a connect-level failure has no bound — each retry attempt can hang indefinitely (well past the ~14s worst-case other modules get from `timeout=30` + the retry adapter's backoff). `tests/test_cli.py::test_get_precipitation_valid_bounding_box_parsing` uses a fake API key/order and expects the live call to fail quickly once past the CLI's own validation — but with no timeout, "fail quickly" became "hang for minutes" whenever the upstream API is slow/unreachable.

**Fix**: add `timeout=30` to all three `session.get()` calls, matching the convention already used elsewhere (`nisra/_base.py`, `nisra/ashe.py`, etc.).

## Test plan

- [x] `uv run pytest tests/test_metoffice.py tests/test_cli.py -q --no-cov` — 66 passed
- [x] `uv run pre-commit run --files src/bolster/data_sources/metoffice.py` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)