### PR TITLE
fix(rebase): skip PRs with a pending PyTest run already queued

### DIFF
--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -44,6 +44,18 @@ jobs:
                     --jq '.[] | select(.mergeStateStatus != "CLEAN") | [.number, .headRefName] | @tsv' | \
                   while IFS=$'\t' read -r pr branch; do
                     echo "----------------------------------------"
+
+                    # Skip if this branch already has a PyTest run queued/in-progress:
+                    # pushing now would just supersede that run before it gets a turn
+                    # in the global concurrency queue, restarting the wait from zero
+                    # instead of letting it finish.
+                    pending=$(gh run list --workflow=pytest.yml --branch "$branch" --limit 1 \
+                      --json status --jq '.[0].status // ""')
+                    if [ "$pending" = "queued" ] || [ "$pending" = "in_progress" ]; then
+                      echo "⏳ PR #$pr ($branch) already has a $pending PyTest run — skipping this cycle"
+                      continue
+                    fi
+
                     echo "Updating PR #$pr ($branch) with latest main..."
 
                     git fetch origin "$branch" || { echo "✗ Could not fetch $branch (fork?)"; continue; }


### PR DESCRIPTION
## Summary

PRs #1937 (joserfc bump) and #1913 (pydantic-settings bump) have been sitting `MERGEABLE` but unable to merge for hours, despite every check passing except the PyTest matrix — which never even ran. Root cause:

1. `rebase.yml` triggers on every push to `main`, and unconditionally force-pushes `main` into every open, non-`CLEAN` PR.
2. The PyTest workflow uses a single global `pytest-all` concurrency group (#1938/#1941) — only one run across all branches executes at a time; others queue.
3. When a PR's queued run is still waiting for its turn and another commit lands on `main` in the meantime, the next rebase cycle pushes a new commit to that same PR branch — which supersedes (cancels) the still-queued run before it ever starts, via GitHub's built-in same-ref cancellation for `pull_request`-triggered workflows.
4. This repeats every time anything merges to `main`. Confirmed via the Actions history: #1937 and #1913 each had **3 separate PyTest runs today, every single one cancelled before any job started**, because each rebase cycle reset them before their previous queued run got a turn.

## Fix

Before pushing `main` into a branch, check whether that branch already has a `queued` or `in_progress` PyTest run:

```bash
pending=$(gh run list --workflow=pytest.yml --branch "$branch" --limit 1 --json status --jq '.[0].status // ""')
if [ "$pending" = "queued" ] || [ "$pending" = "in_progress" ]; then
  echo "⏳ PR #$pr ($branch) already has a $pending PyTest run — skipping this cycle"
  continue
fi
```

If so, skip that branch this cycle — let the existing run finish (pass or fail) before resetting it again. The branch will get rebased on the next cycle once its current run has resolved.

## Test plan

- [x] YAML validated, pre-commit clean
- [x] Bash syntax validated (`bash -n`)
- [ ] Confirm on the next few `main` merges that #1937/#1913 (or whichever PRs are mid-queue at the time) stop getting reset and eventually get a completed PyTest run

🤖 Generated with [Claude Code](https://claude.com/claude-code)