### PR TITLE
ci(pytest): scope concurrency group per-ref instead of global

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -6,25 +6,14 @@ on:
     pull_request:
         branches: ["main"]
 
-# Only one PyTest run (across all branches/PRs) hits the live NISRA/
-# NIAssembly/etc endpoints at a time. Removed in #1946 on the theory that
-# the download cache made cross-branch throttling unnecessary, but on
-# 2026-06-28 removing it let 7 branches' full matrices (~28 jobs) fire
-# within 28 seconds of each other, and every one of them timed out against
-# data.niassembly.gov.uk — a server that degrades under concurrent load
-# rather than rate-limiting (no HTTP 429s observed) looks exactly like
-# this. Runs queue rather than cancel, so a slow run delays but doesn't
-# drop later ones.
-#
-# `queue: max` (GHA, 2026-05) lets pending runs actually wait their turn
-# instead of GitHub's default behaviour of cancelling a still-pending run
-# the moment a newer one is queued for the same group. Without it, the
-# rebase.yml bot re-pushing a branch while its run was still queued behind
-# this lane silently invalidated that run before it ever started — observed
-# repeatedly on 2026-06-28 as a starvation loop on several branches.
+# Per-ref group + queue: max: each ref gets its own FIFO queue, so a new
+# commit on a PR cancels that PR's own stale run (cancel-in-progress: true)
+# without GitHub's cross-ref "higher priority waiting request" eviction
+# wiping out unrelated branches' queued runs. See PR description for the
+# 2026-06-28 incident history that led here.
 concurrency:
-    group: pytest-all
-    cancel-in-progress: false
+    group: pytest-${{ github.ref }}
+    cancel-in-progress: true
     queue: max
 
 jobs:


### PR DESCRIPTION
## Summary

Scopes the PyTest workflow's `concurrency:` group per-ref (`pytest-${{ github.ref }}`) instead of one global `pytest-all` group shared across every branch/PR.

## Why

`pytest-all` was introduced (#1948, restored after #1935 today) to stop multiple branches' full test matrices firing concurrently against flaky upstream APIs (NISRA, NI Assembly) — confirmed root cause of CI timeouts when 7 branches fired within 28 seconds of each other on 2026-06-28.

`queue: max` (GHA, 2026-05) was then added in #1935 to fix queued runs being silently cancelled rather than waiting their turn. It didn't fully fix it: GitHub's concurrency groups have a separate, pre-existing platform behaviour — a fresh push to the same ref makes its own previous queued/in-progress run for that group "lower priority" and cancels it on the spot (`"Canceling since a higher priority waiting request for pytest-all exists"`), independent of `queue: max`. This bit `#1935` itself today: a run that had been waiting ~29 minutes for its turn in the shared `pytest-all` queue was wiped out within a minute of an unrelated auto-rebase commit landing on the same PR — zero jobs ever dispatched, twice in a row.

`queue: max` only orders *distinct refs'* entries relative to each other; it doesn't protect a ref's own queued run from being preempted by its own next commit. The two problems need two different mechanisms:
- same-ref preemption → `cancel-in-progress: true` (a stale run for an old commit on a PR really should be cancelled, instantly, not stuck in limbo)
- cross-ref throttling → was `pytest-all` + `queue: max`

Scoping the group per-ref (`pytest-${{ github.ref }}`) makes same-ref preemption immediate and correct. The tradeoff: it removes the cross-ref throttle entirely — unrelated PRs are no longer forced to queue behind each other, so multiple branches' matrices *can* run concurrently against NISRA/NIAssembly again, same as before #1948. Given today's volume (7 PRs/branches all needing fixes within one afternoon) was itself unusually high, and the underlying page-cache/HEAD-cache fixes from #1948 already reduce repeat-hit cost significantly, this trades a return of some cross-branch contention risk for eliminating the much more disruptive same-ref starvation loop. If cross-branch saturation reappears as the dominant problem, a combined two-tier approach (workflow-level shared group + job-level per-ref group, confirmed as a supported pattern) is the next step — not implemented here to keep this change minimal and reviewable.

## Test plan

- [x] `uv run pre-commit run --files .github/workflows/pytest.yml` — clean (yaml check, formatting)
- [ ] CI on this PR — confirm its own run isn't preempted by anything (nothing else should share its ref)
- [ ] Manual observation post-merge: next time `rebase.yml` pushes a fresh commit to an open PR while its previous run is still queued, confirm the old run is cancelled immediately (not after a multi-minute wait) and the new commit's run proceeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)
