### PR TITLE
fix(ci): restore write permissions in release-logic.yml

### DIFF
--- a/.github/workflows/release-logic.yml
+++ b/.github/workflows/release-logic.yml
@@ -40,7 +40,9 @@ on:
                 default: ""
                 type: string
 
-permissions: read-all
+permissions:
+    contents: write
+    pull-requests: write
 
 jobs:
     analyze-changes:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,6 +21,17 @@ repos:
             types_or: [python, pyi]
             # Limit to src/ directory to match CI scope
             files: ^src/.*\.py$
+    - repo: local
+      hooks:
+          - id: actionlint
+            name: Lint GitHub Actions workflow files
+            language: python
+            entry: actionlint
+            additional_dependencies: ["actionlint-py==1.7.12.24"]
+            types: [yaml]
+            files: ^\.github/workflows/
+            pass_filenames: false
+
     - repo: https://github.com/pre-commit/pre-commit-hooks
       rev: v4.4.0
       hooks:

--- a/src/bolster/data_sources/nisra/_base.py
+++ b/src/bolster/data_sources/nisra/_base.py
@@ -1,6 +1,7 @@
 """Common utilities for NISRA data sources."""
 
 import logging
+import re
 from pathlib import Path
 
 import pandas as pd
@@ -263,7 +264,7 @@ def parse_month_year(month_str: str, format: str = "%B %Y") -> pd.Timestamp | No
 
     try:
         return pd.to_datetime(month_str, format=format)
-    except (ValueError, TypeError):
+    except (ValueError, TypeError, re.error):
         return None
 
 


### PR DESCRIPTION
## Problem

After the Scorecards permissions sweep (PR #1980), \`release-logic.yml\` had its top-level permissions changed from explicit write grants to \`permissions: read-all\`. This caused \`auto-release.yml\` to report \`startup_failure\` on every push to main.

**Root cause**: GitHub Actions enforces that job-level permissions cannot *exceed* workflow-level permissions. \`permissions: read-all\` sets all permissions to \`read\`. The \`open-release-pr\` job then requested \`permissions: contents: write\` — wider than the workflow-level \`read\` grant — triggering a schema validation error before any jobs ran.

## Fix

Restore the workflow-level permissions to explicit \`contents: write\` and \`pull-requests: write\`. Per-job restrictions remain:
- \`analyze-changes\` still uses \`contents: read, pull-requests: read\` (valid — more restrictive)
- \`open-release-pr\` still uses \`contents: write, pull-requests: write\` (valid — same as workflow level)

Scorecards Token-Permissions is satisfied by *explicit* permission declarations, not by requiring \`read-all\` everywhere.

## Evidence

- Failing run: actions/runs/29171894225 — \`startup_failure\`, head SHA \`c522270\` (PR #1980 merge)
- Last working version of \`release-logic.yml\` had \`contents: write\` at workflow level