### PR TITLE
feat(cache): report file-download cache hit/miss counts after tests

### DIFF
--- a/src/bolster/utils/cache.py
+++ b/src/bolster/utils/cache.py
@@ -29,6 +29,12 @@ logger = logging.getLogger(__name__)
 # Base cache directory
 CACHE_BASE = Path.home() / ".cache" / "bolster"
 
+# Process-wide hit/miss counters, surfaced in the pytest terminal summary
+# (see tests/conftest.py) since CachedDownloader's own INFO-level logging
+# is filtered out by pytest's log_cli_level=WARNING in CI.
+hits = 0
+misses = 0
+
 
 class CacheError(Exception):
     """Base exception for cache operations."""
@@ -104,10 +110,12 @@ class CachedDownloader:
         ext = Path(url).suffix or ".bin"
         cache_path = self.cache_dir / f"{url_hash}{ext}"
 
+        global hits
         if cache_path.exists():
             age = datetime.now() - datetime.fromtimestamp(cache_path.stat().st_mtime)
             if age.total_seconds() < cache_ttl_hours * 3600:
                 logger.info(f"Using cached file: {cache_path}")
+                hits += 1
                 return cache_path
 
         return None
@@ -144,6 +152,8 @@ class CachedDownloader:
                 return cached
 
         # Download the file
+        global misses
+        misses += 1
         url_hash = hash_url(url)
         ext = Path(url).suffix or ".bin"
         cache_path = self.cache_dir / f"{url_hash}{ext}"

--- a/src/bolster/utils/cache.py
+++ b/src/bolster/utils/cache.py
@@ -94,6 +94,13 @@ class CachedDownloader:
         self.namespace = namespace
         self.timeout = timeout
         self.cache_dir = CACHE_BASE / namespace
+        if not self.cache_dir.exists():
+            logger.warning(
+                f"Cache directory {self.cache_dir} did not exist — creating it fresh. "
+                "If this is CI, a restored cache (e.g. actions/cache) should have already "
+                "created this directory; a fresh create here likely means the cache "
+                "missed or restored to an unexpected path."
+            )
         self.cache_dir.mkdir(parents=True, exist_ok=True)
 
     def get_cached_file(self, url: str, cache_ttl_hours: int = 24) -> Path | None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,12 +32,20 @@ def pytest_configure(config):
 
 
 def pytest_terminal_summary(terminalreporter, exitstatus, config):
-    """Report page cache size at end of test session."""
+    """Report page cache size and CachedDownloader hit/miss counts at end of test session."""
     cache_dir = Path.home() / ".cache" / "bolster" / "_pages"
     if cache_dir.exists():
         files = list(cache_dir.glob("*.html"))
         total_bytes = sum(f.stat().st_size for f in files)
         terminalreporter.write_sep("-", f"page cache: {len(files)} entries, {total_bytes / 1024:.1f} KB ({cache_dir})")
+
+    from bolster.utils import cache as _cache
+
+    total = _cache.hits + _cache.misses
+    rate = f"{_cache.hits / total:.0%}" if total else "n/a"
+    terminalreporter.write_sep(
+        "-", f"file download cache: {_cache.hits} hits, {_cache.misses} misses ({rate} hit rate)"
+    )
 
 
 def pytest_collection_modifyitems(config, items):


### PR DESCRIPTION
## Summary

Couldn't answer "is the GHA download cache (#1936) actually being used during the test run, or just successfully restored and then ignored?" from CI logs — `CachedDownloader`'s hit/miss log lines (`"Using cached file"`, `"Downloading {url}"`) are `INFO`-level, and `pyproject.toml` sets `log_cli_level = "WARNING"`, so they're filtered out of every pytest run's live output regardless of whether the cache is helping.

- Adds two process-wide counters (`hits`, `misses`) to `bolster.utils.cache`, incremented in `get_cached_file()` and `download()` respectively
- Surfaces them in the existing `pytest_terminal_summary` hook in `tests/conftest.py` (right next to the page-cache size line that's already there), e.g.:
  ```
  --- page cache: 21 entries, 884.9 KB (...) ---
  --- file download cache: 25 hits, 0 misses (100% hit rate) ---
  ```

## Verification

Ran locally against `tests/test_nisra_ashe_integrity.py`:
- Warm cache: **25 hits, 0 misses (100%)**
- After `rm -rf ~/.cache/bolster/nisra`: **23 hits, 2 misses (92%)** — exactly 2 misses, one per distinct file URL ASHE downloads, with the rest of the same session's tests immediately hitting the newly-repopulated cache

This is now hard, numeric evidence (not timing inference) for whether the GHA cache is doing real work on any given CI run — should show near-100% hit rates once the daily cache is warm.

## Test plan

- [x] Verified hit/miss counts behave correctly on both warm and cold cache locally
- [x] `uv run pre-commit run --files src/bolster/utils/cache.py tests/conftest.py` — clean
- [x] `uv run pytest --doctest-modules src/bolster/utils/cache.py` — 3 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)