### PR TITLE
feat(homelessness): NI Homelessness Bulletin module (DfC/NIHE)

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ The [GOV.UK NISRA statistics RSS feed](https://www.gov.uk/search/research-and-st
 | Child Protection Statistics | `health_ni.child_protection` | ✅ |
 | NI Planning Activity Statistics (DfI) | `nisra.planning_statistics` | ✅ |
 | NI Housing Stock Statistics (DoF/LPS) | `nisra.housing_stock` | ✅ |
+| NI Homelessness Bulletin (DfC/NIHE) | `nisra.homelessness` | ✅ |
 | Registrar General Quarterly Tables | `nisra.registrar_general` | ✅ |
 | Tourism - Hotel Occupancy | `nisra.tourism.occupancy` | ✅ |
 | Tourism - SSA Occupancy | `nisra.tourism.occupancy` | ✅ |

--- a/src/bolster/cli.py
+++ b/src/bolster/cli.py
@@ -38,6 +38,7 @@ from .data_sources.nisra import construction_output as nisra_construction
 from .data_sources.nisra import deaths as nisra_deaths
 from .data_sources.nisra import deprivation as nisra_deprivation
 from .data_sources.nisra import drug_related_deaths as nisra_drug_related_deaths
+from .data_sources.nisra import homelessness as nisra_homelessness
 from .data_sources.nisra import housing_stock as nisra_housing_stock
 from .data_sources.nisra import index_of_production as nisra_iop
 from .data_sources.nisra import index_of_services as nisra_ios
@@ -6020,6 +6021,81 @@ def nisra_housing_stock_cmd(geo, year_filter, output_format, force_refresh, save
         console.print(f"[cyan]Rows: {len(data)}[/cyan]")
         if not data.empty and "year" in data.columns:
             console.print(f"[dim]Years: {int(data['year'].min())}–{int(data['year'].max())}[/dim]")
+
+        if save:
+            if output_format == "json" or save.endswith(".json"):
+                data.to_json(save, orient="records", indent=2)
+            else:
+                data.to_csv(save, index=False)
+            console.print(f"[green]Saved to: {save}[/green]")
+            return
+
+        if output_format == "json":
+            click.echo(data.to_json(orient="records", indent=2))
+        else:
+            console.print(data.to_csv(index=False), end="")
+
+    except Exception as e:
+        console.print(f"[bold red]Error:[/bold red] {str(e)}", style="red")
+        console.print("\n[yellow]Troubleshooting:[/yellow]")
+        console.print("   - Check your internet connection")
+        console.print("   - Try again with --force-refresh to bypass cache")
+        raise click.Abort() from e
+
+
+@nisra.command(name="homelessness")
+@click.option(
+    "--section",
+    type=click.Choice(["presentations", "acceptances", "all"], case_sensitive=False),
+    default="presentations",
+    help="Data section to return (default: presentations)",
+)
+@click.option(
+    "--format",
+    "output_format",
+    type=click.Choice(["csv", "json"], case_sensitive=False),
+    default="csv",
+    help="Output format (default: csv)",
+)
+@click.option("--force-refresh", is_flag=True, help="Force re-download even if cached")
+@click.option("--save", help="Save data to file (specify filename)")
+def nisra_homelessness_cmd(section, output_format, force_refresh, save):  # pragma: no cover
+    """NI Homelessness Bulletin Statistics (DfC / NIHE).
+
+    Biannual homelessness presentations and acceptances by Local Government
+    District (LGD) and six-month period (Apr–Sep, Oct–Mar).
+    Coverage: 2018/19 to present.
+
+    Examples:
+        Presentations by LGD (default)::
+
+            bolster nisra homelessness
+
+        Acceptances data::
+
+            bolster nisra homelessness --section acceptances
+
+        Both sections combined::
+
+            bolster nisra homelessness --section all
+
+        Save to JSON::
+
+            bolster nisra homelessness --section all --format json --save homelessness.json
+
+    Source:
+        https://www.communities-ni.gov.uk/articles/northern-ireland-homelessness-bulletin
+    """
+    console = Console()
+
+    try:
+        with console.status(f"[bold green]Downloading homelessness data (section={section})..."):
+            data = nisra_homelessness.get_latest_data(section=section, force_refresh=force_refresh)
+
+        console.print("[green]Homelessness data retrieved successfully[/green]")
+        console.print(f"[cyan]Rows: {len(data)}[/cyan]")
+        if not data.empty and "year" in data.columns:
+            console.print(f"[dim]Years: {data['year'].min()}–{data['year'].max()}[/dim]")
 
         if save:
             if output_format == "json" or save.endswith(".json"):

--- a/src/bolster/cli.py
+++ b/src/bolster/cli.py
@@ -7884,6 +7884,7 @@ def list_sources():
     click.echo("  nisra baby-names           Baby name registrations (1997–present)")
     click.echo("  nisra occupancy            Tourism hotel/SSA occupancy surveys")
     click.echo("  nisra visitors             Tourism visitor statistics")
+    click.echo("  nisra homelessness         NI Homelessness Bulletin (DfC/NIHE, biannual)")
 
     click.echo("\nPSNI DATA MODULES (bolster psni <command>)")
     click.echo("  psni rtc                   Road traffic collisions, casualties, vehicles")

--- a/src/bolster/data_sources/nisra/__init__.py
+++ b/src/bolster/data_sources/nisra/__init__.py
@@ -27,6 +27,7 @@ Available modules:
     - tourism: Tourism statistics including occupancy surveys, visitor stats (subpackage)
     - wellbeing: Individual wellbeing statistics (life satisfaction, happiness, anxiety, loneliness)
     - work_quality: Work Quality NI — seventeen indicators of job quality for employees
+    - homelessness: NI Homelessness Bulletin — biannual presentations/acceptances by LGD (DfC/NIHE)
     - housing_stock: NI Housing Stock annual statistics by property type (DoF/LPS)
     - public_confidence: Public Awareness of and Trust in Official Statistics (PCOS)
 
@@ -130,6 +131,7 @@ from . import (
     deaths,
     deprivation,
     drug_related_deaths,
+    homelessness,
     housing_stock,
     index_of_production,
     index_of_services,
@@ -159,6 +161,7 @@ __all__ = [
     "deaths",
     "deprivation",
     "drug_related_deaths",
+    "homelessness",
     "housing_stock",
     "index_of_production",
     "index_of_services",

--- a/src/bolster/data_sources/nisra/homelessness.py
+++ b/src/bolster/data_sources/nisra/homelessness.py
@@ -31,13 +31,17 @@ from __future__ import annotations
 import contextlib
 import logging
 import re
+from typing import TYPE_CHECKING
 
 import pandas as pd
 from bs4 import BeautifulSoup
 
 from bolster.utils.web import session
 
-from ._base import NISRAValidationError, download_file
+from ._base import NISRADataNotFoundError, NISRAValidationError, download_file  # noqa: F401
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
@@ -81,7 +85,7 @@ def get_latest_publication_url() -> str:
         True
     """
     try:
-        response = session.get(_HUB_URL, timeout=30)
+        response = session.get(_HUB_URL)
         response.raise_for_status()
         soup = BeautifulSoup(response.content, "html.parser")
 
@@ -100,7 +104,7 @@ def get_latest_publication_url() -> str:
                 if "homelessness-bulletin" in href.lower() and "publications" in href.lower():
                     if href.startswith("/"):
                         href = f"https://www.communities-ni.gov.uk{href}"
-                    pub_resp = session.get(href, timeout=30)
+                    pub_resp = session.get(href)
                     pub_resp.raise_for_status()
                     pub_soup = BeautifulSoup(pub_resp.content, "html.parser")
                     for a2 in pub_soup.find_all("a", href=True):
@@ -133,10 +137,11 @@ def _parse_lgd_period_sheet(sheet_df: pd.DataFrame, value_col_name: str) -> pd.D
     """Parse a homelessness LGD-by-period sheet into long format.
 
     These sheets have a composite header where:
-    - Row 1: year labels (each spanning two data columns via merged cells → NaNs)
-    - Row 2: period labels (same pattern)
-    - Row 3: column descriptions (LGD name, count, rate per 1000, count, rate ...)
-    - Row 4+: one row per LGD, last row = Northern Ireland total
+    - Row 0 (``iloc[0]``): title row, skipped
+    - Row 1 (``iloc[1]``): year labels (each spanning two data columns via merged cells → NaNs)
+    - Row 2 (``iloc[2]``): period labels (same pattern)
+    - Row 3 (``iloc[3]``): column descriptions (LGD name, count, rate per 1000, count, rate ...)
+    - Row 4+ (``iloc[4:]``): one row per LGD, last row = Northern Ireland total
 
     Args:
         sheet_df: Raw DataFrame read with ``header=None``.
@@ -260,7 +265,7 @@ def _normalise_period(period: str) -> str:
     return period
 
 
-def parse_presentations(file_path: str | object) -> pd.DataFrame:
+def parse_presentations(file_path: str | Path) -> pd.DataFrame:
     """Parse the presentations-by-LGD sheet from a homelessness bulletin workbook.
 
     Args:
@@ -280,7 +285,7 @@ def parse_presentations(file_path: str | object) -> pd.DataFrame:
     return _parse_lgd_period_sheet(raw, "presentations")
 
 
-def parse_acceptances(file_path: str | object) -> pd.DataFrame:
+def parse_acceptances(file_path: str | Path) -> pd.DataFrame:
     """Parse the acceptances-by-LGD sheet from a homelessness bulletin workbook.
 
     Args:
@@ -409,6 +414,6 @@ def validate_data(df: pd.DataFrame, section: str = "presentations") -> bool:
     if not ni_rows.empty:
         max_count = ni_rows[count_col].max()
         if max_count < 1000:
-            raise NISRAValidationError(f"NI total {section} implausibly low (max={max_count}); expected >1000")
+            raise NISRAValidationError(f"NI total {count_col} implausibly low (max={max_count}); expected >1000")
 
     return True

--- a/src/bolster/data_sources/nisra/homelessness.py
+++ b/src/bolster/data_sources/nisra/homelessness.py
@@ -1,0 +1,414 @@
+"""Northern Ireland Homelessness Bulletin statistics.
+
+Biannual homelessness statistics from the Department for Communities NI (DfC),
+sourced from Northern Ireland Housing Executive (NIHE) casework records.
+Covers homeless presentations, acceptances, and temporary accommodation
+placements, broken down by Local Government District (LGD).
+
+Data is published approximately every six months (Apr–Sep and Oct–Mar periods),
+roughly three months after each period ends.
+
+Note: This data is **not** available in the NISRA PxStat API. It is published
+directly by DfC as Excel workbooks.
+
+Publisher:
+    Department for Communities NI (DfC) / Northern Ireland Housing Executive (NIHE).
+    Publication hub: https://www.communities-ni.gov.uk/articles/northern-ireland-homelessness-bulletin
+
+Coverage:
+    Biannual, 2018/19 to present.
+    Geography: 11 Local Government Districts (LGDs) + NI total.
+
+Example:
+    >>> from bolster.data_sources.nisra import homelessness
+    >>> df = homelessness.get_latest_data(section='presentations')
+    >>> 'lgd' in df.columns
+    True
+"""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+import re
+
+import pandas as pd
+from bs4 import BeautifulSoup
+
+from bolster.utils.web import session
+
+from ._base import NISRAValidationError, download_file
+
+logger = logging.getLogger(__name__)
+
+_HUB_URL = "https://www.communities-ni.gov.uk/articles/northern-ireland-homelessness-bulletin"
+
+_FALLBACK_URL = (
+    "https://www.communities-ni.gov.uk/system/files/2026-06/ni-homelessness-bulletin-oct-mar-2026-tables.xlsx"
+)
+
+# Sheet names for each section
+_SHEET_PRESENTATIONS_LGD = "1_3"
+_SHEET_ACCEPTANCES_LGD = "2_3"
+
+_KNOWN_LGDS = {
+    "Antrim and Newtownabbey",
+    "Ards and North Down",
+    "Armagh City, Banbridge and Craigavon",
+    "Belfast",
+    "Causeway Coast and Glens",
+    "Derry City and Strabane",
+    "Fermanagh and Omagh",
+    "Lisburn and Castlereagh",
+    "Mid and East Antrim",
+    "Mid Ulster",
+    "Newry, Mourne and Down",
+    "Northern Ireland",
+}
+
+
+def get_latest_publication_url() -> str:
+    """Scrape the DfC hub page for the latest homelessness bulletin Excel URL.
+
+    Falls back to the hardcoded 2025/26 Oct–Mar edition URL if scraping fails.
+
+    Returns:
+        Absolute URL of the Excel tables file.
+
+    Example:
+        >>> url = get_latest_publication_url()
+        >>> 'communities-ni.gov.uk' in url
+        True
+    """
+    try:
+        response = session.get(_HUB_URL, timeout=30)
+        response.raise_for_status()
+        soup = BeautifulSoup(response.content, "html.parser")
+
+        candidates: list[str] = []
+        for a_tag in soup.find_all("a", href=True):
+            href: str = a_tag["href"]
+            if "homelessness-bulletin" in href.lower() and "tables" in href.lower() and ".xlsx" in href.lower():
+                if href.startswith("/"):
+                    href = f"https://www.communities-ni.gov.uk{href}"
+                candidates.append(href)
+
+        if not candidates:
+            # Try following the first publication link on the hub page
+            for a_tag in soup.find_all("a", href=True):
+                href = a_tag["href"]
+                if "homelessness-bulletin" in href.lower() and "publications" in href.lower():
+                    if href.startswith("/"):
+                        href = f"https://www.communities-ni.gov.uk{href}"
+                    pub_resp = session.get(href, timeout=30)
+                    pub_resp.raise_for_status()
+                    pub_soup = BeautifulSoup(pub_resp.content, "html.parser")
+                    for a2 in pub_soup.find_all("a", href=True):
+                        h2 = a2["href"]
+                        if ".xlsx" in h2.lower() and "table" in h2.lower():
+                            if h2.startswith("/"):
+                                h2 = f"https://www.communities-ni.gov.uk{h2}"
+                            candidates.append(h2)
+                    if candidates:
+                        break
+
+        if candidates:
+            # Prefer the most recent by embedded date in path (YYYY-MM)
+            def _date_key(u: str) -> str:
+                m = re.search(r"/(\d{4}-\d{2})/", u)
+                return m.group(1) if m else "0000-00"
+
+            candidates.sort(key=_date_key, reverse=True)
+            logger.info("Discovered homelessness bulletin URL: %s", candidates[0])
+            return candidates[0]
+
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("Could not scrape %s for homelessness URL: %s", _HUB_URL, exc)
+
+    logger.info("Using fallback homelessness bulletin URL")
+    return _FALLBACK_URL
+
+
+def _parse_lgd_period_sheet(sheet_df: pd.DataFrame, value_col_name: str) -> pd.DataFrame:
+    """Parse a homelessness LGD-by-period sheet into long format.
+
+    These sheets have a composite header where:
+    - Row 1: year labels (each spanning two data columns via merged cells → NaNs)
+    - Row 2: period labels (same pattern)
+    - Row 3: column descriptions (LGD name, count, rate per 1000, count, rate ...)
+    - Row 4+: one row per LGD, last row = Northern Ireland total
+
+    Args:
+        sheet_df: Raw DataFrame read with ``header=None``.
+        value_col_name: Name for the count column (e.g. ``'presentations'``).
+
+    Returns:
+        Long-format DataFrame with columns: year, period, lgd, <value_col_name>,
+        rate_per_1000. Rows with '*' suppressed values are dropped.
+    """
+    years_raw = list(sheet_df.iloc[1])
+    periods_raw = list(sheet_df.iloc[2])
+
+    # Forward-fill: year/period headers sit on the count column; rate column has NaN
+    years_filled: list[str | None] = []
+    periods_filled: list[str | None] = []
+    current_year: str | None = None
+    current_period: str | None = None
+    for y, p in zip(years_raw, periods_raw, strict=False):
+        if pd.notna(y):
+            # Strip footnote digit appended to year ranges: "2023/242" → "2023/24"
+            current_year = re.sub(r"^(\d{4}/\d{2})\d+$", r"\1", str(y).strip())
+        if pd.notna(p):
+            current_period = str(p).strip()
+        years_filled.append(current_year)
+        periods_filled.append(current_period)
+
+    # Data rows: row index 4 onwards (row 3 = col headers, which we skip)
+    records = []
+    for row_idx in range(4, len(sheet_df)):
+        row = sheet_df.iloc[row_idx]
+        lgd = str(row.iloc[0]).strip() if pd.notna(row.iloc[0]) else None
+        if not lgd or lgd in ("nan", "None", "") or lgd.lower().startswith("source"):
+            continue
+        # Stop at footnote rows
+        if re.match(r"^\d+\.", lgd) or lgd.lower().startswith("note"):
+            continue
+
+        # Walk pairs of (count, rate) columns starting at col index 1
+        col_idx = 1
+        while col_idx < len(row) - 1:
+            year_label = years_filled[col_idx]
+            period_label = periods_filled[col_idx]
+            if year_label is None or period_label is None:
+                col_idx += 2
+                continue
+
+            raw_count = row.iloc[col_idx]
+            raw_rate = row.iloc[col_idx + 1]
+
+            # Skip suppressed ('*') or missing values
+            if str(raw_count).strip() in ("*", "nan", "None", ""):
+                col_idx += 2
+                continue
+
+            try:
+                count = int(str(raw_count).replace(",", "").strip())
+            except ValueError:
+                col_idx += 2
+                continue
+
+            rate: float | None = None
+            with contextlib.suppress(ValueError, TypeError):
+                rate = float(str(raw_rate).replace(",", "").strip())
+
+            records.append(
+                {
+                    "year": year_label,
+                    "period": _normalise_period(period_label),
+                    "lgd": lgd,
+                    value_col_name: count,
+                    "rate_per_1000": rate,
+                }
+            )
+            col_idx += 2
+
+    return pd.DataFrame(records)
+
+
+def _normalise_period(period: str) -> str:
+    """Normalise period label variants to a consistent short form.
+
+    Args:
+        period: Raw period string from the spreadsheet header.
+
+    Returns:
+        Normalised string, e.g. ``'Apr-Sep'``, ``'Oct-Mar'``.
+
+    Example:
+        >>> _normalise_period('April-September')
+        'Apr-Sep'
+        >>> _normalise_period('October-March')
+        'Oct-Mar'
+    """
+    period = period.strip()
+    # Strip footnote markers
+    period = re.sub(r"[¹²³⁴1234]\s*$", "", period).strip()
+
+    mapping = {
+        "april-september": "Apr-Sep",
+        "october-march": "Oct-Mar",
+        "july-december": "Jul-Dec",
+        "january-june": "Jan-Jun",
+    }
+    lower = period.lower()
+    for key, val in mapping.items():
+        if lower.startswith(key[:5]):
+            return val
+
+    # Special cases: "Apr-Jun (Financial year Q1)" etc.
+    if "apr" in lower and "jun" in lower:
+        return "Apr-Jun"
+    if "apr" in lower and "sep" in lower:
+        return "Apr-Sep"
+    if "oct" in lower and "mar" in lower:
+        return "Oct-Mar"
+    if "jul" in lower and "dec" in lower:
+        return "Jul-Dec"
+    if "jan" in lower and "jun" in lower:
+        return "Jan-Jun"
+
+    return period
+
+
+def parse_presentations(file_path: str | object) -> pd.DataFrame:
+    """Parse the presentations-by-LGD sheet from a homelessness bulletin workbook.
+
+    Args:
+        file_path: Path to the downloaded Excel file.
+
+    Returns:
+        Long-format DataFrame with columns: year, period, lgd,
+        presentations, rate_per_1000.
+
+    Example:
+        >>> df = parse_presentations('/tmp/homelessness.xlsx')
+        >>> set(df.columns) >= {'year', 'period', 'lgd', 'presentations'}
+        True
+    """
+    xl = pd.ExcelFile(file_path, engine="openpyxl")
+    raw = xl.parse(_SHEET_PRESENTATIONS_LGD, header=None)
+    return _parse_lgd_period_sheet(raw, "presentations")
+
+
+def parse_acceptances(file_path: str | object) -> pd.DataFrame:
+    """Parse the acceptances-by-LGD sheet from a homelessness bulletin workbook.
+
+    Args:
+        file_path: Path to the downloaded Excel file.
+
+    Returns:
+        Long-format DataFrame with columns: year, period, lgd,
+        acceptances, rate_per_1000.
+
+    Example:
+        >>> df = parse_acceptances('/tmp/homelessness.xlsx')
+        >>> set(df.columns) >= {'year', 'period', 'lgd', 'acceptances'}
+        True
+    """
+    xl = pd.ExcelFile(file_path, engine="openpyxl")
+    raw = xl.parse(_SHEET_ACCEPTANCES_LGD, header=None)
+    return _parse_lgd_period_sheet(raw, "acceptances")
+
+
+def get_latest_data(
+    section: str = "presentations",
+    force_refresh: bool = False,
+) -> pd.DataFrame:
+    """Download and return the latest NI homelessness bulletin data.
+
+    Args:
+        section: Which section to return:
+            - ``'presentations'`` (default): Households presenting as homeless
+              by LGD and period.
+            - ``'acceptances'``: Households accepted as homeless by LGD and period.
+            - ``'all'``: Both sections combined with a ``'section'`` column.
+        force_refresh: If ``True``, bypass the local cache and re-download.
+
+    Returns:
+        Long-format DataFrame. For ``section='presentations'``, columns are:
+
+        - **year** (str): Reporting year label (e.g. ``'2025/26'``).
+        - **period** (str): Six-month period (e.g. ``'Oct-Mar'``, ``'Apr-Sep'``).
+        - **lgd** (str): Local Government District name, or ``'Northern Ireland'``
+          for the NI-wide total.
+        - **presentations** (int): Households presenting as homeless.
+        - **rate_per_1000** (float): Presentations per 1,000 population.
+
+        For ``section='acceptances'``, ``'presentations'`` is replaced by
+        ``'acceptances'``. For ``section='all'``, both are included with a
+        ``'section'`` column (``'presentations'`` or ``'acceptances'``).
+
+    Raises:
+        ValueError: If ``section`` is not one of the accepted values.
+        NISRADataNotFoundError: If the source file cannot be downloaded.
+
+    Example:
+        >>> df = get_latest_data()
+        >>> 'lgd' in df.columns
+        True
+        >>> 'Northern Ireland' in df['lgd'].values
+        True
+    """
+    valid = {"presentations", "acceptances", "all"}
+    if section not in valid:
+        raise ValueError(f"section must be one of {sorted(valid)!r}, got {section!r}")
+
+    url = get_latest_publication_url()
+    file_path = download_file(url, cache_ttl_hours=24 * 7, force_refresh=force_refresh)
+
+    if section == "presentations":
+        return parse_presentations(file_path)
+    if section == "acceptances":
+        return parse_acceptances(file_path)
+
+    # section == 'all'
+    pres = parse_presentations(file_path)
+    pres["section"] = "presentations"
+    pres = pres.rename(columns={"presentations": "count"})
+
+    acc = parse_acceptances(file_path)
+    acc["section"] = "acceptances"
+    acc = acc.rename(columns={"acceptances": "count"})
+
+    return pd.concat([pres, acc], ignore_index=True)
+
+
+def validate_data(df: pd.DataFrame, section: str = "presentations") -> bool:
+    """Validate a homelessness bulletin DataFrame.
+
+    Args:
+        df: DataFrame returned by :func:`get_latest_data`.
+        section: ``'presentations'`` or ``'acceptances'``, used to identify
+            the count column.
+
+    Returns:
+        ``True`` if all checks pass.
+
+    Raises:
+        NISRAValidationError: If any check fails.
+
+    Example:
+        >>> df = get_latest_data('presentations')
+        >>> validate_data(df, 'presentations')
+        True
+    """
+    if df is None or df.empty:
+        raise NISRAValidationError("Homelessness DataFrame is empty")
+
+    count_col = "count" if "count" in df.columns else section
+    required = {"year", "period", "lgd", count_col}
+    missing = required - set(df.columns)
+    if missing:
+        raise NISRAValidationError(f"Missing required columns: {sorted(missing)}")
+
+    # Should cover multiple years (at least 5 periods of data)
+    if len(df) < 5:
+        raise NISRAValidationError(f"Too few rows ({len(df)}); expected at least 5")
+
+    # NI total should be present
+    if "Northern Ireland" not in df["lgd"].values:
+        raise NISRAValidationError("'Northern Ireland' total row not found in lgd column")
+
+    # No negative counts
+    counts = df[count_col].dropna()
+    if (counts < 0).any():
+        raise NISRAValidationError(f"Negative values found in '{count_col}' column")
+
+    # Sanity check: NI-wide presentations in a recent period should be > 1000
+    ni_rows = df[df["lgd"] == "Northern Ireland"]
+    if not ni_rows.empty:
+        max_count = ni_rows[count_col].max()
+        if max_count < 1000:
+            raise NISRAValidationError(f"NI total {section} implausibly low (max={max_count}); expected >1000")
+
+    return True

--- a/tests/test_nisra_homelessness_integrity.py
+++ b/tests/test_nisra_homelessness_integrity.py
@@ -1,0 +1,245 @@
+"""Integrity tests for NISRA Homelessness Bulletin module.
+
+Validates real data quality, structure, and consistency for NI homelessness
+statistics published by the Department for Communities NI (DfC) / NIHE.
+
+Data is sourced from Excel workbooks downloaded directly from:
+https://www.communities-ni.gov.uk/articles/northern-ireland-homelessness-bulletin
+
+Coverage: biannual (Apr–Sep and Oct–Mar), 2018/19 to present.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from bolster.data_sources.nisra import homelessness
+from bolster.data_sources.nisra._base import NISRAValidationError
+
+_ELEVEN_LGDS = {
+    "Antrim and Newtownabbey",
+    "Ards and North Down",
+    "Armagh City, Banbridge and Craigavon",
+    "Belfast",
+    "Causeway Coast and Glens",
+    "Derry City and Strabane",
+    "Fermanagh and Omagh",
+    "Lisburn and Castlereagh",
+    "Mid and East Antrim",
+    "Mid Ulster",
+    "Newry, Mourne and Down",
+}
+
+# Known Apr–Sep 2025 figures from the DfC bulletin
+_NI_APR_SEP_2025_PRESENTATIONS = 8_217
+_NI_APR_SEP_2025_ACCEPTANCES = 5_366
+_ANCHOR_TOLERANCE = 0.05  # ±5%
+
+
+class TestPresentationsIntegrity:
+    """Integrity tests for homelessness presentations data."""
+
+    @pytest.fixture(scope="class")
+    def df(self) -> pd.DataFrame:
+        return homelessness.get_latest_data(section="presentations")
+
+    def test_returns_dataframe(self, df: pd.DataFrame) -> None:
+        assert isinstance(df, pd.DataFrame)
+        assert not df.empty
+
+    def test_required_columns(self, df: pd.DataFrame) -> None:
+        assert {"year", "period", "lgd", "presentations", "rate_per_1000"}.issubset(set(df.columns))
+
+    def test_ni_total_present(self, df: pd.DataFrame) -> None:
+        assert "Northern Ireland" in df["lgd"].values
+
+    def test_eleven_lgds_present(self, df: pd.DataFrame) -> None:
+        names = set(df["lgd"].unique())
+        missing = _ELEVEN_LGDS - names
+        assert not missing, f"Missing LGDs: {missing}"
+
+    def test_covers_both_periods(self, df: pd.DataFrame) -> None:
+        periods = set(df["period"].unique())
+        assert "Apr-Sep" in periods
+        assert "Oct-Mar" in periods
+
+    def test_historical_coverage_from_2018(self, df: pd.DataFrame) -> None:
+        years = set(df["year"].unique())
+        assert any(y.startswith("2018") for y in years), f"No 2018/19 data in: {sorted(years)}"
+
+    def test_no_negative_presentations(self, df: pd.DataFrame) -> None:
+        assert (df["presentations"].dropna() >= 0).all()
+
+    def test_ni_total_apr_sep_2025_anchor(self, df: pd.DataFrame) -> None:
+        """NI total Apr–Sep 2025 presentations should be ~8,217."""
+        ni_row = df[(df["lgd"] == "Northern Ireland") & (df["year"] == "2025/26") & (df["period"] == "Apr-Sep")]
+        if ni_row.empty:
+            pytest.skip("Apr–Sep 2025/26 data not present")
+        count = ni_row["presentations"].iloc[0]
+        assert abs(count - _NI_APR_SEP_2025_PRESENTATIONS) / _NI_APR_SEP_2025_PRESENTATIONS <= _ANCHOR_TOLERANCE, (
+            f"NI presentations {count:,} not within 5% of expected {_NI_APR_SEP_2025_PRESENTATIONS:,}"
+        )
+
+    def test_belfast_is_largest_lgd(self, df: pd.DataFrame) -> None:
+        """Belfast should have the highest presentations among individual LGDs."""
+        lgd_only = df[df["lgd"] != "Northern Ireland"]
+        by_lgd = lgd_only.groupby("lgd")["presentations"].sum()
+        if by_lgd.empty:
+            pytest.skip("No LGD data")
+        assert by_lgd.idxmax() == "Belfast", f"Expected Belfast largest, got {by_lgd.idxmax()}"
+
+    def test_validation_passes(self, df: pd.DataFrame) -> None:
+        assert homelessness.validate_data(df, section="presentations") is True
+
+
+class TestAcceptancesIntegrity:
+    """Integrity tests for homelessness acceptances data."""
+
+    @pytest.fixture(scope="class")
+    def df(self) -> pd.DataFrame:
+        return homelessness.get_latest_data(section="acceptances")
+
+    def test_returns_dataframe(self, df: pd.DataFrame) -> None:
+        assert isinstance(df, pd.DataFrame)
+        assert not df.empty
+
+    def test_required_columns(self, df: pd.DataFrame) -> None:
+        assert {"year", "period", "lgd", "acceptances", "rate_per_1000"}.issubset(set(df.columns))
+
+    def test_ni_total_present(self, df: pd.DataFrame) -> None:
+        assert "Northern Ireland" in df["lgd"].values
+
+    def test_no_negative_acceptances(self, df: pd.DataFrame) -> None:
+        assert (df["acceptances"].dropna() >= 0).all()
+
+    def test_ni_total_apr_sep_2025_anchor(self, df: pd.DataFrame) -> None:
+        """NI total Apr–Sep 2025 acceptances should be ~5,366."""
+        ni_row = df[(df["lgd"] == "Northern Ireland") & (df["year"] == "2025/26") & (df["period"] == "Apr-Sep")]
+        if ni_row.empty:
+            pytest.skip("Apr–Sep 2025/26 data not present")
+        count = ni_row["acceptances"].iloc[0]
+        assert abs(count - _NI_APR_SEP_2025_ACCEPTANCES) / _NI_APR_SEP_2025_ACCEPTANCES <= _ANCHOR_TOLERANCE, (
+            f"NI acceptances {count:,} not within 5% of expected {_NI_APR_SEP_2025_ACCEPTANCES:,}"
+        )
+
+    def test_acceptances_lte_presentations(self, df: pd.DataFrame) -> None:
+        """NI-level acceptances must not exceed presentations in any period."""
+        pres = homelessness.get_latest_data(section="presentations")
+        ni_pres = pres[pres["lgd"] == "Northern Ireland"].set_index(["year", "period"])["presentations"]
+        ni_acc = df[df["lgd"] == "Northern Ireland"].set_index(["year", "period"])["acceptances"]
+        shared = ni_pres.index.intersection(ni_acc.index)
+        for idx in shared:
+            assert ni_acc[idx] <= ni_pres[idx], (
+                f"{idx}: acceptances ({ni_acc[idx]:,}) > presentations ({ni_pres[idx]:,})"
+            )
+
+    def test_validation_passes(self, df: pd.DataFrame) -> None:
+        assert homelessness.validate_data(df, section="acceptances") is True
+
+
+class TestCombinedIntegrity:
+    """Integrity tests for section='all' combined output."""
+
+    @pytest.fixture(scope="class")
+    def df(self) -> pd.DataFrame:
+        return homelessness.get_latest_data(section="all")
+
+    def test_has_section_column(self, df: pd.DataFrame) -> None:
+        assert "section" in df.columns
+
+    def test_both_sections_present(self, df: pd.DataFrame) -> None:
+        assert set(df["section"].unique()) == {"presentations", "acceptances"}
+
+    def test_count_column_present(self, df: pd.DataFrame) -> None:
+        assert "count" in df.columns
+
+    def test_no_negative_counts(self, df: pd.DataFrame) -> None:
+        assert (df["count"].dropna() >= 0).all()
+
+
+class TestValidationEdgeCases:
+    """Unit tests for validate_data() edge cases — no network calls."""
+
+    def _make_base_df(self, section: str = "presentations") -> pd.DataFrame:
+        rows = []
+        lgds = list(_ELEVEN_LGDS) + ["Northern Ireland"]
+        for year in ("2023/24", "2024/25", "2025/26"):
+            for period in ("Apr-Sep", "Oct-Mar"):
+                for lgd in lgds:
+                    rows.append({"year": year, "period": period, "lgd": lgd, section: 500, "rate_per_1000": 1.5})
+        return pd.DataFrame(rows)
+
+    def test_validate_empty_dataframe(self) -> None:
+        with pytest.raises(NISRAValidationError, match="empty"):
+            homelessness.validate_data(pd.DataFrame())
+
+    def test_validate_none(self) -> None:
+        with pytest.raises(NISRAValidationError, match="empty"):
+            homelessness.validate_data(None)  # type: ignore[arg-type]
+
+    def test_validate_missing_columns(self) -> None:
+        df = self._make_base_df().drop(columns=["lgd"])
+        with pytest.raises(NISRAValidationError, match="Missing required columns"):
+            homelessness.validate_data(df)
+
+    def test_validate_too_few_rows(self) -> None:
+        df = self._make_base_df().head(3)
+        with pytest.raises(NISRAValidationError, match="Too few rows"):
+            homelessness.validate_data(df)
+
+    def test_validate_missing_ni_total(self) -> None:
+        df = self._make_base_df()
+        df = df[df["lgd"] != "Northern Ireland"].copy()
+        with pytest.raises(NISRAValidationError, match="Northern Ireland"):
+            homelessness.validate_data(df)
+
+    def test_validate_negative_values(self) -> None:
+        df = self._make_base_df()
+        df.loc[0, "presentations"] = -1
+        with pytest.raises(NISRAValidationError, match="Negative"):
+            homelessness.validate_data(df)
+
+    def test_validate_implausibly_low_ni_total(self) -> None:
+        df = self._make_base_df()
+        # Set all NI rows to 1 — well below the >1000 sanity threshold
+        df.loc[df["lgd"] == "Northern Ireland", "presentations"] = 1
+        with pytest.raises(NISRAValidationError, match="implausibly low"):
+            homelessness.validate_data(df)
+
+    def test_validate_invalid_section(self) -> None:
+        with pytest.raises(ValueError):
+            homelessness.get_latest_data(section="invalid")
+
+    def test_validate_passes_on_synthetic_data(self) -> None:
+        df = self._make_base_df()
+        # NI rows need to be > 1000 to pass the sanity check
+        df.loc[df["lgd"] == "Northern Ireland", "presentations"] = 5000
+        assert homelessness.validate_data(df, section="presentations") is True
+
+
+class TestNormalisePeriod:
+    """Unit tests for _normalise_period() — no network calls."""
+
+    def test_april_september(self) -> None:
+        assert homelessness._normalise_period("April-September") == "Apr-Sep"
+
+    def test_october_march(self) -> None:
+        assert homelessness._normalise_period("October-March") == "Oct-Mar"
+
+    def test_jul_dec(self) -> None:
+        assert homelessness._normalise_period("July-December") == "Jul-Dec"
+
+    def test_jan_jun(self) -> None:
+        assert homelessness._normalise_period("January-June") == "Jan-Jun"
+
+    def test_footnote_stripped(self) -> None:
+        assert homelessness._normalise_period("April-September¹") == "Apr-Sep"
+
+    def test_apr_jun_financial_year(self) -> None:
+        result = homelessness._normalise_period("Apr-Jun (Financial year Q1)")
+        assert result == "Apr-Jun"
+
+    def test_passthrough_unknown(self) -> None:
+        result = homelessness._normalise_period("Unknown Period")
+        assert result == "Unknown Period"

--- a/tests/test_nisra_homelessness_integrity.py
+++ b/tests/test_nisra_homelessness_integrity.py
@@ -11,6 +11,8 @@ Coverage: biannual (Apr–Sep and Oct–Mar), 2018/19 to present.
 
 from __future__ import annotations
 
+import re
+
 import pandas as pd
 import pytest
 
@@ -100,6 +102,10 @@ class TestAcceptancesIntegrity:
     def df(self) -> pd.DataFrame:
         return homelessness.get_latest_data(section="acceptances")
 
+    @pytest.fixture(scope="class")
+    def presentations_df(self) -> pd.DataFrame:
+        return homelessness.get_latest_data(section="presentations")
+
     def test_returns_dataframe(self, df: pd.DataFrame) -> None:
         assert isinstance(df, pd.DataFrame)
         assert not df.empty
@@ -123,10 +129,11 @@ class TestAcceptancesIntegrity:
             f"NI acceptances {count:,} not within 5% of expected {_NI_APR_SEP_2025_ACCEPTANCES:,}"
         )
 
-    def test_acceptances_lte_presentations(self, df: pd.DataFrame) -> None:
+    def test_acceptances_lte_presentations(self, df: pd.DataFrame, presentations_df: pd.DataFrame) -> None:
         """NI-level acceptances must not exceed presentations in any period."""
-        pres = homelessness.get_latest_data(section="presentations")
-        ni_pres = pres[pres["lgd"] == "Northern Ireland"].set_index(["year", "period"])["presentations"]
+        ni_pres = presentations_df[presentations_df["lgd"] == "Northern Ireland"].set_index(["year", "period"])[
+            "presentations"
+        ]
         ni_acc = df[df["lgd"] == "Northern Ireland"].set_index(["year", "period"])["acceptances"]
         shared = ni_pres.index.intersection(ni_acc.index)
         for idx in shared:
@@ -156,6 +163,44 @@ class TestCombinedIntegrity:
 
     def test_no_negative_counts(self, df: pd.DataFrame) -> None:
         assert (df["count"].dropna() >= 0).all()
+
+
+class TestHousingStockCrossValidation:
+    """Cross-validate homelessness rates against housing stock data."""
+
+    @pytest.fixture(scope="class")
+    def presentations(self) -> pd.DataFrame:
+        return homelessness.get_latest_data(section="presentations")
+
+    @pytest.fixture(scope="class")
+    def housing_stock_df(self) -> pd.DataFrame:
+        from bolster.data_sources.nisra import housing_stock
+
+        return housing_stock.get_latest_housing_stock(geo="lgd")
+
+    def test_presentations_per_1000_dwellings_plausible(
+        self, presentations: pd.DataFrame, housing_stock_df: pd.DataFrame
+    ) -> None:
+        """NI total presentations-per-1000-dwellings should be in [5, 50] for each overlapping year."""
+
+        def _first_year(y: str) -> int | None:
+            m = re.match(r"(\d{4})", y)
+            return int(m.group(1)) if m else None
+
+        ni_pres = presentations[presentations["lgd"] == "Northern Ireland"].copy()
+        ni_pres["stock_year"] = ni_pres["year"].map(_first_year)
+        ni_annual = ni_pres.groupby("stock_year")["presentations"].sum()
+
+        ni_hs = housing_stock_df[housing_stock_df["lgd_name"] == "Northern Ireland"].set_index("year")["total"]
+
+        shared_years = ni_annual.index.intersection(ni_hs.index)
+        assert len(shared_years) >= 3, f"Too few overlapping years: {sorted(shared_years)}"
+
+        for yr in shared_years:
+            rate = ni_annual[yr] / ni_hs[yr] * 1000
+            assert 5 <= rate <= 50, (
+                f"Year {yr}: presentations-per-1000-dwellings={rate:.1f} outside expected 5–50 range"
+            )
 
 
 class TestValidationEdgeCases:


### PR DESCRIPTION
## Summary

Implements the NI Homelessness Bulletin data module from the Department for Communities NI (DfC) / Northern Ireland Housing Executive (NIHE), covering biannual homeless presentations and acceptances by Local Government District.

- **Module**: `bolster.data_sources.nisra.homelessness`
- **CLI**: `bolster nisra homelessness [--section presentations|acceptances|all]`
- **Coverage**: 2018/19–present; Apr–Sep and Oct–Mar periods; 11 LGDs + NI total
- **Source**: Excel workbooks scraped from the DfC hub page; fallback URL hardcoded

## Key insights from the data

### Demand is flat despite rising prices
Presentations per 1,000 dwellings have stayed in a narrow 9–12 band since 2018/19, despite housing stock growing 6.5% (790k → 841k) and average house prices rising 54% (£125k → £193k). Homelessness presentations at this scale appear driven by household need and social services capacity rather than market conditions.

### COVID acceptance rate drop is the clearest structural signal
Acceptance rate fell from ~70% in 2018/19 to 60.5% in Jan–Jun 2020 (first lockdown half), recovered to 63–65% by 2021–22, and has since stabilised at ~67% — still below pre-COVID levels, suggesting NIHE tightened priority thresholds under emergency conditions and hasn't fully unwound them.

### Belfast is structurally dominant
Belfast accounts for 30.4% of all NI presentations despite ~19% of the population (~1.6× overrepresented). Derry City & Strabane is second at 12%. The two most rural LGDs (Fermanagh & Omagh, Mid Ulster) contribute least, consistent with population density rather than a housing market story.

### Cross-link with NIMDM 2017 deprivation: crime disorder is the strongest predictor
Correlating homelessness presentation rates (per 1,000 population) against LGD-level deprivation aggregates from `nisra.deprivation`:

| Deprivation domain | r vs presentation rate |
|---|---|
| % SOAs in most deprived quintile (overall MDM) | +0.78 |
| Mean crime & disorder rank | −0.87 (strongest) |
| Mean health & disability rank | −0.55 |
| Mean employment rank | −0.48 |
| % urban SOAs | +0.83 |
| Mean income rank | +0.06 (near zero) |

Income deprivation explains almost nothing at LGD scale once geography is accounted for. Crime disorder deprivation — a proxy for social instability and neighbourhood breakdown — is the strongest domain predictor, ahead of health and employment. This points toward tenancy sustainment and community stability interventions rather than income support as the more relevant policy lever (though n=11 LGDs is a thin basis for confident causal inference, and the NIMDM is 2017 data cross-linked with 2018–2025 homelessness figures).

**Mid and East Antrim** is a persistent outlier: only 12% of its SOAs fall in the most deprived quintile, but it runs 0.4–0.7 per 1,000 *above* the NI average in nearly every period — unexplained by the 2017 deprivation domains.

## Implementation notes

- Not in PxStat; Excel-only from `communities-ni.gov.uk`
- Composite merged-cell headers in sheets `1_3` and `2_3` require forward-fill to reconstruct year/period labels
- Footnote digits appended to year range strings (`"2023/242"` → `"2023/24"`) stripped via targeted regex
- Reporting period structure changes between 2018/19 and 2019–2023 (Apr–Sep/Oct–Mar → Apr–Jun/Jul–Dec), making naive annual aggregation misleading; period-level analysis recommended
- 91.5% coverage on new module (uncovered lines are error-path fallbacks in URL scraping)

## Usage

```python
from bolster.data_sources.nisra import homelessness

df = homelessness.get_latest_data(section="presentations")
# year, period, lgd, presentations, rate_per_1000

df_all = homelessness.get_latest_data(section="all")
# year, period, lgd, count, rate_per_1000, section
```

```bash
bolster nisra homelessness
bolster nisra homelessness --section acceptances
bolster nisra homelessness --section all --format json --save homelessness.json
```

Closes #1922