### PR TITLE
fix(ci): use --group fuzz flag for atheris install

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -24,7 +24,7 @@ jobs:
                   cache-dependency-glob: "uv.lock"
 
             - name: Install with fuzz extras
-              run: uv sync --extra fuzz
+              run: uv sync --group fuzz
 
             - name: Run fuzzer
               run: |


### PR DESCRIPTION
One-liner missed from #1980 squash — the fuzz workflow used `--extra` but atheris is in `[dependency-groups]`, which requires `--group`.