### PR TITLE
fix(dva): handle sheet name format change and datetime date values

### DIFF
--- a/src/bolster/data_sources/dva.py
+++ b/src/bolster/data_sources/dva.py
@@ -210,16 +210,21 @@ def get_latest_dva_publication_url() -> tuple[str, str, datetime]:
     raise DVADataNotFoundError("Could not find any DVA monthly tests publications in the last 6 months")
 
 
-def _parse_month_year(date_str: str) -> datetime | None:
-    """Parse a 'YYYY Month' string into a datetime.
+def _parse_month_year(date_str: str | datetime) -> datetime | None:
+    """Parse a date value into a datetime.
 
     Args:
-        date_str: String like '2024 December' or '2025 January'
+        date_str: String like '2024 December', or a datetime object (openpyxl
+            returns datetime directly from newer DVA Excel files)
 
     Returns:
         datetime object or None if parsing fails
     """
-    if not date_str or not isinstance(date_str, str):
+    if not date_str:
+        return None
+    if isinstance(date_str, datetime):
+        return date_str.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+    if not isinstance(date_str, str):
         return None
 
     date_str = date_str.strip()
@@ -285,7 +290,7 @@ def parse_vehicle_tests(file_path: str | Path) -> pd.DataFrame:
     # Find the vehicle tests sheet
     sheet_name = None
     for name in wb.sheetnames:
-        if "1_1a" in name and "Veh" in name:
+        if ("1_1a" in name or "1.1a" in name) and "Veh" in name:
             sheet_name = name
             break
 
@@ -304,7 +309,7 @@ def parse_vehicle_tests(file_path: str | Path) -> pd.DataFrame:
         if not date_str or not tests:
             continue
 
-        date = _parse_month_year(str(date_str))
+        date = _parse_month_year(date_str)
         if not date:
             continue
 
@@ -369,7 +374,7 @@ def parse_driver_tests(file_path: str | Path) -> pd.DataFrame:
     # Find the driver tests sheet
     sheet_name = None
     for name in wb.sheetnames:
-        if "2_1" in name and "Driver" in name:
+        if ("2_1" in name or "2.1" in name) and "Driver" in name:
             sheet_name = name
             break
 
@@ -388,7 +393,7 @@ def parse_driver_tests(file_path: str | Path) -> pd.DataFrame:
         if not date_str or not tests:
             continue
 
-        date = _parse_month_year(str(date_str))
+        date = _parse_month_year(date_str)
         if not date:
             continue
 
@@ -453,7 +458,7 @@ def parse_theory_tests(file_path: str | Path) -> pd.DataFrame:
     # Find the theory tests sheet
     sheet_name = None
     for name in wb.sheetnames:
-        if "3_1" in name and "Theory" in name:
+        if ("3_1" in name or "3.1" in name) and "Theory" in name:
             sheet_name = name
             break
 
@@ -472,7 +477,7 @@ def parse_theory_tests(file_path: str | Path) -> pd.DataFrame:
         if not date_str or not tests:
             continue
 
-        date = _parse_month_year(str(date_str))
+        date = _parse_month_year(date_str)
         if not date:
             continue
 


### PR DESCRIPTION
## Summary

DVA Excel published June 2026 changed two things simultaneously, breaking both `TestGetLatestAllTests` tests on all Python versions. This caused the two open dependabot PRs (#1971, #1973) to show as failing even though the dependency bumps themselves are unrelated.

### Changes

**Sheet name format**: notation changed from underscores (`1_1a Veh...`) to dots (`1.1a Veh...`). Updated all three sheet matchers to accept either separator.

**Date cell type**: date cells now return `datetime` objects directly rather than `'YYYY Month'` strings. `_parse_month_year` previously guarded `isinstance(date_str, str)` and returned `None` for anything else, so every data row was silently skipped, producing an empty DataFrame and raising `DVADataError`. Fixed by:
- Broadening `_parse_month_year` to accept `datetime | str` — returns the datetime directly (normalised to midnight, day 1) when given a datetime
- Removing the `str()` coercion at all three call sites, which was discarding the type

## Test results

`1878 passed, 7 skipped, 0 failed` locally across the full suite.

Unblocks #1971 and #1973.