### PR TITLE
refactor: consolidate _hash_url duplicates onto bolster.utils.cache.hash_url

### DIFF
--- a/src/bolster/data_sources/dva.py
+++ b/src/bolster/data_sources/dva.py
@@ -57,6 +57,7 @@ from pathlib import Path
 import pandas as pd
 from bs4 import BeautifulSoup
 
+from bolster.utils.cache import hash_url
 from bolster.utils.web import session
 
 logger = logging.getLogger(__name__)
@@ -82,13 +83,6 @@ class DVADataNotFoundError(DVADataError):
     pass
 
 
-def _hash_url(url: str) -> str:
-    """Generate a safe filename from a URL."""
-    import hashlib
-
-    return hashlib.md5(url.encode(), usedforsecurity=False).hexdigest()
-
-
 def _download_file(url: str, cache_ttl_hours: int = 24, force_refresh: bool = False) -> Path:
     """Download a file with caching support.
 
@@ -103,7 +97,7 @@ def _download_file(url: str, cache_ttl_hours: int = 24, force_refresh: bool = Fa
     Raises:
         DVADataNotFoundError: If download fails
     """
-    url_hash = _hash_url(url)
+    url_hash = hash_url(url)
     ext = Path(url).suffix or ".xlsx"
     cache_path = CACHE_DIR / f"{url_hash}{ext}"
 

--- a/src/bolster/data_sources/education_suspensions.py
+++ b/src/bolster/data_sources/education_suspensions.py
@@ -32,7 +32,6 @@ Example:
     True
 """
 
-import hashlib
 import logging
 from pathlib import Path
 from urllib.parse import urljoin
@@ -40,6 +39,7 @@ from urllib.parse import urljoin
 import bs4
 import pandas as pd
 
+from bolster.utils.cache import hash_url
 from bolster.utils.web import session
 
 logger = logging.getLogger(__name__)
@@ -77,13 +77,9 @@ class EducationSuspensionsParseError(EducationSuspensionsError):
 # ---------------------------------------------------------------------------
 
 
-def _hash_url(url: str) -> str:
-    return hashlib.md5(url.encode(), usedforsecurity=False).hexdigest()
-
-
 def _cached_file(url: str) -> Path | None:
     """Return path to a cached copy of *url* if it exists and is fresh."""
-    url_hash = _hash_url(url)
+    url_hash = hash_url(url)
     ext = Path(url.split("?")[0]).suffix or ".xlsx"
     cache_path = CACHE_DIR / f"{url_hash}{ext}"
     if cache_path.exists():
@@ -103,7 +99,7 @@ def _download_file(url: str, force_refresh: bool = False) -> Path:
         if cached:
             return cached
 
-    url_hash = _hash_url(url)
+    url_hash = hash_url(url)
     ext = Path(url.split("?")[0]).suffix or ".xlsx"
     cache_path = CACHE_DIR / f"{url_hash}{ext}"
 

--- a/src/bolster/data_sources/ni_house_price_index.py
+++ b/src/bolster/data_sources/ni_house_price_index.py
@@ -30,7 +30,6 @@ Example:
     True
 """
 
-import hashlib
 import logging
 import re
 import warnings
@@ -42,6 +41,7 @@ from urllib.parse import urlparse
 import bs4
 import pandas as pd
 
+from bolster.utils.cache import hash_url
 from bolster.utils.web import session
 
 logger = logging.getLogger(__name__)
@@ -69,11 +69,6 @@ class NIHPIDataNotFoundError(NIHPIDataError):
     pass
 
 
-def _hash_url(url: str) -> str:
-    """Generate a safe filename from a URL."""
-    return hashlib.md5(url.encode(), usedforsecurity=False).hexdigest()
-
-
 def _get_cached_file(url: str, cache_ttl_hours: int = 24) -> Path | None:
     """Return cached file if exists and fresh, else None.
 
@@ -84,7 +79,7 @@ def _get_cached_file(url: str, cache_ttl_hours: int = 24) -> Path | None:
     Returns:
         Path to cached file if valid, None otherwise
     """
-    url_hash = _hash_url(url)
+    url_hash = hash_url(url)
     ext = Path(url).suffix or ".xlsx"
     cache_path = CACHE_DIR / f"{url_hash}{ext}"
 
@@ -116,7 +111,7 @@ def _download_file(url: str, cache_ttl_hours: int = 24, force_refresh: bool = Fa
         if cached:
             return cached
 
-    url_hash = _hash_url(url)
+    url_hash = hash_url(url)
     ext = Path(url).suffix or ".xlsx"
     cache_path = CACHE_DIR / f"{url_hash}{ext}"
 


### PR DESCRIPTION
## Summary

- `dva.py`, `education_suspensions.py`, and `ni_house_price_index.py` each had an identical local `_hash_url` helper (MD5 hex digest of URL, `usedforsecurity=False`)
- Replaced all three with the existing `hash_url` from `bolster.utils.cache`, removing ~15 lines of duplication
- No behaviour change — the shared function is identical

Identified in maintenance review #1989.