### PR TITLE
ci: serialize matrix jobs to warm download cache sequentially

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -14,7 +14,7 @@ jobs:
     build:
         runs-on: ubuntu-latest
         strategy:
-            max-parallel: 3
+            max-parallel: 1
             matrix:
                 python-version: ["3.11", "3.12", "3.13"]
 


### PR DESCRIPTION
## Summary

- `max-parallel: 3 → 1` in the pytest matrix strategy

GitHub Actions restores the download cache at the start of each job and saves it at the end. With parallel jobs all three legs start simultaneously and cannot restore from each other within the same run — each job fetches from the network independently, which causes flaky 503s when upstream (NISRA etc.) rate-limits concurrent requests.

Serialising to `max-parallel: 1` means Python 3.11 runs first, warms the cache, and 3.12 and 3.13 each restore from it in turn.

> **Note**: this adds ~5–10 min of wall-clock time per CI run (jobs queue instead of running in parallel), which is an acceptable trade-off for reliability.

[skip ci]