### PR TITLE
fix(web): add retry jitter and cache application/json + rss+xml responses

### DIFF
--- a/src/bolster/utils/web.py
+++ b/src/bolster/utils/web.py
@@ -3,7 +3,7 @@
 Provides a pre-configured :class:`requests.Session` (``session``) with:
 
 - Automatic retry on transient server errors (500/502/503/504)
-- Rate-limit awareness: exponential backoff on 429 responses, capped at 60 s
+- Exponential backoff with jitter: 0s, 2–7s, 4–9s, 8–13s (~29s worst case)
 - A consistent ``User-Agent`` header for polite scraping
 - Helpers for downloading Excel files and ZIP archives in memory
 
@@ -68,10 +68,13 @@ class RateLimitAwareRetry(Retry):
 
 # Configure retry strategy for transient failures
 # Retries on: connection errors, 429, 500, 502, 503, 504 status codes
-# urllib3 default backoff: 0s, 2s, 4s, 8s (factor=1) — ~14s worst case
+# Backoff: exponential (factor=1) plus up to 5s jitter per attempt so
+# parallel CI matrix legs don't retry in lockstep against the same
+# throttled endpoint. Resulting waits: 0s, 2–7s, 4–9s, 8–13s (~29s worst).
 _retry_strategy = RateLimitAwareRetry(
     total=4,
     backoff_factor=1,
+    backoff_jitter=5.0,
     status_forcelist=[429, 500, 502, 503, 504],
     allowed_methods=["HEAD", "GET", "OPTIONS"],
     raise_on_status=True,
@@ -84,9 +87,10 @@ class CachingSession(requests.Session):
     """requests.Session that caches GET and HEAD responses to disk with a TTL.
 
     GET: only caches *un-parametered* requests (no ``params=`` kwarg) whose
-    Content-Type starts with "text/" (HTML, XML, plain text, etc.) — binary
-    downloads (Excel, ZIP, etc.) bypass the cache and should go through
-    CachedDownloader instead. Calls passing ``params=`` are never cached:
+    Content-Type is a text-like format — specifically anything starting with
+    "text/" (HTML, XML, plain text) or "application/json" or
+    "application/rss+xml". Binary downloads (Excel, ZIP, etc.) bypass the
+    cache and should go through CachedDownloader instead. Calls passing ``params=`` are never cached:
     the cache key is derived from the base URL only, so caching a
     parametered request risks silently serving a different request's
     response for the same cache slot (e.g. ``?personId=1`` vs
@@ -142,10 +146,15 @@ class CachingSession(requests.Session):
         response = super().get(url, **kwargs)
 
         content_type = response.headers.get("Content-Type", "")
+        _cacheable = (
+            content_type.startswith("text/")
+            or content_type.startswith("application/json")
+            or content_type.startswith("application/rss+xml")
+        )
         if response.status_code == 404:
             cache_404_path.write_bytes(b"")
             logger.debug(f"Page 404 cached: {url}")
-        elif response.ok and content_type.startswith("text/"):
+        elif response.ok and _cacheable:
             cache_path.write_bytes(response.content)
             logger.debug(f"Page cached: {url}")
 


### PR DESCRIPTION
## Summary

Two fixes to `bolster.utils.web`'s retry and caching behaviour, both targeting the persistent NI Assembly / NISRA 503 flakiness in CI:

### 1. Retry jitter (`backoff_jitter=5.0`)

Previously: plain exponential backoff `0s → 2s → 4s → 8s` (deterministic, no jitter). When multiple CI matrix legs (3.11/3.12/3.13) all hit a throttled endpoint and start retrying, they retry in *lockstep* — all piling back onto the server simultaneously at 2s, 4s, 8s, amplifying the load rather than spreading it.

With `backoff_jitter=5.0`: each wait gets an additional `random.random() * 5.0` seconds added (per urllib3's own `get_backoff_time` implementation — additional, not replacing). Resulting waits: `0s, 2–7s, 4–9s, 8–13s` (~29s worst case). Parallel legs now desynchronise across a 5-second window on each retry, reducing the chance they all hit the same throttled server at the same moment.

Also corrects the module docstring which claimed "capped at 60s" and "extended backoff on 429" — neither was actually implemented. The `RateLimitAwareRetry.increment` override only logged 429s, then applied identical backoff to any other error.

### 2. Cache `application/json` and `application/rss+xml`

`CachingSession.get()` previously only cached `Content-Type: text/*` responses. The NI Assembly JSON API (`data.niassembly.gov.uk`) returns `application/json; charset=utf-8`, and the NISRA RSS feed returns `application/rss+xml; charset=utf-8` — neither was being cached, so every un-parametered call to these endpoints fetched live regardless of how recently it had been called within the same run or across runs on the same day.

Confirmed locally: `GetAllCurrentMembers_JSON` now writes to `~/.cache/bolster/_pages/` on first call and is served from cache on subsequent calls within the 1hr TTL.

Note: parametered requests (e.g. `GetQuestionsByDepartment_JSON?departmentId=82`) are still explicitly excluded from caching — the correct behaviour introduced in #1948, since the cache key is derived from the base URL only and caching a parametered response would silently serve wrong data for different parameter values. This PR doesn't change that behaviour.

## Test plan

- [x] `uv run pre-commit run --files src/bolster/utils/web.py` — clean
- [x] `_retry_strategy.backoff_jitter == 5.0` confirmed in Python REPL
- [x] NI Assembly JSON endpoint now populates page cache on first call (confirmed via `~/.cache/bolster/_pages/` file creation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
