### PR TITLE
revert(ci): remove global pytest-all concurrency group

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -6,14 +6,6 @@ on:
     pull_request:
         branches: ["main"]
 
-# Only one PyTest run (across all branches/PRs) hits the live NISRA/NIAssembly
-# endpoints at a time, so a flaky upstream can't be hammered by a dozen
-# concurrent matrix jobs at once (e.g. after a mass PR-rebase). Runs queue
-# rather than cancel, so a slow run delays but doesn't drop later ones.
-concurrency:
-    group: pytest-all
-    cancel-in-progress: false
-
 jobs:
     build:
         runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Removes the `concurrency: { group: pytest-all, cancel-in-progress: false }` block from `pytest.yml` entirely.

**Why this is safe now**: that block existed to stop many concurrent branches from cold-hammering flaky upstream NISRA/NIAssembly endpoints simultaneously. #1936/#1945 added a GitHub Actions download cache for `~/.cache/bolster`, confirmed today via real CI debug output and the new file-download-cache hit/miss summary: **135 hits, 5 misses (96% hit rate)** on a real run. With most file downloads served from cache regardless of how many branches are testing at once, the original justification for a single global queue is much weaker.

**Side benefit**: the global queue was also compounding with the auto-rebase workflow to occasionally starve PRs of ever completing a PyTest run (#1937, #1913 each got reset 3 times today before #1943 fixed the rebase-side trigger). Removing the queue removes this failure mode entirely, on top of #1943's fix.

Every branch/PR's PyTest run now fires and runs independently and immediately on push, with no cross-branch throttling.

## Test plan

- [x] YAML validated, pre-commit clean
- [ ] Confirm multiple branches can run PyTest concurrently without queueing
- [ ] Watch the next few days for any return of upstream 503/timeout cascades; if they reappear despite the cache, revisit throttling (e.g. splitting branches into 2 alternating concurrency groups for partial throttling)

🤖 Generated with [Claude Code](https://claude.com/claude-code)