### PR TITLE
fix(ni_water): use session retry/caching for CSV fetch instead of bypassing via pandas read_csv(url)

### DIFF
--- a/src/bolster/data_sources/ni_water.py
+++ b/src/bolster/data_sources/ni_water.py
@@ -27,6 +27,7 @@ with support for both current quality data and historical zone mapping.
 
 import csv
 import logging
+from io import StringIO
 from urllib.error import HTTPError
 
 import pandas as pd
@@ -83,9 +84,9 @@ def get_water_quality_csv_data() -> pd.DataFrame:
 
     logger.info(f"Downloading water quality data from {WATER_QUALITY_CSV_URL}")
 
-    with session.get(WATER_QUALITY_CSV_URL, stream=True) as r:
+    with session.get(WATER_QUALITY_CSV_URL, timeout=30) as r:
         r.raise_for_status()
-        _water_quality_cache = pd.read_csv(r.url)
+        _water_quality_cache = pd.read_csv(StringIO(r.text))
 
         if _water_quality_cache.empty:
             raise RuntimeError("No water quality data found in CSV")


### PR DESCRIPTION
## Summary

Fixes #1952 — `get_water_quality_csv_data()` was passing `r.url` (a URL string) to `pd.read_csv()` instead of the fetched response body. `pandas.read_csv` treats a string argument as a path/URL and performs its **own** independent HTTP fetch via fsspec's `HTTPFileSystem`, completely bypassing `session` (`bolster.utils.web`'s `CachingSession`, which has retry-on-503/502/etc and page caching). The original `session.get()` call only ever validated the URL; its response body was discarded, and the actual CSV data was refetched a second time, unprotected by any retry logic.

This caused an intermittent CI failure: `ValueError: Invalid file path or buffer object type: <class 'NoneType'>` across ~10 tests, on a run where the exact same tests had passed on `main` 32 minutes earlier and pass consistently when run locally — confirming this was pandas' own unprotected second fetch hitting a transient blip, not a real data/logic regression.

## Why this fix, not session-injection into pandas

Investigated whether pandas readers can accept a custom session directly instead of pre-fetching into a buffer: they can't. `storage_options` is for fsspec backend auth config (e.g. S3 credentials), not session objects, and fsspec's `HTTPFileSystem` doesn't accept a pre-configured `requests.Session` either. Wrapping the already-fetched body in `StringIO`/`BytesIO` is the correct and only practical approach — and it's already the established convention in this codebase:
- `gender_pay_gap.py:214` — `pd.read_csv(StringIO(response.text))`
- `nisra/child_protection.py` (5 call sites) — `pd.read_excel(BytesIO(content))`
- `boe_base_rate.py:170` — `pd.ExcelFile(io.BytesIO(response.content))`

A repo-wide grep confirmed `ni_water.py` was the only file with this bug.

## Side benefit

Switching from `stream=True` (body discarded) to a normally-consumed `session.get()` call means this URL now flows through `CachingSession`'s existing page cache automatically (1hr TTL on `text/*` responses) — confirmed locally: a cache file now appears under `~/.cache/bolster/_pages/` after running the tests, which never happened before this fix.

## Test plan

- [x] `uv run pytest tests/test_ni_water.py tests/test_ni_water_integration.py -q --no-cov` — 25 passed
- [x] `uv run pre-commit run --files src/bolster/data_sources/ni_water.py` — clean
- [x] Confirmed page cache entry created for the CSV URL after running tests (previously never cached)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
