### PR TITLE
ci: extract shared release logic into reusable workflow_call

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,338 +1,93 @@
 name: Automated Release
 
 on:
-  push:
-    branches: [main]
-  workflow_dispatch:
-    inputs:
-      version_bump:
-        description: 'Version bump type (patch, minor, major)'
-        required: false
-        default: 'auto'
-        type: choice
-        options:
-        - auto
-        - patch
-        - minor
-        - major
+    push:
+        branches: [main]
+    workflow_dispatch:
+        inputs:
+            version_bump:
+                description: "Version bump type (patch, minor, major)"
+                required: false
+                default: "auto"
+                type: choice
+                options:
+                    - auto
+                    - patch
+                    - minor
+                    - major
 
 permissions:
-  contents: write
-  pull-requests: write
+    contents: write
+    pull-requests: write
 
 jobs:
-  analyze-changes:
-    runs-on: ubuntu-latest
-    outputs:
-      should_release: ${{ steps.analyze.outputs.should_release }}
-      version_bump: ${{ steps.analyze.outputs.version_bump }}
-      changelog: ${{ steps.analyze.outputs.changelog }}
-    steps:
-    - uses: actions/checkout@v7
-      with:
-        fetch-depth: 0
+    release:
+        uses: ./.github/workflows/release-logic.yml
+        with:
+            version_bump: ${{ inputs.version_bump || 'auto' }}
+            block_minor: true
+            package_name: bolster
+            docs_url: https://bolster.help
+            pypi_base_url: https://pypi.org/project/bolster
+        permissions:
+            contents: write
+            pull-requests: write
 
-    - name: Setup Python and uv
-      uses: astral-sh/setup-uv@v7
-      with:
-        python-version: "3.11"
-        enable-cache: false
+    refresh-release-pr:
+        # Bolster-specific: rebase.yml keeps open release PR branches current
+        # but never regenerates the PR description. This job re-derives the
+        # changelog and updates the PR body on every push to main.
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v7
+              with:
+                  fetch-depth: 0
+                  token: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Analyze changes and determine version bump
-      id: analyze
-      uses: actions/github-script@v9
-      with:
-        script: |
-          // Get commits since last tag
-          const { execSync } = require('child_process');
+            - name: Find an open release PR and refresh its changelog
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              run: |
+                  PR_JSON=$(gh pr list --base main --state open --json number,headRefName \
+                    --jq '[.[] | select(.headRefName | startswith("release/v"))][0]')
 
-          // Get last tag
-          let lastTag;
-          try {
-            lastTag = execSync('git describe --tags --abbrev=0', { encoding: 'utf-8' }).trim();
-          } catch (e) {
-            lastTag = 'v0.0.0'; // If no tags exist
-          }
+                  if [ -z "$PR_JSON" ] || [ "$PR_JSON" = "null" ]; then
+                    echo "No open release PR found — nothing to refresh"
+                    exit 0
+                  fi
 
-          console.log(`Last tag: ${lastTag}`);
+                  PR_NUMBER=$(echo "$PR_JSON" | jq -r '.number')
+                  BRANCH=$(echo "$PR_JSON" | jq -r '.headRefName')
+                  VERSION=${BRANCH#release/v}
+                  echo "Refreshing PR #${PR_NUMBER} (${BRANCH}, v${VERSION})"
 
-          // Get commits since last tag
-          const commits = execSync(`git log ${lastTag}..HEAD --pretty=format:"%s"`, { encoding: 'utf-8' })
-            .split('\n')
-            .filter(line => line.trim());
+                  git fetch origin "$BRANCH" main --tags --quiet
 
-          console.log(`Commits since ${lastTag}:`, commits);
+                  PREV_TAG=$(git tag --sort=-v:refname | grep -A1 "^v${VERSION}$" | tail -1)
+                  if [ "$PREV_TAG" = "v${VERSION}" ]; then
+                    PREV_TAG="v0.0.0"
+                  fi
+                  PREV_TAG=${PREV_TAG:-v0.0.0}
+                  echo "Previous tag: ${PREV_TAG}"
 
-          // Skip release if only docs/CI changes
-          const skipPatterns = [
-            /^docs?(\(.*\))?:/,
-            /^ci(\(.*\))?:/,
-            /^chore(\(.*\))?:/,
-            /^style(\(.*\))?:/,
-            /^test(\(.*\))?:/,
-            /Merge pull request/,
-            /Update.*dependabot/i
-          ];
+                  CHANGELOG=$(git log "${PREV_TAG}..origin/${BRANCH}" --pretty=format:"%s" | grep -Ev \
+                    -e '^docs?(\(.*\))?:' \
+                    -e '^ci(\(.*\))?:' \
+                    -e '^chore(\(.*\))?:' \
+                    -e '^style(\(.*\))?:' \
+                    -e '^test(\(.*\))?:' \
+                    -e "^Merge (branch|remote-tracking branch|pull request)" \
+                    -e '[Uu]pdate.*dependabot' \
+                    | sed 's/^/- /')
 
-          const releaseCommits = commits.filter(commit =>
-            !skipPatterns.some(pattern => pattern.test(commit))
-          );
+                  if [ -z "$CHANGELOG" ]; then
+                    echo "No commits found in range — leaving PR body untouched"
+                    exit 0
+                  fi
 
-          // Manual override from workflow_dispatch
-          if (context.eventName === 'workflow_dispatch' && context.payload.inputs?.version_bump !== 'auto') {
-            core.setOutput('should_release', 'true');
-            core.setOutput('version_bump', context.payload.inputs.version_bump);
-            core.setOutput('changelog', 'Manual release triggered');
-            return;
-          }
+                  printf 'Automated version bump to %s.\n\n## Changes in this release\n\n%s\n\n## Installation\n\n```bash\npip install bolster==%s\n```\n\n## Documentation\n\n- [Documentation](https://bolster.help)\n- [PyPI Package](https://pypi.org/project/bolster/%s/)\n\n---\n*This PR was automatically created by the release workflow.*\n' \
+                    "${VERSION}" "${CHANGELOG}" "${VERSION}" "${VERSION}" \
+                    > /tmp/pr-body.md
 
-          // Check for version:* label on the merged PR (label overrides commit analysis)
-          let labelOverride = null;
-          try {
-            const headSha = execSync('git rev-parse HEAD', { encoding: 'utf-8' }).trim();
-            const prs = await github.rest.repos.listPullRequestsAssociatedWithCommit({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              commit_sha: headSha,
-            });
-            for (const pr of prs.data) {
-              const versionLabel = pr.labels.map(l => l.name).find(n => n.startsWith('version:'));
-              if (versionLabel) {
-                labelOverride = versionLabel.replace('version:', '');
-                console.log(`PR #${pr.number} label override: ${labelOverride}`);
-                break;
-              }
-            }
-          } catch (e) {
-            console.log(`Could not check PR labels: ${e.message}`);
-          }
-
-          if (labelOverride === 'skip') {
-            console.log('PR label version:skip - skipping release');
-            core.setOutput('should_release', 'false');
-            return;
-          }
-
-          // Skip if no meaningful changes (and no label forcing a release)
-          if (releaseCommits.length === 0 && !labelOverride) {
-            console.log('No release-worthy changes found');
-            core.setOutput('should_release', 'false');
-            return;
-          }
-
-          // Determine version bump: label takes priority over commit analysis
-          let versionBump = labelOverride || 'patch';
-
-          if (!labelOverride) {
-            let hasBreaking = false;
-            let hasFeatures = false;
-
-            for (const commit of releaseCommits) {
-              if (commit.includes('BREAKING CHANGE') || commit.includes('!:')) {
-                hasBreaking = true;
-                break;
-              }
-              if (commit.match(/^feat(\(.*\))?:/)) {
-                hasFeatures = true;
-              }
-            }
-
-            if (hasBreaking) {
-              versionBump = 'major';
-            } else if (hasFeatures) {
-              versionBump = 'minor';
-            }
-          }
-
-          // Only patch releases are fully automated.
-          // Minor (feat:) and major (breaking) require explicit workflow_dispatch
-          // to avoid out-of-order version bumps from concurrent PRs.
-          if (versionBump === 'major' || versionBump === 'minor') {
-            console.log(`${versionBump} version detected - requires manual release via workflow_dispatch`);
-            core.setOutput('should_release', 'false');
-            return;
-          }
-
-          // Generate changelog
-          const changelog = releaseCommits
-            .map(commit => `- ${commit}`)
-            .join('\n');
-
-          core.setOutput('should_release', 'true');
-          core.setOutput('version_bump', versionBump);
-          core.setOutput('changelog', changelog);
-
-          console.log(`Release decision: ${versionBump} version bump`);
-
-  refresh-release-pr:
-    # Independent of analyze-changes/should_release: rebase.yml keeps an
-    # already-open release PR's branch up to date with main, but never
-    # regenerates its description, so the "Changes in this release" list
-    # silently falls behind every commit merged after the PR was opened.
-    # This job re-derives the changelog from the PR's own branch and
-    # updates its body in place whenever one is found.
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v7
-      with:
-        fetch-depth: 0
-        token: ${{ secrets.GITHUB_TOKEN }}
-
-    - name: Find an open release PR and refresh its changelog
-      env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: |
-        PR_JSON=$(gh pr list --base main --state open --json number,headRefName \
-          --jq '[.[] | select(.headRefName | startswith("release/v"))][0]')
-
-        if [ -z "$PR_JSON" ] || [ "$PR_JSON" = "null" ]; then
-          echo "No open release PR found — nothing to refresh"
-          exit 0
-        fi
-
-        PR_NUMBER=$(echo "$PR_JSON" | jq -r '.number')
-        BRANCH=$(echo "$PR_JSON" | jq -r '.headRefName')
-        VERSION=${BRANCH#release/v}
-        echo "Refreshing PR #${PR_NUMBER} (${BRANCH}, v${VERSION})"
-
-        git fetch origin "$BRANCH" main --tags --quiet
-
-        # Find the tag immediately before this release's own tag (version-
-        # sorted, not by ancestry) — the branch's own bump commit is buried
-        # partway up its history under however many "merge main in" commits
-        # rebase.yml has added since, so walking from its tip for the
-        # "previous" tag via `describe` would find the wrong one, and this
-        # release's own tag (v${VERSION}) may not even be merged to main yet.
-        PREV_TAG=$(git tag --sort=-v:refname | grep -A1 "^v${VERSION}$" | tail -1)
-        if [ "$PREV_TAG" = "v${VERSION}" ]; then
-          PREV_TAG="v0.0.0"
-        fi
-        PREV_TAG=${PREV_TAG:-v0.0.0}
-        echo "Previous tag: ${PREV_TAG}"
-
-        # Match analyze-changes' own skip patterns (docs/ci/chore/style/test
-        # commits, merges, dependabot) so the refreshed changelog stays in
-        # the same format as the original.
-        CHANGELOG=$(git log "${PREV_TAG}..origin/${BRANCH}" --pretty=format:"%s" | grep -Ev \
-          -e '^docs?(\(.*\))?:' \
-          -e '^ci(\(.*\))?:' \
-          -e '^chore(\(.*\))?:' \
-          -e '^style(\(.*\))?:' \
-          -e '^test(\(.*\))?:' \
-          -e "^Merge (branch|remote-tracking branch|pull request)" \
-          -e '[Uu]pdate.*dependabot' \
-          | sed 's/^/- /')
-
-        if [ -z "$CHANGELOG" ]; then
-          echo "No commits found in range — leaving PR body untouched"
-          exit 0
-        fi
-
-        printf 'Automated version bump to %s.\n\n## Changes in this release\n\n%s\n\n## Installation\n\n```bash\npip install bolster==%s\n```\n\n## Documentation\n\n- [Documentation](https://bolster.help)\n- [PyPI Package](https://pypi.org/project/bolster/%s/)\n\n---\n*This PR was automatically created by the release workflow.*\n' \
-          "${VERSION}" "${CHANGELOG}" "${VERSION}" "${VERSION}" \
-          > /tmp/pr-body.md
-
-        gh pr edit "$PR_NUMBER" --body-file /tmp/pr-body.md
-        echo "Updated PR #${PR_NUMBER} description"
-
-  open-release-pr:
-    needs: analyze-changes
-    if: needs.analyze-changes.outputs.should_release == 'true'
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v7
-      with:
-        fetch-depth: 0
-        token: ${{ secrets.GITHUB_TOKEN }}
-
-    - name: Setup Python and uv
-      uses: astral-sh/setup-uv@v7
-      with:
-        python-version: "3.11"
-
-    - name: Install dependencies
-      run: uv sync --dev
-
-    - name: Configure git
-      run: |
-        git config user.name "github-actions[bot]"
-        git config user.email "github-actions[bot]@users.noreply.github.com"
-
-    - name: Bump version
-      run: |
-        uv run bump-my-version bump ${{ needs.analyze-changes.outputs.version_bump }}
-        NEW_VERSION=$(uv run bump-my-version show current_version)
-        echo "NEW_VERSION=$NEW_VERSION" >> $GITHUB_ENV
-
-    - name: Generate changelog entry
-      env:
-        CHANGELOG_ENTRY: ${{ needs.analyze-changes.outputs.changelog }}
-      run: |
-        python3 - <<'PYEOF'
-        import os
-        from datetime import date
-        from pathlib import Path
-
-        version = os.environ["NEW_VERSION"]
-        entry_text = os.environ["CHANGELOG_ENTRY"]
-        entry = f"\n## [{version}] - {date.today()}\n\n{entry_text}\n"
-
-        path = Path("CHANGELOG.md")
-        content = path.read_text()
-        # Insert new entry after the first heading line (newest at top)
-        lines = content.split("\n")
-        for i, line in enumerate(lines):
-            if line.startswith("# "):
-                lines.insert(i + 1, entry)
-                break
-        path.write_text("\n".join(lines))
-        PYEOF
-
-    - name: Push version bump branch, tag, and open PR
-      env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        CHANGELOG_ENTRY: ${{ needs.analyze-changes.outputs.changelog }}
-      run: |
-        BRANCH="release/v${NEW_VERSION}"
-
-        # Idempotency: if the tag already exists (e.g. a previous run pushed the
-        # tag but failed before creating the PR), skip straight to PR creation.
-        if git ls-remote --exit-code origin "refs/tags/v${NEW_VERSION}" 2>/dev/null; then
-          echo "Tag v${NEW_VERSION} already exists on remote — checking for open PR"
-          EXISTING_PR=$(gh pr list --head "$BRANCH" --base main --json number --jq '.[0].number' 2>/dev/null || true)
-          if [ -n "$EXISTING_PR" ]; then
-            echo "PR #${EXISTING_PR} already open for ${BRANCH} — nothing to do"
-            exit 0
-          fi
-          echo "No PR found for ${BRANCH} — opening one now"
-          gh pr create \
-            --title "chore: bump version to ${NEW_VERSION}" \
-            --body "Automated version bump to ${NEW_VERSION} (retry — tag was already pushed in a previous run)." \
-            --label "version:skip" \
-            --base main \
-            --head "$BRANCH"
-          exit 0
-        fi
-
-        git checkout -b "$BRANCH"
-        git add .
-        git commit -m "chore: bump version to ${NEW_VERSION}"
-        git tag "v${NEW_VERSION}"
-        git push origin "$BRANCH"
-        git push origin "v${NEW_VERSION}"
-
-        # Write PR body to a file. Use printf with a format string to avoid
-        # YAML parsing issues with backticks and braces in heredoc content.
-        printf 'Automated version bump to %s.\n\n## Changes in this release\n\n%s\n\n## Installation\n\n```bash\npip install bolster==%s\n```\n\n## Documentation\n\n- [Documentation](https://bolster.help)\n- [PyPI Package](https://pypi.org/project/bolster/%s/)\n\n---\n*This PR was automatically created by the release workflow.*\n' \
-          "${NEW_VERSION}" "${CHANGELOG_ENTRY}" "${NEW_VERSION}" "${NEW_VERSION}" \
-          > /tmp/pr-body.md
-
-        # automerge.yml handles auto-merge for github-actions[bot] PRs;
-        # do not pass --auto-merge here as it can fail if the repo feature
-        # is not enabled, which would leave the tag pushed but no PR created.
-        gh pr create \
-          --title "chore: bump version to ${NEW_VERSION}" \
-          --body-file /tmp/pr-body.md \
-          --label "version:skip" \
-          --base main \
-          --head "$BRANCH"
+                  gh pr edit "$PR_NUMBER" --body-file /tmp/pr-body.md
+                  echo "Updated PR #${PR_NUMBER} description"

--- a/.github/workflows/release-logic.yml
+++ b/.github/workflows/release-logic.yml
@@ -1,0 +1,266 @@
+name: Release Logic (Reusable)
+# Shared conventional-commit release workflow. Called by auto-release.yml in
+# this repo and by andrewbolster/mcp.bolster.online via workflow_call.
+#
+# Inputs
+# ------
+# version_bump   : override bump type ('auto' means analyse commits)
+# block_minor    : when true, feat: commits require manual workflow_dispatch
+# package_name   : PyPI package name (used in PR body installation snippet)
+# docs_url       : documentation URL (omitted from PR body when blank)
+# pypi_base_url  : PyPI package base URL, e.g. https://pypi.org/project/bolster
+#                  (omitted from PR body when blank)
+#
+# Jobs
+# ----
+# analyze-changes : inspects commits since last tag, resolves bump type
+# open-release-pr : bumps version, inserts changelog entry, opens PR
+
+on:
+    workflow_call:
+        inputs:
+            version_bump:
+                description: "Version bump override (auto, patch, minor, major)"
+                default: "auto"
+                type: string
+            block_minor:
+                description: "Block automatic minor bumps; require workflow_dispatch"
+                default: true
+                type: boolean
+            package_name:
+                description: "PyPI package name for PR body installation snippet"
+                required: true
+                type: string
+            docs_url:
+                description: "Documentation URL for PR body (leave blank to omit)"
+                default: ""
+                type: string
+            pypi_base_url:
+                description: "PyPI base URL, e.g. https://pypi.org/project/bolster (leave blank to omit)"
+                default: ""
+                type: string
+
+permissions:
+    contents: write
+    pull-requests: write
+
+jobs:
+    analyze-changes:
+        runs-on: ubuntu-latest
+        outputs:
+            should_release: ${{ steps.analyze.outputs.should_release }}
+            version_bump: ${{ steps.analyze.outputs.version_bump }}
+            changelog: ${{ steps.analyze.outputs.changelog }}
+        steps:
+            - uses: actions/checkout@v7
+              with:
+                  fetch-depth: 0
+
+            - name: Analyze changes and determine version bump
+              id: analyze
+              uses: actions/github-script@v9
+              with:
+                  script: |
+                      const { execSync } = require('child_process');
+
+                      let lastTag;
+                      try {
+                        lastTag = execSync('git describe --tags --abbrev=0', { encoding: 'utf-8' }).trim();
+                      } catch (e) {
+                        lastTag = 'v0.0.0';
+                      }
+                      console.log(`Last tag: ${lastTag}`);
+
+                      const commits = execSync(`git log ${lastTag}..HEAD --pretty=format:"%s"`, { encoding: 'utf-8' })
+                        .split('\n')
+                        .filter(line => line.trim());
+                      console.log(`Commits since ${lastTag}:`, commits);
+
+                      const skipPatterns = [
+                        /^docs?(\(.*\))?:/,
+                        /^ci(\(.*\))?:/,
+                        /^chore(\(.*\))?:/,
+                        /^style(\(.*\))?:/,
+                        /^test(\(.*\))?:/,
+                        /Merge pull request/,
+                        /Update.*dependabot/i
+                      ];
+                      const releaseCommits = commits.filter(c => !skipPatterns.some(p => p.test(c)));
+
+                      // Manual override: caller passes the workflow_dispatch input through
+                      const versionBumpInput = '${{ inputs.version_bump }}';
+                      if (versionBumpInput && versionBumpInput !== 'auto') {
+                        core.setOutput('should_release', 'true');
+                        core.setOutput('version_bump', versionBumpInput);
+                        core.setOutput('changelog', 'Manual release triggered');
+                        return;
+                      }
+
+                      // PR label override (version:skip / version:patch / etc.)
+                      let labelOverride = null;
+                      try {
+                        const headSha = execSync('git rev-parse HEAD', { encoding: 'utf-8' }).trim();
+                        const prs = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+                          owner: context.repo.owner,
+                          repo: context.repo.repo,
+                          commit_sha: headSha,
+                        });
+                        for (const pr of prs.data) {
+                          const vLabel = pr.labels.map(l => l.name).find(n => n.startsWith('version:'));
+                          if (vLabel) {
+                            labelOverride = vLabel.replace('version:', '');
+                            console.log(`PR #${pr.number} label override: ${labelOverride}`);
+                            break;
+                          }
+                        }
+                      } catch (e) {
+                        console.log(`Could not check PR labels: ${e.message}`);
+                      }
+
+                      if (labelOverride === 'skip') {
+                        console.log('PR label version:skip — skipping release');
+                        core.setOutput('should_release', 'false');
+                        return;
+                      }
+
+                      if (releaseCommits.length === 0 && !labelOverride) {
+                        console.log('No release-worthy changes found');
+                        core.setOutput('should_release', 'false');
+                        return;
+                      }
+
+                      let versionBump = labelOverride || 'patch';
+                      if (!labelOverride) {
+                        let hasBreaking = false;
+                        let hasFeatures = false;
+                        for (const commit of releaseCommits) {
+                          if (commit.includes('BREAKING CHANGE') || commit.includes('!:')) { hasBreaking = true; break; }
+                          if (commit.match(/^feat(\(.*\))?:/)) hasFeatures = true;
+                        }
+                        if (hasBreaking) versionBump = 'major';
+                        else if (hasFeatures) versionBump = 'minor';
+                      }
+
+                      // Gate: major always requires manual dispatch; minor too when block_minor=true
+                      const blockMinor = '${{ inputs.block_minor }}' === 'true';
+                      if (versionBump === 'major' || (versionBump === 'minor' && blockMinor)) {
+                        console.log(`${versionBump} bump detected — requires manual workflow_dispatch`);
+                        core.setOutput('should_release', 'false');
+                        return;
+                      }
+
+                      const changelog = releaseCommits.map(c => `- ${c}`).join('\n');
+                      core.setOutput('should_release', 'true');
+                      core.setOutput('version_bump', versionBump);
+                      core.setOutput('changelog', changelog);
+                      console.log(`Release decision: ${versionBump}`);
+
+    open-release-pr:
+        needs: analyze-changes
+        if: needs.analyze-changes.outputs.should_release == 'true'
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v7
+              with:
+                  fetch-depth: 0
+                  token: ${{ secrets.GITHUB_TOKEN }}
+
+            - name: Setup Python and uv
+              uses: astral-sh/setup-uv@v7
+              with:
+                  python-version: "3.11"
+
+            - name: Install dependencies
+              run: uv sync --dev
+
+            - name: Configure git
+              run: |
+                  git config user.name "github-actions[bot]"
+                  git config user.email "github-actions[bot]@users.noreply.github.com"
+
+            - name: Bump version
+              run: |
+                  uv run bump-my-version bump ${{ needs.analyze-changes.outputs.version_bump }}
+                  NEW_VERSION=$(uv run bump-my-version show current_version)
+                  echo "NEW_VERSION=$NEW_VERSION" >> $GITHUB_ENV
+
+            - name: Generate changelog entry
+              env:
+                  CHANGELOG_ENTRY: ${{ needs.analyze-changes.outputs.changelog }}
+              run: |
+                  python3 - <<'PYEOF'
+                  import os
+                  from datetime import date
+                  from pathlib import Path
+
+                  version = os.environ["NEW_VERSION"]
+                  entry_text = os.environ["CHANGELOG_ENTRY"]
+                  entry = f"\n## [{version}] - {date.today()}\n\n{entry_text}\n"
+
+                  path = Path("CHANGELOG.md")
+                  content = path.read_text()
+                  lines = content.split("\n")
+                  for i, line in enumerate(lines):
+                      if line.startswith("# "):
+                          lines.insert(i + 1, entry)
+                          break
+                  path.write_text("\n".join(lines))
+                  PYEOF
+
+            - name: Push version bump branch, tag, and open PR
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  CHANGELOG_ENTRY: ${{ needs.analyze-changes.outputs.changelog }}
+                  PACKAGE_NAME: ${{ inputs.package_name }}
+                  DOCS_URL: ${{ inputs.docs_url }}
+                  PYPI_BASE_URL: ${{ inputs.pypi_base_url }}
+              run: |
+                  BRANCH="release/v${NEW_VERSION}"
+
+                  # Idempotency: tag already pushed in a previous run
+                  if git ls-remote --exit-code origin "refs/tags/v${NEW_VERSION}" 2>/dev/null; then
+                    echo "Tag v${NEW_VERSION} already exists — checking for open PR"
+                    EXISTING_PR=$(gh pr list --head "$BRANCH" --base main --json number --jq '.[0].number' 2>/dev/null || true)
+                    if [ -n "$EXISTING_PR" ]; then
+                      echo "PR #${EXISTING_PR} already open — nothing to do"
+                      exit 0
+                    fi
+                    gh pr create \
+                      --title "chore: bump version to ${NEW_VERSION}" \
+                      --body "Automated version bump to ${NEW_VERSION} (retry — tag was already pushed in a previous run)." \
+                      --label "version:skip" \
+                      --base main \
+                      --head "$BRANCH"
+                    exit 0
+                  fi
+
+                  git checkout -b "$BRANCH"
+                  git add .
+                  git commit -m "chore: bump version to ${NEW_VERSION}"
+                  git tag "v${NEW_VERSION}"
+                  git push origin "$BRANCH"
+                  git push origin "v${NEW_VERSION}"
+
+                  # Build optional PR body sections
+                  INSTALL_SECTION=""
+                  if [ -n "$PACKAGE_NAME" ]; then
+                    INSTALL_SECTION="## Installation\n\n\`\`\`bash\npip install ${PACKAGE_NAME}==${NEW_VERSION}\n\`\`\`\n\n"
+                  fi
+                  DOCS_SECTION=""
+                  if [ -n "$DOCS_URL" ] || [ -n "$PYPI_BASE_URL" ]; then
+                    DOCS_SECTION="## Documentation\n\n"
+                    [ -n "$DOCS_URL" ]      && DOCS_SECTION="${DOCS_SECTION}- [Documentation](${DOCS_URL})\n"
+                    [ -n "$PYPI_BASE_URL" ] && DOCS_SECTION="${DOCS_SECTION}- [PyPI Package](${PYPI_BASE_URL}/${NEW_VERSION}/)\n"
+                    DOCS_SECTION="${DOCS_SECTION}\n"
+                  fi
+
+                  printf "Automated version bump to %s.\n\n## Changes in this release\n\n%s\n\n%s%s---\n*This PR was automatically created by the release workflow.*\n" \
+                    "${NEW_VERSION}" "${CHANGELOG_ENTRY}" "${INSTALL_SECTION}" "${DOCS_SECTION}" \
+                    > /tmp/pr-body.md
+
+                  gh pr create \
+                    --title "chore: bump version to ${NEW_VERSION}" \
+                    --body-file /tmp/pr-body.md \
+                    --label "version:skip" \
+                    --base main \
+                    --head "$BRANCH"


### PR DESCRIPTION
Closes #1845

## What

Extracts the `analyze-changes` + `open-release-pr` jobs from `auto-release.yml` into a new `release-logic.yml` reusable workflow (`on: workflow_call`).

`auto-release.yml` becomes a thin caller plus the bolster-specific `refresh-release-pr` job.

## Inputs

| Input | Default | Purpose |
|-------|---------|---------|
| `version_bump` | `auto` | Pass through caller's `workflow_dispatch` override |
| `block_minor` | `true` | bolster blocks minor+major; mcp only blocks major |
| `package_name` | _(required)_ | PyPI name for installation snippet in PR body |
| `docs_url` | _(blank)_ | Documentation link (omitted when blank) |
| `pypi_base_url` | _(blank)_ | PyPI URL prefix (omitted when blank) |

## Changes from the mcp copy

- `block_minor` flag unifies the differing version-gate logic (bolster blocked minor+major; mcp only blocked major)
- Action versions bumped to `checkout@v7`, `github-script@v9`, `setup-uv@v7` uniformly
- `workflow_dispatch` detection fixed: was checking `context.eventName === 'workflow_dispatch'` which is always false inside a `workflow_call`; now reads the `version_bump` input directly

## Companion PR

mcp.bolster.online companion PR: andrewbolster/mcp.bolster.online#[to follow] — replaces its `auto-release.yml` with a single `uses:` call to this workflow.