### PR TITLE
docs: rewrite CONTRIBUTING.rst to reflect actual workflow

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -7,8 +7,6 @@ Contributing
 Contributions are welcome, and they are greatly appreciated! Every little bit
 helps, and credit will always be given.
 
-You can contribute in many ways:
-
 Types of Contributions
 ----------------------
 
@@ -17,7 +15,7 @@ Report Bugs
 
 Report bugs at https://github.com/andrewbolster/bolster/issues.
 
-If you are reporting a bug, please include:
+Please include:
 
 * Your operating system name and version.
 * Any details about your local setup that might be helpful in troubleshooting.
@@ -26,107 +24,150 @@ If you are reporting a bug, please include:
 Fix Bugs
 ~~~~~~~~
 
-Look through the GitHub issues for bugs. Anything tagged with "bug" and "help
-wanted" is open to whoever wants to implement it.
+Look through the GitHub issues for bugs. Anything tagged with ``bug`` and
+``help wanted`` is open to whoever wants to implement it.
+
+Add Data Sources
+~~~~~~~~~~~~~~~~
+
+The most common contribution is a new data source module. Open issues labelled
+``data-source-candidate`` are evaluated and waiting to be built. See
+`Data Source Development`_ below for the full workflow.
 
 Implement Features
 ~~~~~~~~~~~~~~~~~~
 
-Look through the GitHub issues for features. Anything tagged with "enhancement"
-and "help wanted" is open to whoever wants to implement it.
+Look through the GitHub issues for features tagged ``enhancement`` and
+``help wanted``.
 
 Write Documentation
 ~~~~~~~~~~~~~~~~~~~
 
-Bolster could always use more documentation, whether as part of the
-official Bolster docs, in docstrings, or even on the web in blog posts,
-articles, and such.
+Bolster can always use more documentation — docstrings, RST pages, or blog
+posts. The ``docs/`` directory uses Sphinx.
 
 Submit Feedback
 ~~~~~~~~~~~~~~~
 
-The best way to send feedback is to file an issue at https://github.com/andrewbolster/bolster/issues.
-
-If you are proposing a feature:
-
-* Explain in detail how it would work.
-* Keep the scope as narrow as possible, to make it easier to implement.
-* Remember that this is a volunteer-driven project, and that contributions
-  are welcome :)
+File an issue at https://github.com/andrewbolster/bolster/issues.
 
 Get Started!
 ------------
 
-Ready to contribute? Here's how to set up `bolster` for local development.
+Ready to contribute? Here's how to set up ``bolster`` for local development.
 
-1. Fork the `bolster` repo on GitHub.
-2. Clone your fork locally::
+1. Clone the repo directly (no fork needed — branch from ``main``)::
 
     $ git clone git@github.com:andrewbolster/bolster.git
-
-3. Install all dependencies (runtime + dev) using ``uv``::
-
     $ cd bolster
-    $ uv sync --all-extras
 
-4. Create a branch for local development::
+2. Install all dependencies (runtime + dev) using ``uv``::
 
-    $ git checkout -b fix/<name>   # or feat/<name>
+    $ uv sync --all-extras --dev
 
-   Now you can make your changes locally.
+3. Install pre-commit hooks::
 
-5. When you're done making changes, check that your changes pass linting and
-   tests::
+    $ uv run pre-commit install
+
+4. Create a branch::
+
+    $ git checkout -b feat/<name>   # new feature
+    $ git checkout -b fix/<name>    # bug fix
+
+5. Make your changes, then lint and test::
 
     $ uv run pre-commit run --all-files
-    $ uv run pytest tests/ -v
+    $ uv run pytest tests/ -q --no-cov        # quick local run
+    $ make test                               # full run with coverage
 
-6. Commit your changes and push your branch to GitHub::
+6. Push and open a pull request::
 
-    $ git add <changed-files>
-    $ git commit -m "Your detailed description of your changes."
-    $ git push -u origin fix/<name>
+    $ git push -u origin feat/<name>
+    $ gh pr create
 
-7. Open a pull request through the GitHub website and wait for CI to pass.
+   Wait for CI to go green before requesting a merge. **Do not** push
+   additional commits while other PRs are running CI — NISRA and similar
+   upstreams rate-limit concurrent requests and a cache miss in one job
+   can cause a 503 in another.
 
 Pull Request Guidelines
 -----------------------
 
-Before you submit a pull request, check that it meets these guidelines:
+Before submitting a pull request:
 
-1. The pull request should include tests (real-data integrity tests, not mocks).
-2. If the pull request adds functionality, update the docs — add a docstring
-   with an ``Example:`` section and update ``README.md`` and
-   ``docs/data_sources.rst`` if it adds a new data source.
-3. The pull request should work for Python 3.10+.  Check the GitHub Actions
-   CI results and make sure tests pass for all supported versions.
-4. Run ``uv run pre-commit run --all-files`` and resolve any linting issues
-   before requesting a review.
+1. **Tests** — include real-data integrity tests. No mocks. Use
+   ``scope="class"`` fixtures so the network call is made once per class.
+2. **Coverage** — new code must reach >90%. ``cli.py`` is deliberately
+   excluded from coverage checks.
+3. **Docs** — if you add a new data source, update ``README.md``
+   (coverage table) and ``docs/data_sources.rst``. Add a docstring with
+   an ``Example:`` section.
+4. **Lint** — ``uv run pre-commit run --all-files`` must be clean before
+   push. The ``pre-push`` hook enforces the coverage gate automatically.
+5. **Python versions** — CI tests 3.11, 3.12, and 3.13. Check that all
+   three matrix jobs pass.
+
+Data Source Development
+-----------------------
+
+Adding a new data source follows a three-step agent workflow documented
+in ``AGENTS.md``:
+
+``data-explore``
+    Evaluates a ``data-source-candidate`` issue — checks accessibility,
+    format, PxStat availability, and complexity. Posts a scored evaluation
+    comment on the issue.
+
+``data-build``
+    Builds the production module, tests, and CLI from a *RECOMMENDED*
+    evaluation. Works in phases (core module → tests → CLI → cross-validation)
+    and commits after each phase.
+
+``data-review``
+    Reviews open data-source PRs for consistency with shared utilities,
+    test standards, and documentation completeness.
+
+See ``AGENTS.md`` for the full specification of each agent, including
+templates, checklists, and quality gates.
+
+**Key standards** (from ``AGENTS.md``):
+
+* Prefer ``pxstat.read_dataset()`` for NISRA data — no rate limits, no
+  auth, no CI flakiness. Only fall back to Excel scraping when the dataset
+  is not in PxStat.
+* Use ``from bolster.utils.web import session`` for all HTTP — it provides
+  retry logic, a default 30 s timeout, and a 24-hour disk cache.
+* No mocks in tests.
+* Type hints and docstrings on all public functions.
 
 Tips
 ----
 
-To run only the doctests from source code::
+Run only doctests::
 
     $ uv run pytest src/ --doctest-modules --no-cov
 
-To see code coverage::
+Run a single test file quickly::
+
+    $ uv run pytest tests/test_dva_integrity.py -v --no-cov
+
+See coverage with missing lines::
 
     $ uv run pytest tests/ --cov=src/bolster --cov-report=term-missing
 
 Deploying
 ---------
 
-A reminder for the maintainers on how to deploy.
+Maintainers only.
 
 1. Update ``CHANGELOG.md`` with the new version entry.
-2. Bump the version using ``bump-my-version``::
+2. Bump the version::
 
-    $ uv run bump-my-version bump patch  # or minor / major
+    $ uv run bump-my-version bump patch   # or minor / major
 
 3. Push the resulting commit and tag::
 
     $ git push --follow-tags
 
-GitHub Actions ``publish.yml`` will then tag, release, and deploy to PyPI if
-tests pass.
+GitHub Actions ``publish.yml`` will then tag, release, and deploy to PyPI
+once tests pass.


### PR DESCRIPTION
Closes #1841

Rewrites the boilerplate contributing guide to match how development actually works:

- **No fork** — branch directly from `main` with `feat/<name>` / `fix/<name>`
- **Agent workflow** — documents the `data-explore` → `data-build` → `data-review` cycle and points to `AGENTS.md` as the authoritative spec
- **CI courtesy note** — warns contributors not to push while other PRs are running CI (NISRA rate-limiting)
- **Standards** — no mocks, `scope="class"` fixtures, >90% coverage on new code, `cli.py` excluded by design
- **HTTP/data access** — `CachingSession` (30s timeout, 24h cache) and `pxstat.read_dataset()` as the preferred patterns
- **Python versions** — corrects 3.10+ to 3.11–3.13 (actual CI matrix)
- **Practical tips** — quick-run commands for single test files, coverage, doctests