### PR TITLE
feat(justice): NICTS quarterly court business figures

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ The [GOV.UK NISRA statistics RSS feed](https://www.gov.uk/search/research-and-st
 | Baby Names NI (annual, 1997–present) | `nisra.baby_names` | ✅ |
 | NI School Suspensions (DE) | `education_suspensions` | ✅ |
 | NICTS Mortgages Action for Possession (DoJ) | `justice.mortgages` | ✅ |
+| NICTS Quarterly Court Business Figures (DoJ) | `justice.nicts_quarterly` | ✅ |
 | Work Quality NI (NISRA) | `nisra.work_quality` | ✅ |
 | NI LAC Municipal Waste Statistics (DAERA) | `daera_waste` | ✅ |
 | NI Electricity Consumption & Renewable Generation (DfE) | `electricity_renewables` | ✅ |

--- a/docs/data_sources.rst
+++ b/docs/data_sources.rst
@@ -723,18 +723,48 @@ NI Courts and Tribunals Service (NICTS) statistics.
 Mortgage Possession Actions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Quarterly mortgage possession actions (applications, orders, and warrants) by
-court district.
+Quarterly mortgage possession proceedings in the Chancery Division of the NI
+High Court: cases received, cases disposed, and the final orders made.
 
 .. code-block:: python
 
-    from bolster.data_sources import justice
+    from bolster.data_sources.justice import mortgages
 
-    df = justice.get_latest_mortgage_possession_actions()
+    tables = mortgages.get_latest_data()
+    received = tables["received"]
 
 .. code-block:: console
 
-    $ bolster justice mortgage-possession
+    $ bolster justice mortgages
+    $ bolster justice mortgages --table disposed
+
+Quarterly Court Business Figures
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Provisional case receipts, disposals, and outstanding workload across all ten
+NICTS court datasets — Court of Appeal (criminal and civil), the three High
+Court divisions, Crown, County, Magistrates', Children Order proceedings, and
+judicial sitting days. Annual totals from 2017 plus quarterly figures for the
+most recent years, returned as a single tidy long frame.
+
+.. code-block:: python
+
+    from bolster.data_sources.justice import nicts_quarterly
+
+    # Every court, every period
+    df = nicts_quarterly.get_latest_data()
+
+    # A single court
+    crown = nicts_quarterly.get_crown_court()
+
+    # What court keys are available?
+    nicts_quarterly.list_courts()
+
+.. code-block:: console
+
+    $ bolster justice nicts-quarterly --list-courts
+    $ bolster justice nicts-quarterly --court crown_court
+    $ bolster justice nicts-quarterly --annual --format json
 
 ----
 

--- a/src/bolster/cli.py
+++ b/src/bolster/cli.py
@@ -24,6 +24,7 @@ from .data_sources.health_ni import diagnostic_waiting_times as nisra_diagnostic
 from .data_sources.health_ni import disease_prevalence as nisra_disease_prevalence
 from .data_sources.health_ni import emergency_care_waiting_times as nisra_emergency
 from .data_sources.justice import mortgages as justice_mortgages
+from .data_sources.justice import nicts_quarterly as justice_nicts_quarterly
 from .data_sources.metoffice import get_uk_precipitation
 from .data_sources.ni_house_price_index import build as get_ni_house_prices
 from .data_sources.ni_water import get_postcode_to_water_supply_zone, get_water_quality_by_zone
@@ -7160,7 +7161,8 @@ def justice():
     """NI Department of Justice / NICTS statistics.
 
     Access official justice statistics from the Northern Ireland Courts and
-    Tribunals Service (NICTS), including mortgage actions for possession.
+    Tribunals Service (NICTS), including quarterly court business figures and
+    mortgage actions for possession.
     """
     pass
 
@@ -7236,6 +7238,127 @@ def justice_mortgages_cmd(table, output_format, force_refresh, save, summary):
             console.print(f"   Coverage: {int(data['year'].min())}-{int(data['year'].max())}")
             console.print(f"   Peak year: {peak_year} ({int(annual.max()):,} applications)")
             console.print(f"   Latest complete annual total: {int(annual.iloc[-1]):,} ({int(annual.index[-1])})")
+            if not save:
+                return
+
+        if save:
+            try:
+                if output_format == "json" or save.endswith(".json"):
+                    data.astype(str).to_json(save, orient="records", indent=2)
+                else:
+                    data.to_csv(save, index=False)
+                console.print(f"[green]Saved to: {save}[/green]")
+                return
+            except PermissionError:
+                console.print(f"[red]Error: Permission denied writing to {save}[/red]")
+                return
+            except Exception as e:
+                console.print(f"[red]Error saving file: {e}[/red]")
+                return
+
+        if output_format == "json":
+            click.echo(data.astype(str).to_json(orient="records", indent=2))
+        else:
+            console.print(data.to_csv(index=False), end="")
+
+    except Exception as e:
+        console.print(f"[bold red]Error:[/bold red] {str(e)}", style="red")
+        console.print("\n[yellow]Troubleshooting:[/yellow]")
+        console.print("   - Check your internet connection")
+        console.print("   - Try again with --force-refresh to bypass cache")
+        raise click.Abort() from e
+
+
+@justice.command(name="nicts-quarterly")
+@click.option(
+    "--court",
+    default="all",
+    help="Court dataset key, or 'all' (default). Use --list-courts to see the options.",
+)
+@click.option("--list-courts", is_flag=True, help="List available court dataset keys and exit")
+@click.option("--year", type=int, help="Filter to a single calendar year")
+@click.option("--quarter", type=int, help="Filter to a single quarter (1-4); excludes annual totals")
+@click.option("--annual", is_flag=True, help="Show annual totals only, excluding quarterly rows")
+@click.option(
+    "--format",
+    "output_format",
+    type=click.Choice(["csv", "json"], case_sensitive=False),
+    default="csv",
+    help="Output format (default: csv)",
+)
+@click.option("--force-refresh", is_flag=True, help="Force re-download even if cached")
+@click.option("--save", help="Save data to file (specify filename)")
+@click.option("--summary", is_flag=True, help="Show summary statistics instead of full data")
+def justice_nicts_quarterly_cmd(court, list_courts, year, quarter, annual, output_format, force_refresh, save, summary):
+    r"""NICTS quarterly provisional court business figures.
+
+    \b
+    Case receipts, disposals and outstanding workload across all ten NICTS
+    court datasets — Court of Appeal (criminal and civil), the three High
+    Court divisions, Crown, County, Magistrates', Children Order proceedings,
+    and judicial sitting days. Annual totals from 2017 plus quarterly figures
+    for the most recent years.
+
+    Examples:
+        Every court, every period::
+
+            bolster justice nicts-quarterly
+
+        See which court keys are available::
+
+            bolster justice nicts-quarterly --list-courts
+
+        Crown Court only::
+
+            bolster justice nicts-quarterly --court crown_court
+
+        Magistrates' Courts, most recent full year::
+
+            bolster justice nicts-quarterly --court magistrates_courts --year 2024
+
+        Annual totals as JSON::
+
+            bolster justice nicts-quarterly --annual --format json
+
+    Source:
+        https://www.justice-ni.gov.uk/publications/nicts-business-data
+    """
+    from rich.console import Console
+
+    console = Console()
+
+    try:
+        if list_courts:
+            with console.status("[bold green]Downloading NICTS quarterly data..."):
+                courts = justice_nicts_quarterly.list_courts(force_refresh=force_refresh)
+            console.print("[bold]Available courts:[/bold]")
+            for name in courts:
+                console.print(f"   {name}")
+            return
+
+        with console.status("[bold green]Downloading NICTS quarterly data..."):
+            data = justice_nicts_quarterly.get_latest_data(court=court, force_refresh=force_refresh)
+
+        if year is not None:
+            data = data[data["year"] == year]
+        if annual:
+            data = data[data["quarter"].isna()]
+        if quarter is not None:
+            data = data[data["quarter"] == quarter]
+
+        if data.empty:
+            console.print("[yellow]No data matches the requested filters[/yellow]")
+            return
+
+        console.print("[green]NICTS quarterly data retrieved successfully[/green]")
+        console.print(f"[cyan]Court: {court} | Rows: {len(data)}[/cyan]")
+
+        if summary:
+            console.print("\n[bold]Summary:[/bold]")
+            console.print(f"   Coverage: {int(data['year'].min())}-{int(data['year'].max())}")
+            console.print(f"   Courts: {data['court'].nunique()}")
+            console.print(f"   Categories: {data['category'].nunique()}")
+            console.print(f"   Periods: {data['period'].nunique()}")
             if not save:
                 return
 

--- a/src/bolster/data_sources/justice/__init__.py
+++ b/src/bolster/data_sources/justice/__init__.py
@@ -5,6 +5,8 @@ and the Northern Ireland Courts and Tribunals Service (NICTS):
 
 - mortgages: Mortgage actions for possession (cases received, disposed, and
   final orders made in the Chancery Division of the NI High Court).
+- nicts_quarterly: Quarterly provisional court business figures across all ten
+  NICTS court datasets, from the Court of Appeal to the Magistrates' Courts.
 
 Most have corresponding CLI commands under ``bolster justice ...``.
 """

--- a/src/bolster/data_sources/justice/nicts_quarterly.py
+++ b/src/bolster/data_sources/justice/nicts_quarterly.py
@@ -1,0 +1,600 @@
+"""NICTS Quarterly Provisional Figures.
+
+Provides access to the Northern Ireland Courts and Tribunals Service (NICTS)
+quarterly business statistics, covering caseload across every tier of the NI
+court system: receipts, disposals, waiting times, and judicial sitting days.
+
+Ten court datasets are published in a single ODS workbook, one worksheet each:
+
+- ``court_of_appeal_criminal`` - criminal appeals by type and result.
+- ``court_of_appeal_civil`` - civil appeals received and disposed.
+- ``high_court_chancery_division`` - Chancery business (incl. mortgages).
+- ``high_court_kings_bench_division`` - King's Bench writs and outcomes.
+- ``high_court_family_division`` - divorce, ancillary relief, and wardship.
+- ``crown_court`` - Crown Court cases and defendants.
+- ``county_court`` - County Court civil, family, and appeal business.
+- ``magistrates_courts`` - Magistrates' Court criminal and civil business.
+- ``children_order`` - public and private law Children Order proceedings.
+- ``judge_court_sitting_days`` - sitting days and average sitting times.
+
+Every worksheet shares the same period columns, so all ten concatenate into a
+single tidy frame. Each row is one (court, category, subcategory, detail,
+period) observation.
+
+Data Source:
+    **Publication Page**:
+    https://www.justice-ni.gov.uk/publications/nicts-business-data
+
+    The module scrapes this page for quarterly ODS bulletins
+    (``nicts-quarterly-provisional-figures-<months>-<year>.ods``) and selects
+    the most recent. Each bulletin carries the full series from 2017, so a
+    single download gives complete history.
+
+Update Frequency: Quarterly
+Geographic Coverage: Northern Ireland
+Reference Period: 2017 - present (annual totals to 2024, quarterly thereafter)
+
+.. note::
+    These are *provisional* figures and are revised in later bulletins. The
+    frame mixes annual totals (``2024 Total``) and quarters (``2025 Q1``) in
+    the same ``period`` column — filter on ``quarter.isna()`` to separate them,
+    or summing across periods will double-count.
+
+Example:
+    >>> from bolster.data_sources.justice import nicts_quarterly
+    >>> df = nicts_quarterly.get_crown_court()
+    >>> set(df["court"]) == {"crown_court"}
+    True
+    >>> "value" in df.columns
+    True
+"""
+
+import logging
+import re
+from pathlib import Path
+from urllib.parse import unquote, urljoin
+
+import bs4
+import pandas as pd
+from odf.opendocument import load as load_ods
+from odf.table import Table, TableCell, TableRow
+from odf.text import P
+
+from bolster.utils.cache import CachedDownloader, DownloadError
+from bolster.utils.web import session
+
+logger = logging.getLogger(__name__)
+
+# Publication landing page listing every quarterly bulletin
+PUBLICATION_URL = "https://www.justice-ni.gov.uk/publications/nicts-business-data"
+
+# Worksheets that carry front matter rather than court business data
+_NON_DATA_SHEETS = {"cover_sheet", "contents", "notes"}
+
+# Period column headers look like "2024 Total" or "2025 Q1"
+_PERIOD_RE = re.compile(r"^(\d{4})\s+(Total|Q[1-4])$")
+
+# Bulletin filenames encode their reporting quarter as a month range
+_FILENAME_PERIOD_RE = re.compile(r"(january|april|july|october)\s*to\s*(march|june|september|december)\D{0,4}(\d{4})")
+_MONTH_TO_QUARTER = {"january": 1, "april": 2, "july": 3, "october": 4}
+
+# Suppression markers used in place of a value
+_SUPPRESSED = {"", "-", "N/A", "n/a", "[z]", "[c]", "[x]", ":"}
+
+# Durations are published as HH:MM and can exceed 24 hours
+_DURATION_RE = re.compile(r"^(\d+):([0-5]\d)$")
+
+# Footnote references embedded in labels, e.g. "Total [note 3]"
+_NOTE_REF_RE = re.compile(r"\s*[\[{]note \d+[\]}]", re.IGNORECASE)
+
+# Cell repetition attributes can run to thousands for trailing filler
+_MAX_REPEAT = 60
+
+# Bulletins are provisional but only republished quarterly
+_CACHE_TTL_HOURS = 24 * 90
+
+_downloader = CachedDownloader("nicts_quarterly", timeout=60)
+
+
+class NICTSDataError(Exception):
+    """Base exception for NICTS quarterly figures errors."""
+
+    pass
+
+
+class NICTSDataNotFoundError(NICTSDataError):
+    """Raised when the bulletin cannot be located or downloaded."""
+
+    pass
+
+
+class NICTSValidationError(NICTSDataError):
+    """Raised when parsed data fails validation."""
+
+    pass
+
+
+def _normalise_sheet_name(name: str) -> str:
+    """Convert an ODS worksheet name into a stable court key.
+
+    Worksheet names carry incidental punctuation that varies between bulletins
+    (``Court_of_Appeal__Criminal``, ``Magistrates'_Courts``), so they are
+    lowercased and reduced to single underscores.
+
+    Args:
+        name: Raw worksheet name from the workbook.
+
+    Returns:
+        Normalised key, e.g. ``magistrates_courts``.
+
+    Example:
+        >>> _normalise_sheet_name("Court_of_Appeal__Criminal")
+        'court_of_appeal_criminal'
+        >>> _normalise_sheet_name("Magistrates'_Courts")
+        'magistrates_courts'
+    """
+    return re.sub(r"_+", "_", re.sub(r"[^a-z0-9]+", "_", name.lower())).strip("_")
+
+
+def _strip_note_refs(text: str) -> str:
+    """Remove ``[note N]`` footnote markers from a label.
+
+    Example:
+        >>> _strip_note_refs("Total [note 3] [note 32]")
+        'Total'
+    """
+    return _NOTE_REF_RE.sub("", text).strip()
+
+
+def _parse_value(text: str) -> float:
+    """Convert a raw cell string into a numeric value.
+
+    Handles the four shapes NICTS publishes: comma-grouped integers, plain
+    decimals, ``HH:MM`` durations (converted to fractional hours, and which may
+    exceed 24 hours), and suppression markers such as ``[z]`` or ``N/A``.
+
+    Args:
+        text: Raw cell text.
+
+    Returns:
+        The numeric value, or NaN when suppressed or unparseable.
+
+    Example:
+        >>> _parse_value("1,234")
+        1234.0
+        >>> _parse_value("6485:30")
+        6485.5
+        >>> import math
+        >>> math.isnan(_parse_value("[z]"))
+        True
+    """
+    text = text.strip()
+    if text in _SUPPRESSED:
+        return float("nan")
+
+    duration = _DURATION_RE.match(text)
+    if duration:
+        return int(duration.group(1)) + int(duration.group(2)) / 60
+
+    try:
+        return float(text.replace(",", ""))
+    except ValueError:
+        return float("nan")
+
+
+def _parse_period(label: str) -> tuple[int, int | None] | None:
+    """Parse a period column header into (year, quarter).
+
+    Args:
+        label: Column header, e.g. ``"2024 Total"`` or ``"2025 Q1"``.
+
+    Returns:
+        Tuple of (year, quarter) with quarter ``None`` for annual totals, or
+        ``None`` if the label is not a period.
+
+    Example:
+        >>> _parse_period("2025 Q3")
+        (2025, 3)
+        >>> _parse_period("2024 Total")
+        (2024, None)
+        >>> _parse_period("Business Area") is None
+        True
+    """
+    match = _PERIOD_RE.match(label.strip())
+    if not match:
+        return None
+    year = int(match.group(1))
+    marker = match.group(2)
+    return year, None if marker == "Total" else int(marker[1])
+
+
+def _sheet_rows(table: Table) -> list[list[str]]:
+    """Extract a worksheet as a list of raw text rows.
+
+    pandas' ODF reader coerces time-typed cells via :class:`pandas.Timestamp`,
+    which fails on NICTS sitting-time durations over 24 hours. Reading the
+    underlying cell text directly sidesteps that entirely.
+
+    Args:
+        table: ODF table element.
+
+    Returns:
+        List of rows, each a list of cell strings, with trailing blanks removed.
+    """
+    rows: list[list[str]] = []
+    for row in table.getElementsByType(TableRow):
+        row_repeat = min(int(row.getAttribute("numberrowsrepeated") or 1), _MAX_REPEAT)
+        cells: list[str] = []
+        for cell in row.getElementsByType(TableCell):
+            col_repeat = min(int(cell.getAttribute("numbercolumnsrepeated") or 1), _MAX_REPEAT)
+            text = " ".join(str(p) for p in cell.getElementsByType(P))
+            cells.extend([text] * col_repeat)
+        while cells and not cells[-1].strip():
+            cells.pop()
+        if not cells:
+            continue
+        for _ in range(row_repeat):
+            rows.append(list(cells))
+    return rows
+
+
+def _parse_sheet(court: str, rows: list[list[str]]) -> pd.DataFrame:
+    """Reshape one court worksheet into tidy long format.
+
+    Each sheet has two or three label columns followed by the shared period
+    columns. The label columns are mapped onto ``category`` / ``subcategory`` /
+    ``detail``; two-label sheets leave ``detail`` empty.
+
+    Args:
+        court: Normalised court key.
+        rows: Raw text rows from :func:`_sheet_rows`.
+
+    Returns:
+        DataFrame with columns court, category, subcategory, detail, period,
+        year, quarter, value. Empty if no header row is found.
+    """
+    header_idx = None
+    for idx, row in enumerate(rows[:10]):
+        if any(_parse_period(cell) for cell in row):
+            header_idx = idx
+            break
+    if header_idx is None:
+        logger.warning(f"No period header found in sheet {court}; skipping")
+        return pd.DataFrame()
+
+    header = rows[header_idx]
+    periods = [(col_idx, cell.strip(), _parse_period(cell)) for col_idx, cell in enumerate(header)]
+    periods = [(col_idx, label, parsed) for col_idx, label, parsed in periods if parsed]
+    n_labels = periods[0][0]
+
+    records = []
+    for row in rows[header_idx + 1 :]:
+        labels = [_strip_note_refs(cell) for cell in row[:n_labels]]
+        if not any(labels):
+            continue
+        labels += [""] * (3 - len(labels))
+
+        for col_idx, label, parsed in periods:
+            year, quarter = parsed
+            records.append(
+                {
+                    "court": court,
+                    "category": labels[0] or None,
+                    "subcategory": labels[1] or None,
+                    "detail": labels[2] or None,
+                    "period": label,
+                    "year": year,
+                    "quarter": quarter,
+                    "value": _parse_value(row[col_idx]) if col_idx < len(row) else float("nan"),
+                }
+            )
+
+    df = pd.DataFrame.from_records(records)
+    if not df.empty:
+        df["quarter"] = df["quarter"].astype("Int64")
+    return df
+
+
+def list_publications(base_url: str = PUBLICATION_URL) -> list[dict]:
+    """List every quarterly bulletin linked from the publication page.
+
+    Args:
+        base_url: URL of the NICTS business data listing page.
+
+    Returns:
+        List of dicts with ``url``, ``year`` and ``quarter``, newest first.
+
+    Raises:
+        NICTSDataNotFoundError: If the page cannot be fetched or no bulletins
+            are found.
+
+    Example:
+        >>> pubs = list_publications()
+        >>> pubs[0]["url"].endswith(".ods")
+        True
+        >>> pubs[0]["year"] >= pubs[-1]["year"]
+        True
+    """
+    try:
+        response = session.get(base_url, timeout=30)
+        response.raise_for_status()
+    except Exception as e:
+        raise NICTSDataNotFoundError(f"Failed to fetch publication page {base_url}: {e}") from e
+
+    soup = bs4.BeautifulSoup(response.content, features="html.parser")
+
+    publications: dict[str, dict] = {}
+    for anchor in soup.find_all("a", href=True):
+        href = anchor["href"]
+        if not href.lower().endswith(".ods"):
+            continue
+        url = urljoin(base_url, href)
+        slug = re.sub(r"[^a-z0-9]+", " ", unquote(url).lower())
+        match = _FILENAME_PERIOD_RE.search(slug)
+        if not match:
+            continue
+        publications[url] = {
+            "url": url,
+            "year": int(match.group(3)),
+            "quarter": _MONTH_TO_QUARTER[match.group(1)],
+        }
+
+    if not publications:
+        raise NICTSDataNotFoundError(f"No quarterly bulletins found on {base_url}")
+
+    return sorted(publications.values(), key=lambda p: (p["year"], p["quarter"]), reverse=True)
+
+
+def find_latest_publication(base_url: str = PUBLICATION_URL) -> dict:
+    """Find the most recent quarterly bulletin.
+
+    Args:
+        base_url: URL of the NICTS business data listing page.
+
+    Returns:
+        Dict with ``url``, ``year`` and ``quarter`` for the newest bulletin.
+
+    Raises:
+        NICTSDataNotFoundError: If no bulletin can be located.
+
+    Example:
+        >>> latest = find_latest_publication()
+        >>> 1 <= latest["quarter"] <= 4
+        True
+    """
+    latest = list_publications(base_url)[0]
+    logger.info(f"Latest NICTS bulletin: {latest['year']} Q{latest['quarter']} ({latest['url']})")
+    return latest
+
+
+def download_file(url: str, cache_ttl_hours: int = _CACHE_TTL_HOURS, force_refresh: bool = False) -> Path:
+    """Download a bulletin ODS file with caching.
+
+    Args:
+        url: URL of the ODS file.
+        cache_ttl_hours: Cache validity in hours (default: 90 days).
+        force_refresh: If True, bypass the cache and re-download.
+
+    Returns:
+        Path to the downloaded (or cached) file.
+
+    Raises:
+        NICTSDataNotFoundError: If the download fails.
+    """
+    try:
+        return _downloader.download(url, cache_ttl_hours=cache_ttl_hours, force_refresh=force_refresh)
+    except DownloadError as e:
+        raise NICTSDataNotFoundError(str(e)) from e
+
+
+def parse_data(file_path: Path) -> pd.DataFrame:
+    """Parse every court worksheet from a bulletin into one tidy frame.
+
+    Args:
+        file_path: Path to the ODS bulletin file.
+
+    Returns:
+        DataFrame with columns court, category, subcategory, detail, period,
+        year, quarter, value — all ten courts concatenated.
+
+    Raises:
+        NICTSDataError: If the workbook contains no parseable court data.
+    """
+    doc = load_ods(str(Path(file_path)))
+
+    frames = []
+    for table in doc.spreadsheet.getElementsByType(Table):
+        court = _normalise_sheet_name(table.getAttribute("name") or "")
+        if not court or court in _NON_DATA_SHEETS:
+            continue
+        frame = _parse_sheet(court, _sheet_rows(table))
+        if not frame.empty:
+            frames.append(frame)
+
+    if not frames:
+        raise NICTSDataError(f"No court worksheets found in {file_path}")
+
+    return pd.concat(frames, ignore_index=True)
+
+
+def get_latest_data(court: str = "all", force_refresh: bool = False) -> pd.DataFrame:
+    """Download and parse the latest quarterly bulletin.
+
+    Args:
+        court: Court key to return (see :func:`list_courts`), or ``"all"`` for
+            every court in one frame.
+        force_refresh: If True, bypass the cache and download fresh data.
+
+    Returns:
+        Tidy DataFrame with columns court, category, subcategory, detail,
+        period, year, quarter, value.
+
+    Raises:
+        NICTSDataNotFoundError: If ``court`` is not a known court key.
+
+    Example:
+        >>> df = get_latest_data("county_court")
+        >>> set(df["court"]) == {"county_court"}
+        True
+    """
+    latest = find_latest_publication()
+    df = parse_data(download_file(latest["url"], force_refresh=force_refresh))
+
+    if court == "all":
+        return df
+
+    available = sorted(df["court"].unique())
+    if court not in available:
+        raise NICTSDataNotFoundError(f"Unknown court '{court}'. Available: {', '.join(available)}")
+
+    return df[df["court"] == court].reset_index(drop=True)
+
+
+def list_courts(force_refresh: bool = False) -> list[str]:
+    """List the court keys available in the latest bulletin.
+
+    Args:
+        force_refresh: If True, bypass the cache and download fresh data.
+
+    Returns:
+        Sorted list of court keys.
+
+    Example:
+        >>> "crown_court" in list_courts()
+        True
+    """
+    return sorted(get_latest_data(force_refresh=force_refresh)["court"].unique())
+
+
+def get_crown_court(force_refresh: bool = False) -> pd.DataFrame:
+    """Get Crown Court business (Table 6).
+
+    Args:
+        force_refresh: If True, bypass the cache and download fresh data.
+
+    Returns:
+        Tidy DataFrame of Crown Court receipts, disposals, and waiting times at
+        both case and defendant level.
+
+    Example:
+        >>> df = get_crown_court()
+        >>> "Received" in set(df["subcategory"])
+        True
+    """
+    return get_latest_data("crown_court", force_refresh=force_refresh)
+
+
+def get_magistrates_courts(force_refresh: bool = False) -> pd.DataFrame:
+    """Get Magistrates' Courts business (Table 8).
+
+    Args:
+        force_refresh: If True, bypass the cache and download fresh data.
+
+    Returns:
+        Tidy DataFrame of Magistrates' Court criminal and civil business.
+
+    Example:
+        >>> df = get_magistrates_courts()
+        >>> set(df["court"]) == {"magistrates_courts"}
+        True
+    """
+    return get_latest_data("magistrates_courts", force_refresh=force_refresh)
+
+
+def get_county_court(force_refresh: bool = False) -> pd.DataFrame:
+    """Get County Court business (Table 7).
+
+    Args:
+        force_refresh: If True, bypass the cache and download fresh data.
+
+    Returns:
+        Tidy DataFrame of County Court civil, family, and appeal business.
+
+    Example:
+        >>> df = get_county_court()
+        >>> set(df["court"]) == {"county_court"}
+        True
+    """
+    return get_latest_data("county_court", force_refresh=force_refresh)
+
+
+def get_sitting_days(force_refresh: bool = False) -> pd.DataFrame:
+    """Get judicial sitting days and average sitting times (Table 10).
+
+    Sitting *times* are reported as durations and are returned in fractional
+    hours, so a published ``6485:30`` becomes ``6485.5``.
+
+    Args:
+        force_refresh: If True, bypass the cache and download fresh data.
+
+    Returns:
+        Tidy DataFrame of sitting days and times by judge level and court type.
+
+    Example:
+        >>> df = get_sitting_days()
+        >>> "Total Sitting Days" in set(df["category"])
+        True
+    """
+    return get_latest_data("judge_court_sitting_days", force_refresh=force_refresh)
+
+
+def validate_data(df: pd.DataFrame, min_records: int = 1000) -> bool:
+    """Validate a parsed NICTS quarterly DataFrame.
+
+    Checks structure and sanity:
+
+    - Required columns are present.
+    - There are at least ``min_records`` rows.
+    - Years fall within a plausible range (2017 onwards).
+    - Quarters, where present, are 1-4.
+    - All non-null values are non-negative.
+
+    Args:
+        df: DataFrame to validate.
+        min_records: Minimum acceptable number of rows.
+
+    Returns:
+        True if the data passes all checks.
+
+    Raises:
+        NICTSValidationError: If any validation check fails.
+
+    Example:
+        >>> import pandas as pd
+        >>> validate_data(pd.DataFrame())
+        Traceback (most recent call last):
+        ...
+        bolster.data_sources.justice.nicts_quarterly.NICTSValidationError: DataFrame is empty
+    """
+    if df is None or df.empty:
+        raise NICTSValidationError("DataFrame is empty")
+
+    required = {"court", "category", "period", "year", "quarter", "value"}
+    missing = required - set(df.columns)
+    if missing:
+        raise NICTSValidationError(f"Missing required columns: {sorted(missing)}")
+
+    if len(df) < min_records:
+        raise NICTSValidationError(f"Too few records: {len(df)} < {min_records}")
+
+    if df["year"].min() < 2017 or df["year"].max() > 2100:
+        raise NICTSValidationError(f"Year range out of bounds: {df['year'].min()}-{df['year'].max()}")
+
+    quarters = df["quarter"].dropna()
+    if not quarters.empty and (quarters.min() < 1 or quarters.max() > 4):
+        raise NICTSValidationError(f"Quarter out of bounds: {quarters.min()}-{quarters.max()}")
+
+    values = df["value"].dropna()
+    if (values < 0).any():
+        raise NICTSValidationError("Negative values found in column 'value'")
+
+    return True
+
+
+def clear_cache() -> int:
+    """Clear all cached NICTS bulletin files.
+
+    Returns:
+        Number of files deleted.
+    """
+    return _downloader.clear()

--- a/tests/test_justice_nicts_quarterly_integrity.py
+++ b/tests/test_justice_nicts_quarterly_integrity.py
@@ -1,0 +1,421 @@
+"""Integrity tests for the NICTS Quarterly Provisional Figures module.
+
+Tests use real data downloaded from justice-ni.gov.uk (no mocks). Network
+calls are made once per class via ``scope="class"`` fixtures and cached for
+the duration of the test session. Parsing and validation edge cases are
+covered by network-free unit tests.
+"""
+
+import math
+
+import pandas as pd
+import pytest
+
+from bolster.data_sources.justice import nicts_quarterly
+from bolster.data_sources.justice.nicts_quarterly import (
+    NICTSDataNotFoundError,
+    NICTSValidationError,
+)
+
+EXPECTED_COURTS = {
+    "children_order",
+    "county_court",
+    "court_of_appeal_civil",
+    "court_of_appeal_criminal",
+    "crown_court",
+    "high_court_chancery_division",
+    "high_court_family_division",
+    "high_court_kings_bench_division",
+    "judge_court_sitting_days",
+    "magistrates_courts",
+}
+
+
+class TestPublicationDiscovery:
+    """Discovery of quarterly bulletins from the DoJ publication page."""
+
+    @pytest.fixture(scope="class")
+    def publications(self):
+        return nicts_quarterly.list_publications()
+
+    def test_publications_found(self, publications):
+        assert len(publications) >= 10
+
+    def test_all_ods_urls(self, publications):
+        assert all(p["url"].lower().endswith(".ods") for p in publications)
+
+    def test_quarters_in_range(self, publications):
+        assert all(1 <= p["quarter"] <= 4 for p in publications)
+
+    def test_years_plausible(self, publications):
+        assert all(2020 <= p["year"] <= 2100 for p in publications)
+
+    def test_sorted_newest_first(self, publications):
+        keys = [(p["year"], p["quarter"]) for p in publications]
+        assert keys == sorted(keys, reverse=True)
+
+    def test_urls_unique(self, publications):
+        urls = [p["url"] for p in publications]
+        assert len(urls) == len(set(urls))
+
+    def test_latest_matches_first(self, publications):
+        latest = nicts_quarterly.find_latest_publication()
+        assert latest == publications[0]
+
+    def test_latest_is_recent(self, publications):
+        """The most recent bulletin should be no more than ~2 years stale."""
+        assert publications[0]["year"] >= 2025
+
+
+class TestFullDatasetIntegrity:
+    """Integrity tests across all ten court worksheets."""
+
+    @pytest.fixture(scope="class")
+    def latest_data(self):
+        return nicts_quarterly.get_latest_data()
+
+    def test_required_columns(self, latest_data):
+        expected = {"court", "category", "subcategory", "detail", "period", "year", "quarter", "value"}
+        assert expected.issubset(set(latest_data.columns))
+
+    def test_not_empty(self, latest_data):
+        assert len(latest_data) > 5000
+
+    def test_all_courts_present(self, latest_data):
+        assert set(latest_data["court"]) == EXPECTED_COURTS
+
+    def test_every_court_has_data(self, latest_data):
+        counts = latest_data.groupby("court")["value"].count()
+        assert (counts > 50).all()
+
+    def test_historical_coverage_from_2017(self, latest_data):
+        assert latest_data["year"].min() == 2017
+
+    def test_recent_coverage(self, latest_data):
+        assert latest_data["year"].max() >= 2025
+
+    def test_year_dtype_integer(self, latest_data):
+        assert pd.api.types.is_integer_dtype(latest_data["year"])
+
+    def test_quarter_nullable_integer(self, latest_data):
+        assert isinstance(latest_data["quarter"].dtype, pd.Int64Dtype)
+
+    def test_quarters_in_range(self, latest_data):
+        quarters = latest_data["quarter"].dropna()
+        assert quarters.between(1, 4).all()
+
+    def test_annual_totals_have_no_quarter(self, latest_data):
+        annual = latest_data[latest_data["period"].str.endswith("Total")]
+        assert annual["quarter"].isna().all()
+
+    def test_quarterly_periods_have_quarter(self, latest_data):
+        quarterly = latest_data[~latest_data["period"].str.endswith("Total")]
+        assert quarterly["quarter"].notna().all()
+
+    def test_period_label_matches_year(self, latest_data):
+        derived = latest_data["period"].str.slice(0, 4).astype(int)
+        assert (derived == latest_data["year"]).all()
+
+    def test_values_non_negative(self, latest_data):
+        assert (latest_data["value"].dropna() >= 0).all()
+
+    def test_values_mostly_populated(self, latest_data):
+        """Suppression markers exist but should be a small minority."""
+        assert latest_data["value"].isna().mean() < 0.05
+
+    def test_category_always_present(self, latest_data):
+        assert latest_data["category"].notna().all()
+
+    def test_every_court_shares_period_columns(self, latest_data):
+        """All worksheets use the same period header, so all courts align."""
+        per_court = latest_data.groupby("court")["period"].apply(lambda s: frozenset(s))
+        assert per_court.nunique() == 1
+
+    def test_periods_are_contiguous_years(self, latest_data):
+        years = sorted(latest_data["year"].unique())
+        assert years == list(range(years[0], years[-1] + 1))
+
+    def test_validate_passes(self, latest_data):
+        assert nicts_quarterly.validate_data(latest_data) is True
+
+
+class TestCourtFiltering:
+    """Filtering the combined frame down to a single court."""
+
+    @pytest.fixture(scope="class")
+    def crown(self):
+        return nicts_quarterly.get_crown_court()
+
+    def test_single_court(self, crown):
+        assert set(crown["court"]) == {"crown_court"}
+
+    def test_index_reset(self, crown):
+        assert crown.index[0] == 0
+
+    def test_has_receipts_and_disposals(self, crown):
+        assert {"Received", "Disposed"}.issubset(set(crown["subcategory"]))
+
+    def test_case_and_defendant_levels(self, crown):
+        assert {"Case", "Defendant"}.issubset(set(crown["category"]))
+
+    def test_crown_receipts_plausible(self, crown):
+        """Crown Court receives roughly 1,000-2,000 cases annually."""
+        totals = crown[
+            (crown["category"] == "Case") & (crown["subcategory"] == "Received") & (crown["detail"] == "Total")
+        ]
+        annual = totals[totals["quarter"].isna()]["value"].dropna()
+        assert annual.between(500, 5000).all()
+
+    def test_unknown_court_raises(self):
+        with pytest.raises(NICTSDataNotFoundError, match="Unknown court"):
+            nicts_quarterly.get_latest_data("supreme_court")
+
+    def test_list_courts(self):
+        assert set(nicts_quarterly.list_courts()) == EXPECTED_COURTS
+
+
+class TestMagistratesCourts:
+    """The highest-volume court, useful for catching thousands-separator bugs."""
+
+    @pytest.fixture(scope="class")
+    def magistrates(self):
+        return nicts_quarterly.get_magistrates_courts()
+
+    def test_single_court(self, magistrates):
+        assert set(magistrates["court"]) == {"magistrates_courts"}
+
+    def test_large_values_parsed(self, magistrates):
+        """Adult defendant receipts run to tens of thousands per year."""
+        assert magistrates["value"].max() > 20000
+
+    def test_adult_defendants_present(self, magistrates):
+        assert any("Adult Defendants" in str(c) for c in magistrates["category"].unique())
+
+    def test_three_label_levels(self, magistrates):
+        assert magistrates["detail"].notna().any()
+
+
+class TestCountyCourt:
+    """County Court has the largest worksheet."""
+
+    @pytest.fixture(scope="class")
+    def county(self):
+        return nicts_quarterly.get_county_court()
+
+    def test_single_court(self, county):
+        assert set(county["court"]) == {"county_court"}
+
+    def test_appeals_business_area(self, county):
+        assert any("Appeals" in str(c) for c in county["category"].unique())
+
+    def test_row_count_substantial(self, county):
+        assert len(county) > 1000
+
+
+class TestSittingDays:
+    """Sitting days exercise the HH:MM duration parser."""
+
+    @pytest.fixture(scope="class")
+    def sitting(self):
+        return nicts_quarterly.get_sitting_days()
+
+    def test_single_court(self, sitting):
+        assert set(sitting["court"]) == {"judge_court_sitting_days"}
+
+    def test_both_categories(self, sitting):
+        assert {"Total Sitting Days", "Average sitting times"}.issubset(set(sitting["category"]))
+
+    def test_average_times_are_fractional_hours(self, sitting):
+        """Averages are HH:MM durations; a typical sitting day is 1-8 hours."""
+        avg = sitting[sitting["category"] == "Average sitting times"]["value"].dropna()
+        assert not avg.empty
+        assert avg.between(0, 24).all()
+
+    def test_average_times_not_all_integers(self, sitting):
+        """If HH:MM parsing collapsed to hours only, every value would be whole."""
+        avg = sitting[sitting["category"] == "Average sitting times"]["value"].dropna()
+        assert (avg % 1 != 0).any()
+
+    def test_sitting_days_are_whole_numbers(self, sitting):
+        days = sitting[sitting["category"] == "Total Sitting Days"]["value"].dropna()
+        assert (days % 1 == 0).all()
+
+    def test_judge_levels(self, sitting):
+        assert any("Judge" in str(s) for s in sitting["subcategory"].unique())
+
+
+class TestTwoLabelSheets:
+    """Court of Appeal sheets have two label columns, not three."""
+
+    @pytest.fixture(scope="class")
+    def appeals(self):
+        return nicts_quarterly.get_latest_data("court_of_appeal_civil")
+
+    def test_detail_column_empty(self, appeals):
+        assert appeals["detail"].isna().all()
+
+    def test_category_and_subcategory_populated(self, appeals):
+        assert appeals["category"].notna().all()
+        assert appeals["subcategory"].notna().all()
+
+    def test_receipts_and_disposals(self, appeals):
+        assert {"Received", "Disposed"}.issubset(set(appeals["subcategory"]))
+
+    def test_concatenates_with_three_label_sheets(self):
+        """Two- and three-label sheets must share a schema to concat cleanly."""
+        combined = nicts_quarterly.get_latest_data()
+        two_label = combined[combined["court"] == "court_of_appeal_civil"]
+        three_label = combined[combined["court"] == "crown_court"]
+        assert list(two_label.columns) == list(three_label.columns)
+
+
+class TestValueParsing:
+    """Unit tests for the cell value parser - no network calls needed."""
+
+    def test_plain_integer(self):
+        assert nicts_quarterly._parse_value("42") == 42.0
+
+    def test_thousands_separator(self):
+        assert nicts_quarterly._parse_value("32,339") == 32339.0
+
+    def test_decimal(self):
+        assert nicts_quarterly._parse_value("12.5") == 12.5
+
+    def test_duration_under_24h(self):
+        assert nicts_quarterly._parse_value("2:44") == pytest.approx(2 + 44 / 60)
+
+    def test_duration_over_24h(self):
+        """Cumulative sitting hours exceed 24, which breaks naive time parsing."""
+        assert nicts_quarterly._parse_value("6485:30") == 6485.5
+
+    def test_zero(self):
+        assert nicts_quarterly._parse_value("0") == 0.0
+
+    @pytest.mark.parametrize("marker", ["[z]", "N/A", "n/a", "-", "", "  ", "[c]", "[x]", ":"])
+    def test_suppression_markers(self, marker):
+        assert math.isnan(nicts_quarterly._parse_value(marker))
+
+    def test_unparseable_returns_nan(self):
+        assert math.isnan(nicts_quarterly._parse_value("not a number"))
+
+    def test_whitespace_stripped(self):
+        assert nicts_quarterly._parse_value("  1,234  ") == 1234.0
+
+
+class TestPeriodParsing:
+    """Unit tests for period header parsing - no network calls needed."""
+
+    def test_annual_total(self):
+        assert nicts_quarterly._parse_period("2024 Total") == (2024, None)
+
+    @pytest.mark.parametrize("quarter", [1, 2, 3, 4])
+    def test_quarters(self, quarter):
+        assert nicts_quarterly._parse_period(f"2025 Q{quarter}") == (2025, quarter)
+
+    def test_whitespace_tolerated(self):
+        assert nicts_quarterly._parse_period("  2025 Q1  ") == (2025, 1)
+
+    @pytest.mark.parametrize("label", ["Business Area", "Status of case", "", "Q1", "2025", "2025 Q5"])
+    def test_non_period_labels(self, label):
+        assert nicts_quarterly._parse_period(label) is None
+
+
+class TestSheetNameNormalisation:
+    """Unit tests for worksheet name normalisation - no network calls needed."""
+
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            ("Court_of_Appeal__Criminal", "court_of_appeal_criminal"),
+            ("Court_of_Appeal_Civil", "court_of_appeal_civil"),
+            ("Magistrates'_Courts", "magistrates_courts"),
+            ("Judge_Court_Sitting_Days", "judge_court_sitting_days"),
+            ("Children_Order", "children_order"),
+            ("  Crown Court  ", "crown_court"),
+        ],
+    )
+    def test_normalisation(self, raw, expected):
+        assert nicts_quarterly._normalise_sheet_name(raw) == expected
+
+    def test_empty_string(self):
+        assert nicts_quarterly._normalise_sheet_name("") == ""
+
+
+class TestNoteStripping:
+    """Unit tests for footnote reference removal - no network calls needed."""
+
+    def test_single_note(self):
+        assert nicts_quarterly._strip_note_refs("Total [note 3]") == "Total"
+
+    def test_multiple_notes(self):
+        assert nicts_quarterly._strip_note_refs("Received [note 1] [note 32]") == "Received"
+
+    def test_brace_typo_variant(self):
+        """One published table uses '{note 32]' rather than '[note 32]'."""
+        assert nicts_quarterly._strip_note_refs("Disposed {note 32]") == "Disposed"
+
+    def test_no_notes_unchanged(self):
+        assert nicts_quarterly._strip_note_refs("Business Area") == "Business Area"
+
+    def test_case_insensitive(self):
+        assert nicts_quarterly._strip_note_refs("Total [Note 5]") == "Total"
+
+
+class TestValidation:
+    """Unit tests for validation edge cases - no network calls needed."""
+
+    @staticmethod
+    def _frame(n=1000, **overrides):
+        data = {
+            "court": ["crown_court"] * n,
+            "category": ["Case"] * n,
+            "subcategory": ["Received"] * n,
+            "detail": ["Total"] * n,
+            "period": ["2024 Total"] * n,
+            "year": [2024] * n,
+            "quarter": pd.array([None] * n, dtype="Int64"),
+            "value": [1.0] * n,
+        }
+        data.update(overrides)
+        return pd.DataFrame(data)
+
+    def test_validate_empty_dataframe(self):
+        with pytest.raises(NICTSValidationError, match="empty"):
+            nicts_quarterly.validate_data(pd.DataFrame())
+
+    def test_validate_none(self):
+        with pytest.raises(NICTSValidationError, match="empty"):
+            nicts_quarterly.validate_data(None)
+
+    def test_validate_missing_columns(self):
+        df = self._frame().drop(columns=["value"])
+        with pytest.raises(NICTSValidationError, match="Missing required columns"):
+            nicts_quarterly.validate_data(df)
+
+    def test_validate_too_few_records(self):
+        with pytest.raises(NICTSValidationError, match="Too few records"):
+            nicts_quarterly.validate_data(self._frame(n=10))
+
+    def test_validate_year_too_early(self):
+        with pytest.raises(NICTSValidationError, match="Year range out of bounds"):
+            nicts_quarterly.validate_data(self._frame(year=[1999] * 1000))
+
+    def test_validate_year_too_late(self):
+        with pytest.raises(NICTSValidationError, match="Year range out of bounds"):
+            nicts_quarterly.validate_data(self._frame(year=[2200] * 1000))
+
+    def test_validate_quarter_out_of_bounds(self):
+        df = self._frame(quarter=pd.array([7] * 1000, dtype="Int64"))
+        with pytest.raises(NICTSValidationError, match="Quarter out of bounds"):
+            nicts_quarterly.validate_data(df)
+
+    def test_validate_negative_values(self):
+        with pytest.raises(NICTSValidationError, match="Negative values"):
+            nicts_quarterly.validate_data(self._frame(value=[-1.0] * 1000))
+
+    def test_validate_custom_min_records(self):
+        assert nicts_quarterly.validate_data(self._frame(n=20), min_records=10) is True
+
+    def test_validate_all_nan_values_passes(self):
+        """Fully suppressed values are unusual but structurally valid."""
+        assert nicts_quarterly.validate_data(self._frame(value=[float("nan")] * 1000)) is True


### PR DESCRIPTION
## Summary

Closes #1865.

Adds `bolster.data_sources.justice.nicts_quarterly` — NICTS quarterly provisional
court business figures across all ten court datasets, from the Court of Appeal to
the Magistrates' Courts, plus judicial sitting days.

A single ODS bulletin holds ten worksheets with differing label depths (2 or 3
label columns) and shared period columns. The parser reshapes all of them into one
tidy long frame: `court`, `category`, `subcategory`, `detail`, `period`, `year`,
`quarter`, `value`. Annual totals from 2017 onward carry `pd.NA` in `quarter`;
quarterly rows carry 1-4. Live data currently yields 8,814 rows across 17
discoverable publications (2022 Q1 – 2026 Q1).

### Why the custom ODF reader

`pd.read_excel(..., engine="odf")` calls `pd.Timestamp(str(cell))` on time-typed
cells, which raises `DateParseError` on sitting-time durations over 24 hours (e.g.
`6485:34`). The module reads raw `odf` cell text instead and parses values by hand,
converting `HH:MM` to fractional hours.

### Also in this PR

The existing mortgages block in `docs/data_sources.rst` referenced
`justice.get_latest_mortgage_possession_actions()` and `bolster justice
mortgage-possession` — neither has ever existed. Corrected to the real API.

## Test plan

- [x] `uv run pytest tests/test_justice_nicts_quarterly_integrity.py` — 101 passed
- [x] Patch coverage on the new module: 93.6% (target 55%)
- [x] 14 doctests pass
- [x] `uv run pre-commit run --all-files` clean
- [x] CLI smoke-tested: `--list-courts`, `--court`, `--year`, `--quarter`, `--annual`, `--format json`
- [x] Duration parsing verified against live data (2:44 → 2.733333, not truncated)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)