### PR TITLE
feat(hsc-workforce): add NI HSC Workforce Statistics data source

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ The [GOV.UK NISRA statistics RSS feed](https://www.gov.uk/search/research-and-st
 | Cancer Waiting Times | `health_ni.cancer_waiting_times` | ✅ |
 | Diagnostic Waiting Times | `health_ni.diagnostic_waiting_times` | ✅ |
 | Child Protection Statistics | `health_ni.child_protection` | ✅ |
+| HSC Workforce Statistics | `health_ni.hsc_workforce` | ✅ |
 | NI Planning Activity Statistics (DfI) | `nisra.planning_statistics` | ✅ |
 | NI Housing Stock Statistics (DoF/LPS) | `nisra.housing_stock` | ✅ |
 | NI Homelessness Bulletin (DfC/NIHE) | `nisra.homelessness` | ✅ |

--- a/docs/data_sources.rst
+++ b/docs/data_sources.rst
@@ -526,6 +526,30 @@ statistics from the Department of Health.
 
     $ bolster nisra child-protection
 
+HSC Workforce
+~~~~~~~~~~~~~
+
+Quarterly Health and Social Care staff numbers by staff group, organisation,
+and Agenda for Change pay band, together with financial-year turnover and
+workforce stability measures.  Each quarterly release carries a six-year
+series at its own quarter point, so the published workbooks combine into a
+continuous quarterly history from June 2020.
+
+.. code-block:: python
+
+    from bolster.data_sources.health_ni import hsc_workforce
+
+    df = hsc_workforce.get_latest_data()
+
+    hsc_workforce.get_summary(df)        # headline WTE, headcount, active posts
+    hsc_workforce.get_organisations(df)  # by trust and other HSC body
+    hsc_workforce.get_turnover(df)       # leavers, joiners, stability rates
+
+.. code-block:: console
+
+    $ bolster nisra hsc-workforce
+    $ bolster nisra hsc-workforce --dimension organisation
+
 ----
 
 PSNI

--- a/src/bolster/cli.py
+++ b/src/bolster/cli.py
@@ -5187,6 +5187,143 @@ def nisra_elective_waiting_times_cmd(waiting_type, trust, year, output_format, f
         raise click.Abort() from e
 
 
+@nisra.command(name="hsc-workforce")
+@click.option(
+    "--dimension",
+    type=click.Choice(
+        [
+            "all",
+            "summary",
+            "staff_group",
+            "sub_staff_group",
+            "organisation",
+            "organisation_staff_group",
+            "other_organisation_staff_group",
+            "pay_band",
+            "leavers",
+            "joiners",
+            "stability",
+        ],
+        case_sensitive=False,
+    ),
+    default="summary",
+    help="Which workbook table to retrieve (default: summary)",
+)
+@click.option("--organisation", help="Filter by organisation name (e.g. Belfast)")
+@click.option("--staff-group", help="Filter by staff group name (e.g. Medical)")
+@click.option("--year", type=int, help="Filter data for a specific calendar year")
+@click.option(
+    "--format",
+    "output_format",
+    type=click.Choice(["csv", "json"], case_sensitive=False),
+    default="csv",
+    help="Output format (default: csv)",
+)
+@click.option("--force-refresh", is_flag=True, help="Force re-download even if cached")
+@click.option("--save", help="Save output to file (specify filename)")
+def nisra_hsc_workforce_cmd(dimension, organisation, staff_group, year, output_format, force_refresh, save):
+    r"""NI HSC Workforce Statistics — quarterly staff numbers.
+
+    \b
+    Department of Health quarterly census of Health and Social Care staff,
+    covering 24 quarter-end reference dates from June 2020 to March 2026.
+    Each release carries a six-year series at its own quarter point, so the
+    four published workbooks combine into a continuous quarterly history.
+
+    \b
+    Dimensions:
+
+      summary                         Headline WTE, headcount, active posts
+      staff_group / sub_staff_group   Breakdown by staff group
+      organisation                    Breakdown by trust and other HSC body
+      organisation_staff_group        Organisation x staff group cross-tab
+      other_organisation_staff_group  Non-trust bodies, same cross-tab
+      pay_band                        Agenda for Change band shares
+      leavers / joiners / stability   Financial-year turnover measures
+
+    \b
+    Examples::
+
+        bolster nisra hsc-workforce
+        bolster nisra hsc-workforce --dimension organisation
+        bolster nisra hsc-workforce --dimension pay_band --staff-group Medical
+        bolster nisra hsc-workforce --dimension stability --format json
+        bolster nisra hsc-workforce --dimension staff_group --save workforce.csv
+
+    \b
+    Key insights (as of March 2026): the workforce grew from 61,994 WTE in
+    June 2020 to 68,341 WTE; 76,855 people hold 77,705 active posts; and the
+    annual leaving rate fell from 8.1% in 2021/22 to 6.3% in 2025/26.
+
+    \b
+    Source:
+        https://www.health-ni.gov.uk/articles/staff-numbers
+    """
+    from rich.console import Console
+
+    from bolster.data_sources.health_ni import hsc_workforce as hw
+
+    console = Console()
+
+    try:
+        with console.status("[bold green]Downloading HSC workforce statistics..."):
+            data = hw.get_latest_data(force_refresh=force_refresh)
+
+        if dimension != "all":
+            data = data[data["table"] == dimension]
+            if data.empty:
+                console.print(f"[yellow]No data found for dimension='{dimension}'[/yellow]")
+                return
+
+        if organisation:
+            data = data[data["organisation"].str.contains(organisation, case=False, na=False)]
+            if data.empty:
+                console.print(f"[yellow]No data found for organisation matching '{organisation}'[/yellow]")
+                return
+
+        if staff_group:
+            data = data[data["staff_group"].str.contains(staff_group, case=False, na=False)]
+            if data.empty:
+                console.print(f"[yellow]No data found for staff group matching '{staff_group}'[/yellow]")
+                return
+
+        if year:
+            data = data[data["year"] == year]
+            if data.empty:
+                console.print(f"[yellow]No data found for year {year}[/yellow]")
+                return
+
+        console.print(f"[green]Retrieved {len(data):,} records[/green]")
+
+        if not data.empty:
+            console.print(f"[dim]Period: {data['date'].min():%Y-%m-%d} to {data['date'].max():%Y-%m-%d}[/dim]")
+
+        if save:
+            try:
+                if output_format == "json" or save.endswith(".json"):
+                    data.to_json(save, orient="records", date_format="iso", indent=2)
+                else:
+                    data.to_csv(save, index=False)
+                console.print(f"[green]Data saved to: {save}[/green]")
+                return
+            except Exception as e:
+                console.print(f"[red]Error saving file: {e}[/red]")
+                return
+
+        if output_format == "json":
+            click.echo(data.to_json(orient="records", date_format="iso", indent=2))
+        else:
+            console.print("\n[bold]Data:[/bold]")
+            console.print(data.to_csv(index=False), end="")
+
+    except Exception as e:
+        console.print(f"[bold red]Error:[/bold red] {str(e)}", style="red")
+        console.print("\n[yellow]Troubleshooting:[/yellow]")
+        console.print("   • Check your internet connection")
+        console.print("   • Try again with --force-refresh to bypass cache")
+        raise click.Abort() from e
+
+
 @nisra.command(name="registrar-general")
 @click.option("--latest", is_flag=True, help="Get the most recent quarterly tables data")
 @click.option("--quarterly", is_flag=True, help="Show full quarterly time series")

--- a/src/bolster/data_sources/health_ni/__init__.py
+++ b/src/bolster/data_sources/health_ni/__init__.py
@@ -9,6 +9,7 @@ Modules:
     - disease_prevalence: Annual GP disease register sizes and prevalence per 1,000 patients
     - elective_waiting_times: Elective and outpatient waiting times
     - emergency_care_waiting_times: Emergency care (A&E) waiting times against the 4-hour target
+    - hsc_workforce: Quarterly HSC staff numbers by staff group, organisation and pay band
 """
 
 from bolster.data_sources.health_ni import (
@@ -18,6 +19,7 @@ from bolster.data_sources.health_ni import (
     disease_prevalence,
     elective_waiting_times,
     emergency_care_waiting_times,
+    hsc_workforce,
 )
 
 __all__ = [
@@ -27,4 +29,5 @@ __all__ = [
     "disease_prevalence",
     "elective_waiting_times",
     "emergency_care_waiting_times",
+    "hsc_workforce",
 ]

--- a/src/bolster/data_sources/health_ni/hsc_workforce.py
+++ b/src/bolster/data_sources/health_ni/hsc_workforce.py
@@ -1,0 +1,719 @@
+"""NI Health and Social Care (HSC) Workforce Statistics module.
+
+Provides access to the Department of Health's quarterly HSC workforce
+statistics, covering staff numbers across Northern Ireland's health and social
+care system by staff group, HSC organisation, and Agenda for Change pay band.
+
+Each quarterly publication contains a **six-year time series at that quarter
+point** (e.g. the March 2026 release covers 31 March 2021 to 31 March 2026),
+so fetching all published quarters yields roughly two dozen distinct reference
+dates rather than four.
+
+The source workbook contains several differently-shaped tables. They are
+flattened into a single tidy frame, with the ``table`` column identifying the
+dimension combination each row came from:
+
+===============================  ===========================================
+``table``                        Contents
+===============================  ===========================================
+``summary``                      Headline WTE, active posts, headcount
+``staff_group``                  WTE by staff group (9 groups + Total)
+``sub_staff_group``              WTE by sub staff group / profession
+``organisation``                 WTE by HSC organisation (16 orgs + Total)
+``organisation_staff_group``     WTE by trust x staff group (current quarter)
+``other_organisation_staff_group``  Same, decomposing "Other HSC Organisations"
+``pay_band``                     Share of WTE by Agenda for Change pay band
+``leavers``                      Annual leavers and leaving rate
+``joiners``                      Annual joiners and joining rate
+``stability``                    Annual workforce stability rate
+===============================  ===========================================
+
+``organisation_staff_group`` and ``other_organisation_staff_group`` overlap:
+the latter decomposes the former's ``Other HSC Organisations`` row. Never sum
+across both.
+
+The ``leavers``/``joiners``/``stability`` tables are published only in the
+March release and are reported by financial year, so their ``date`` is the
+31 March that ends the financial year.
+
+HSC Trusts:
+    Belfast, Northern, South Eastern, Southern, Western, NI Ambulance Service
+
+Original data source:
+    https://www.health-ni.gov.uk/articles/staff-numbers
+
+Update Frequency:
+    Quarterly, published approximately 2-3 months after the reference date.
+
+Example:
+    >>> from bolster.data_sources.health_ni import hsc_workforce
+    >>> df = hsc_workforce.get_latest_data()
+    >>> sorted(df.columns.tolist())
+    ['date', 'grade_band', 'measure', 'organisation', 'quarter', 'staff_group', 'table', 'value', 'year']
+
+    >>> hsc_workforce.validate_data(df)
+    True
+
+Publication Details:
+    - Frequency: Quarterly (March, June, September, December reference dates)
+    - Published by: Department of Health NI
+    - Source: https://www.health-ni.gov.uk/articles/staff-numbers
+"""
+
+import logging
+import re
+from pathlib import Path
+
+import pandas as pd
+from bs4 import BeautifulSoup
+
+from bolster.utils.web import session
+
+from ._base import (
+    HEALTH_NI_BASE_URL,
+    NISRADataNotFoundError,
+    NISRAValidationError,
+    download_file,
+    make_absolute_url,
+)
+
+logger = logging.getLogger(__name__)
+
+HSC_WORKFORCE_PAGE = "https://www.health-ni.gov.uk/articles/staff-numbers"
+
+#: Reference month for each quarterly publication slug.
+PUBLICATION_MONTHS = {"march": 3, "june": 6, "september": 9, "december": 12}
+
+#: Calendar quarter for each reference month.
+MONTH_QUARTERS = {3: 1, 6: 2, 9: 3, 12: 4}
+
+#: Workbook table number -> ``table`` dimension label.
+TABLE_DIMENSIONS = {
+    "1": "summary",
+    "2A": "staff_group",
+    "2B": "sub_staff_group",
+    "3": "organisation",
+    "4": "organisation_staff_group",
+    "5": "other_organisation_staff_group",
+    "6": "pay_band",
+    "7A": "leavers",
+    "7B": "joiners",
+    "7C": "stability",
+}
+
+#: Row labels in Tables 1 and 7 mapped to canonical measure slugs.
+MEASURE_LABELS = {
+    "wte": "wte",
+    "active posts": "active_posts",
+    "individuals with multiple posts": "individuals_multiple_posts",
+    "headcount": "headcount",
+    "staff in post (headcount)": "staff_in_post",
+    "leavers": "leavers",
+    "leaving rate (%)": "leaving_rate",
+    "joiners": "joiners",
+    "joining rate (%)": "joining_rate",
+    "staff in hsc employment 1 year before": "staff_year_before",
+    "annual workforce stability rate (%)": "stability_rate",
+}
+
+#: Measures expressed as a proportion in the range [0, 1].
+RATE_MEASURES = {"percent_wte", "leaving_rate", "joining_rate", "stability_rate"}
+
+#: Column order of the tidy output frame.
+COLUMNS = [
+    "date",
+    "year",
+    "quarter",
+    "table",
+    "measure",
+    "organisation",
+    "staff_group",
+    "grade_band",
+    "value",
+]
+
+REQUIRED_COLUMNS = set(COLUMNS)
+
+_NOTE_RE = re.compile(r"\s*\[note[^\]]*\]", re.IGNORECASE)
+_TABLE_TITLE_RE = re.compile(r"^Tables?\s*(\d+[A-Za-z]?)\s*[-–:]", re.IGNORECASE)
+_PUBLICATION_SLUG_RE = re.compile(r"workforce-statistics-(march|june|september|december)-(\d{4})", re.IGNORECASE)
+_FINANCIAL_YEAR_RE = re.compile(r"^(\d{4})/(\d{2})$")
+
+
+def _clean_label(value: object) -> str | None:
+    r"""Normalise a spreadsheet label into a stable comparable string.
+
+    Strips ``[note N]`` footnote references, collapses embedded newlines and
+    repeated whitespace, and normalises curly punctuation to ASCII.
+
+    Args:
+        value: Raw cell value from the workbook.
+
+    Returns:
+        Cleaned label, or ``None`` if the cell is blank.
+
+    Example:
+        >>> _clean_label("Nursing & Midwifery Support [note 1]")
+        'Nursing & Midwifery Support'
+        >>> _clean_label("Pay bands 8 \n& above")
+        'Pay bands 8 & above'
+        >>> _clean_label(None) is None
+        True
+    """
+    if value is None or (isinstance(value, float) and pd.isna(value)):
+        return None
+    text = str(value).replace("’", "'").replace("–", "-")
+    text = _NOTE_RE.sub("", text)
+    text = re.sub(r"\s+", " ", text).strip()
+    return text or None
+
+
+def _period_end(year: int, month: int) -> pd.Timestamp:
+    """Return the last calendar day of *month* in *year*.
+
+    Args:
+        year: Four-digit calendar year.
+        month: Month number (1-12).
+
+    Returns:
+        Timestamp for the final day of that month.
+
+    Example:
+        >>> _period_end(2026, 3).strftime("%Y-%m-%d")
+        '2026-03-31'
+    """
+    return pd.Timestamp(year=year, month=month, day=1) + pd.offsets.MonthEnd(0)
+
+
+def _as_year(value: object) -> int | None:
+    """Return *value* as a plausible calendar year, or ``None``.
+
+    Workbook year headers arrive as floats (``2021.0``); non-year headers such
+    as ``"% Change 2021 to 2026"`` are rejected.
+
+    Args:
+        value: Raw header cell value.
+
+    Returns:
+        The year as an ``int``, or ``None`` if the cell is not a year.
+
+    Example:
+        >>> _as_year(2021.0)
+        2021
+        >>> _as_year("% Change 2021 to 2026") is None
+        True
+    """
+    if value is None or (isinstance(value, float) and pd.isna(value)):
+        return None
+    try:
+        year = int(float(value))
+    except (TypeError, ValueError):
+        return None
+    return year if 1990 <= year <= 2100 else None
+
+
+def _as_financial_year_end(value: object) -> int | None:
+    """Return the calendar year in which a ``YYYY/YY`` financial year ends.
+
+    Args:
+        value: Raw header cell value, e.g. ``"2025/26"``.
+
+    Returns:
+        The ending calendar year, or ``None`` if *value* is not a financial year.
+
+    Example:
+        >>> _as_financial_year_end("2025/26")
+        2026
+        >>> _as_financial_year_end("Leavers") is None
+        True
+    """
+    text = _clean_label(value)
+    if text is None:
+        return None
+    match = _FINANCIAL_YEAR_RE.match(text)
+    return int(match.group(1)) + 1 if match else None
+
+
+def _as_measure(label: str | None) -> str | None:
+    """Map a Table 1 or Table 7 row label to a canonical measure slug.
+
+    Args:
+        label: Cleaned row label.
+
+    Returns:
+        Canonical measure slug, or ``None`` if the label is blank.
+
+    Example:
+        >>> _as_measure("Individuals with multiple posts")
+        'individuals_multiple_posts'
+        >>> _as_measure("Some New Measure")
+        'some_new_measure'
+    """
+    if label is None:
+        return None
+    known = MEASURE_LABELS.get(label.lower())
+    if known is not None:
+        return known
+    return re.sub(r"[^a-z0-9]+", "_", label.lower()).strip("_")
+
+
+def list_publications() -> list[dict]:
+    """List the quarterly HSC workforce publications linked from the article page.
+
+    Returns:
+        List of dictionaries sorted oldest-first, each with keys ``url``
+        (publication page URL), ``period`` (e.g. ``"march-2026"``), ``date``
+        (reference date as a Timestamp), ``year`` and ``quarter``.
+
+    Raises:
+        NISRADataNotFoundError: If the article page cannot be fetched or lists
+            no quarterly publications.
+
+    Example:
+        >>> pubs = list_publications()
+        >>> all(p["quarter"] in (1, 2, 3, 4) for p in pubs)
+        True
+    """
+    try:
+        resp = session.get(HSC_WORKFORCE_PAGE, timeout=30)
+        resp.raise_for_status()
+    except Exception as exc:
+        raise NISRADataNotFoundError(f"Failed to fetch {HSC_WORKFORCE_PAGE}: {exc}") from exc
+
+    soup = BeautifulSoup(resp.content, "html.parser")
+    publications: dict[str, dict] = {}
+    for anchor in soup.find_all("a", href=True):
+        match = _PUBLICATION_SLUG_RE.search(anchor["href"])
+        if match is None:
+            continue
+        url = make_absolute_url(anchor["href"], HEALTH_NI_BASE_URL)
+        if url in publications:
+            continue
+        month = PUBLICATION_MONTHS[match.group(1).lower()]
+        year = int(match.group(2))
+        publications[url] = {
+            "url": url,
+            "period": f"{match.group(1).lower()}-{year}",
+            "date": _period_end(year, month),
+            "year": year,
+            "quarter": MONTH_QUARTERS[month],
+        }
+
+    if not publications:
+        raise NISRADataNotFoundError(f"No quarterly workforce publications found on {HSC_WORKFORCE_PAGE}")
+
+    return sorted(publications.values(), key=lambda pub: pub["date"])
+
+
+def find_publication_xlsx(publication_url: str) -> str:
+    """Return the workbook URL linked from a quarterly publication page.
+
+    Args:
+        publication_url: A publication page URL from :func:`list_publications`.
+
+    Returns:
+        Absolute URL of the ``.xlsx`` workbook.
+
+    Raises:
+        NISRADataNotFoundError: If the page cannot be fetched or has no
+            ``.xlsx`` link.
+    """
+    try:
+        resp = session.get(publication_url, timeout=30)
+        resp.raise_for_status()
+    except Exception as exc:
+        raise NISRADataNotFoundError(f"Failed to fetch {publication_url}: {exc}") from exc
+
+    soup = BeautifulSoup(resp.content, "html.parser")
+    for anchor in soup.find_all("a", href=True):
+        if anchor["href"].lower().endswith(".xlsx"):
+            return make_absolute_url(anchor["href"], HEALTH_NI_BASE_URL)
+
+    raise NISRADataNotFoundError(f"No .xlsx link found on {publication_url}")
+
+
+def _iter_table_blocks(raw: pd.DataFrame):
+    """Split a raw sheet into ``(table_id, header, body)`` blocks.
+
+    Sheets may stack several tables (e.g. ``Tables 2A to 2B``). Each block
+    starts at a ``Table N:`` title in the first column; the row beneath it is
+    the header and the rows after that are the body.
+
+    Args:
+        raw: Sheet read with ``header=None``.
+
+    Yields:
+        Tuples of table identifier (e.g. ``"2A"``), header Series, and body
+        DataFrame with all-blank rows removed.
+    """
+    titles: list[tuple[int, str]] = []
+    for position, value in enumerate(raw.iloc[:, 0]):
+        if value is None or (isinstance(value, float) and pd.isna(value)):
+            continue
+        match = _TABLE_TITLE_RE.match(str(value).strip())
+        if match is not None:
+            titles.append((position, match.group(1).upper()))
+
+    for index, (start, table_id) in enumerate(titles):
+        end = titles[index + 1][0] if index + 1 < len(titles) else len(raw)
+        if start + 2 >= end:
+            continue
+        header = raw.iloc[start + 1]
+        body = raw.iloc[start + 2 : end].dropna(how="all")
+        yield table_id, header, body
+
+
+def _parse_year_series(header: pd.Series, body: pd.DataFrame, table: str, month: int) -> list[dict]:
+    """Parse a table whose rows are labels and columns are calendar years.
+
+    Covers Tables 1, 2A, 2B and 3. ``% Change`` columns are ignored.
+
+    Args:
+        header: Header row of the block.
+        body: Body rows of the block.
+        table: ``table`` dimension label for the output rows.
+        month: Reference month of the publication (used to date each year column).
+
+    Returns:
+        List of tidy record dictionaries.
+    """
+    year_columns = {col: year for col, value in header.items() if col != 0 and (year := _as_year(value)) is not None}
+    dimension = {"summary": "measure", "organisation": "organisation"}.get(table, "staff_group")
+
+    records: list[dict] = []
+    for _, row in body.iterrows():
+        label = _clean_label(row[0])
+        if label is None:
+            continue
+        for column, year in year_columns.items():
+            value = pd.to_numeric(row[column], errors="coerce")
+            if pd.isna(value):
+                continue
+            date = _period_end(year, month)
+            records.append(
+                {
+                    "date": date,
+                    "year": year,
+                    "quarter": MONTH_QUARTERS[month],
+                    "table": table,
+                    "measure": _as_measure(label) if dimension == "measure" else "wte",
+                    "organisation": label if dimension == "organisation" else None,
+                    "staff_group": label if dimension == "staff_group" else None,
+                    "grade_band": None,
+                    "value": float(value),
+                }
+            )
+    return records
+
+
+def _parse_cross_tab(header: pd.Series, body: pd.DataFrame, table: str, date: pd.Timestamp) -> list[dict]:
+    """Parse a table whose rows and columns are both dimensions.
+
+    Covers Tables 4 and 5 (organisation x staff group) and Table 6
+    (staff group x pay band). Table 6 values are proportions of WTE, except
+    its trailing ``Total WTE`` column which is an absolute WTE count.
+
+    Args:
+        header: Header row of the block.
+        body: Body rows of the block.
+        table: ``table`` dimension label for the output rows.
+        date: Reference date of the publication.
+
+    Returns:
+        List of tidy record dictionaries.
+    """
+    by_pay_band = table == "pay_band"
+    column_labels = {col: label for col, value in header.items() if col != 0 and (label := _clean_label(value))}
+
+    records: list[dict] = []
+    for _, row in body.iterrows():
+        row_label = _clean_label(row[0])
+        if row_label is None:
+            continue
+        for column, column_label in column_labels.items():
+            value = pd.to_numeric(row[column], errors="coerce")
+            if pd.isna(value):
+                continue
+            is_total_wte = by_pay_band and column_label == "Total WTE"
+            records.append(
+                {
+                    "date": date,
+                    "year": int(date.year),
+                    "quarter": MONTH_QUARTERS[date.month],
+                    "table": table,
+                    "measure": "wte" if (is_total_wte or not by_pay_band) else "percent_wte",
+                    "organisation": None if by_pay_band else row_label,
+                    "staff_group": row_label if by_pay_band else column_label,
+                    "grade_band": None if (is_total_wte or not by_pay_band) else column_label,
+                    "value": float(value),
+                }
+            )
+    return records
+
+
+def _parse_financial_year(header: pd.Series, body: pd.DataFrame, table: str) -> list[dict]:
+    """Parse a Table 7 block reported by financial year.
+
+    Rows are measures; columns are ``YYYY/YY`` financial years. Each column is
+    dated to the 31 March that ends the financial year.
+
+    Args:
+        header: Header row of the block.
+        body: Body rows of the block.
+        table: ``table`` dimension label (``leavers``, ``joiners`` or ``stability``).
+
+    Returns:
+        List of tidy record dictionaries.
+    """
+    year_columns = {
+        col: year for col, value in header.items() if col != 0 and (year := _as_financial_year_end(value)) is not None
+    }
+
+    records: list[dict] = []
+    for _, row in body.iterrows():
+        measure = _as_measure(_clean_label(row[0]))
+        if measure is None:
+            continue
+        for column, year in year_columns.items():
+            value = pd.to_numeric(row[column], errors="coerce")
+            if pd.isna(value):
+                continue
+            records.append(
+                {
+                    "date": _period_end(year, 3),
+                    "year": year,
+                    "quarter": 1,
+                    "table": table,
+                    "measure": measure,
+                    "organisation": None,
+                    "staff_group": None,
+                    "grade_band": None,
+                    "value": float(value),
+                }
+            )
+    return records
+
+
+def parse_workbook(file_path: str | Path, period_date: pd.Timestamp) -> pd.DataFrame:
+    """Parse one quarterly HSC workforce workbook into tidy long format.
+
+    Args:
+        file_path: Path to a downloaded ``.xlsx`` workbook.
+        period_date: Reference date of the publication (e.g. 2026-03-31).
+            Used to date the year columns of the time-series tables and to
+            date the current-quarter cross-tab tables.
+
+    Returns:
+        Long-format DataFrame with the columns listed in :data:`COLUMNS`.
+
+    Raises:
+        NISRAValidationError: If no recognised tables are found in the workbook.
+    """
+    with pd.ExcelFile(file_path) as workbook:
+        sheet_names = workbook.sheet_names
+
+    records: list[dict] = []
+    for sheet in sheet_names:
+        if sheet.lower().startswith(("cover", "notes", "source")):
+            continue
+        raw = pd.read_excel(file_path, sheet_name=sheet, header=None)
+        for table_id, header, body in _iter_table_blocks(raw):
+            table = TABLE_DIMENSIONS.get(table_id)
+            if table is None:
+                logger.warning(f"Unrecognised table '{table_id}' on sheet '{sheet}' — skipping")
+                continue
+            if table in {"leavers", "joiners", "stability"}:
+                records.extend(_parse_financial_year(header, body, table))
+            elif table in {"organisation_staff_group", "other_organisation_staff_group", "pay_band"}:
+                records.extend(_parse_cross_tab(header, body, table, period_date))
+            else:
+                records.extend(_parse_year_series(header, body, table, period_date.month))
+
+    if not records:
+        raise NISRAValidationError(f"No recognised workforce tables found in {file_path}")
+
+    return pd.DataFrame.from_records(records, columns=COLUMNS)
+
+
+def get_latest_data(force_refresh: bool = False) -> pd.DataFrame:
+    """Download and combine every published quarterly HSC workforce release.
+
+    Each release carries a six-year series at its own quarter point, so the
+    combined frame spans considerably more history than the handful of
+    publications currently listed.
+
+    Args:
+        force_refresh: If ``True``, bypass the on-disk cache and re-download.
+
+    Returns:
+        Tidy long-format DataFrame with columns:
+
+        - ``date`` (datetime): Reference date (quarter end)
+        - ``year`` (int): Calendar year of the reference date
+        - ``quarter`` (int): Calendar quarter, 1-4
+        - ``table`` (str): Source table dimension (see module docstring)
+        - ``measure`` (str): ``wte``, ``headcount``, ``percent_wte``, etc.
+        - ``organisation`` (str or None): HSC organisation, where applicable
+        - ``staff_group`` (str or None): Staff group or profession
+        - ``grade_band`` (str or None): Agenda for Change pay band
+        - ``value`` (float): The observed value
+
+    Raises:
+        NISRADataNotFoundError: If no publications or workbooks can be located.
+        NISRAValidationError: If the combined data fails validation.
+    """
+    frames = []
+    for publication in list_publications():
+        url = find_publication_xlsx(publication["url"])
+        logger.info(f"Downloading HSC workforce workbook for {publication['period']} from {url}")
+        file_path = download_file(url, force_refresh=force_refresh)
+        frames.append(parse_workbook(file_path, publication["date"]))
+
+    df = pd.concat(frames, ignore_index=True)
+    dimensions = ["date", "table", "measure", "organisation", "staff_group", "grade_band"]
+    df = (
+        df.drop_duplicates(subset=dimensions, keep="last")
+        .sort_values(["date", "table", "measure", "organisation", "staff_group", "grade_band"], na_position="first")
+        .reset_index(drop=True)
+    )
+    validate_data(df)
+    return df
+
+
+def get_summary(df: pd.DataFrame) -> pd.DataFrame:
+    """Return the headline workforce totals (Table 1).
+
+    Args:
+        df: DataFrame from :func:`get_latest_data`.
+
+    Returns:
+        Rows where ``table == "summary"``, covering WTE, active posts,
+        individuals with multiple posts, and headcount.
+    """
+    return df[df["table"] == "summary"].reset_index(drop=True)
+
+
+def get_staff_groups(df: pd.DataFrame, include_total: bool = False) -> pd.DataFrame:
+    """Return WTE by staff group (Table 2A).
+
+    Args:
+        df: DataFrame from :func:`get_latest_data`.
+        include_total: If ``True``, retain the ``Total`` row.
+
+    Returns:
+        Rows where ``table == "staff_group"``.
+    """
+    subset = df[df["table"] == "staff_group"]
+    if not include_total:
+        subset = subset[subset["staff_group"] != "Total"]
+    return subset.reset_index(drop=True)
+
+
+def get_organisations(df: pd.DataFrame, include_total: bool = False) -> pd.DataFrame:
+    """Return WTE by HSC organisation (Table 3).
+
+    Args:
+        df: DataFrame from :func:`get_latest_data`.
+        include_total: If ``True``, retain the ``Total`` row.
+
+    Returns:
+        Rows where ``table == "organisation"``.
+    """
+    subset = df[df["table"] == "organisation"]
+    if not include_total:
+        subset = subset[subset["organisation"] != "Total"]
+    return subset.reset_index(drop=True)
+
+
+def get_pay_bands(df: pd.DataFrame) -> pd.DataFrame:
+    """Return the share of WTE by Agenda for Change pay band (Table 6).
+
+    Args:
+        df: DataFrame from :func:`get_latest_data`.
+
+    Returns:
+        Rows where ``table == "pay_band"`` and ``measure == "percent_wte"``.
+        Each staff group's proportions sum to 1.
+    """
+    subset = df[(df["table"] == "pay_band") & (df["measure"] == "percent_wte")]
+    return subset.reset_index(drop=True)
+
+
+def get_turnover(df: pd.DataFrame) -> pd.DataFrame:
+    """Return annual joiner, leaver and stability figures (Tables 7A-7C).
+
+    Only published in the March release, and reported by financial year.
+
+    Args:
+        df: DataFrame from :func:`get_latest_data`.
+
+    Returns:
+        Rows where ``table`` is one of ``leavers``, ``joiners`` or ``stability``.
+    """
+    return df[df["table"].isin({"leavers", "joiners", "stability"})].reset_index(drop=True)
+
+
+def list_staff_groups(df: pd.DataFrame) -> list[str]:
+    """Return the sorted staff group names present in *df*.
+
+    Args:
+        df: DataFrame from :func:`get_latest_data`.
+
+    Returns:
+        Sorted list of staff group labels, excluding ``Total``.
+    """
+    values = df.loc[df["table"] == "staff_group", "staff_group"].dropna().unique()
+    return sorted(value for value in values if value != "Total")
+
+
+def list_organisations(df: pd.DataFrame) -> list[str]:
+    """Return the sorted HSC organisation names present in *df*.
+
+    Args:
+        df: DataFrame from :func:`get_latest_data`.
+
+    Returns:
+        Sorted list of organisation labels, excluding ``Total``.
+    """
+    values = df.loc[df["table"] == "organisation", "organisation"].dropna().unique()
+    return sorted(value for value in values if value != "Total")
+
+
+def validate_data(df: pd.DataFrame, min_records: int = 1000) -> bool:
+    """Validate an HSC workforce DataFrame against quality expectations.
+
+    Args:
+        df: DataFrame from :func:`get_latest_data` or :func:`parse_workbook`.
+        min_records: Minimum acceptable row count.
+
+    Returns:
+        ``True`` if all checks pass.
+
+    Raises:
+        NISRAValidationError: If the frame is empty, missing required columns,
+            too small, contains unknown ``table`` labels, has negative values,
+            or has rate measures outside the range [0, 1].
+    """
+    if df is None or len(df) == 0:
+        raise NISRAValidationError("HSC workforce DataFrame is empty")
+
+    missing = REQUIRED_COLUMNS - set(df.columns)
+    if missing:
+        raise NISRAValidationError(f"Missing required columns: {sorted(missing)}")
+
+    if len(df) < min_records:
+        raise NISRAValidationError(f"Expected at least {min_records} records, got {len(df)}")
+
+    unknown = set(df["table"].dropna().unique()) - set(TABLE_DIMENSIONS.values())
+    if unknown:
+        raise NISRAValidationError(f"Unknown table labels: {sorted(unknown)}")
+
+    values = df["value"].dropna()
+    if (values < 0).any():
+        raise NISRAValidationError(f"value contains negative entries; min = {values.min()}")
+
+    rates = df.loc[df["measure"].isin(RATE_MEASURES), "value"].dropna()
+    if len(rates) > 0 and rates.max() > 1:
+        raise NISRAValidationError(f"Rate measures must be proportions in [0, 1]; max = {rates.max()}")
+
+    return True

--- a/tests/test_health_ni_hsc_workforce_integrity.py
+++ b/tests/test_health_ni_hsc_workforce_integrity.py
@@ -1,0 +1,382 @@
+"""Data integrity tests for the NI HSC Workforce Statistics module.
+
+These tests validate that the workforce data is internally consistent across
+the several differently-shaped tables flattened out of each quarterly
+workbook.  They use real data (no mocks) with a ``scope="class"`` fixture so
+the network fetch happens once per class.
+
+Key validations:
+- Required columns present, with the expected dtypes
+- Every published quarter contributes a six-year series (24 reference dates)
+- ``Total`` rows reconcile exactly against the sum of their parts, both by
+  staff group and by HSC organisation, and against the Table 1 headline WTE
+- Pay band shares sum to 1 for each staff group
+- Headcount is below active posts (individuals holding multiple posts)
+- Validation helper raises on bad input
+"""
+
+import pandas as pd
+import pytest
+
+from bolster.data_sources.health_ni import hsc_workforce as hw
+from bolster.data_sources.health_ni._base import NISRAValidationError
+
+#: The five geographic HSC Trusts, always present in the organisation table.
+HSC_TRUSTS = {
+    "Belfast HSC Trust",
+    "Northern HSC Trust",
+    "South Eastern HSC Trust",
+    "Southern HSC Trust",
+    "Western HSC Trust",
+}
+
+
+class TestHSCWorkforceIntegrity:
+    """Integration tests using real downloaded workbooks."""
+
+    @pytest.fixture(scope="class")
+    def latest_data(self) -> pd.DataFrame:
+        """Download and parse every published quarterly release once."""
+        return hw.get_latest_data()
+
+    def test_required_columns(self, latest_data: pd.DataFrame) -> None:
+        """All required columns must be present."""
+        missing = hw.REQUIRED_COLUMNS - set(latest_data.columns)
+        assert not missing, f"Missing columns: {sorted(missing)}"
+
+    def test_dataframe_not_empty(self, latest_data: pd.DataFrame) -> None:
+        """Dataset must contain a substantial number of records."""
+        assert len(latest_data) >= 1000
+
+    def test_date_dtype(self, latest_data: pd.DataFrame) -> None:
+        """Date column must be datetime-typed."""
+        assert pd.api.types.is_datetime64_any_dtype(latest_data["date"])
+
+    def test_value_dtype_is_float(self, latest_data: pd.DataFrame) -> None:
+        """WTE figures are fractional, so value must be float-typed."""
+        assert pd.api.types.is_float_dtype(latest_data["value"])
+
+    def test_quarters_are_valid(self, latest_data: pd.DataFrame) -> None:
+        """Quarter must always be 1-4 and agree with the month of the date."""
+        assert set(latest_data["quarter"].unique()).issubset({1, 2, 3, 4})
+        derived = latest_data["date"].dt.quarter
+        assert (latest_data["quarter"] == derived).all()
+
+    def test_dates_are_period_ends(self, latest_data: pd.DataFrame) -> None:
+        """Every reference date must be a quarter end (March/June/Sept/Dec)."""
+        months = set(latest_data["date"].dt.month.unique())
+        assert months.issubset({3, 6, 9, 12}), f"Unexpected months: {sorted(months)}"
+
+    def test_historical_coverage(self, latest_data: pd.DataFrame) -> None:
+        """Each release carries a six-year series, so coverage far exceeds the
+        handful of publications currently listed."""
+        assert latest_data["date"].nunique() >= 20
+        assert latest_data["date"].min() <= pd.Timestamp("2021-03-31")
+        assert latest_data["date"].max() >= pd.Timestamp("2025-03-31")
+
+    def test_expected_tables_present(self, latest_data: pd.DataFrame) -> None:
+        """All documented table dimensions must appear in the output."""
+        missing = set(hw.TABLE_DIMENSIONS.values()) - set(latest_data["table"].unique())
+        assert not missing, f"Missing tables: {sorted(missing)}"
+
+    def test_no_negative_values(self, latest_data: pd.DataFrame) -> None:
+        """Staff counts and rates must never be negative."""
+        assert (latest_data["value"].dropna() >= 0).all()
+
+    def test_trusts_present(self, latest_data: pd.DataFrame) -> None:
+        """The five geographic Trusts must appear among the organisations."""
+        organisations = set(hw.list_organisations(latest_data))
+        assert HSC_TRUSTS.issubset(organisations)
+
+    def test_ambulance_service_present(self, latest_data: pd.DataFrame) -> None:
+        """NIAS is reported as an organisation alongside the five Trusts."""
+        organisations = set(hw.list_organisations(latest_data))
+        assert any("Ambulance" in name for name in organisations)
+
+    def test_staff_groups_present(self, latest_data: pd.DataFrame) -> None:
+        """The major clinical staff groups must be present."""
+        groups = set(hw.list_staff_groups(latest_data))
+        assert "Medical & Dental" in groups
+        assert "Registered Nursing & Midwifery" in groups
+        assert len(groups) >= 8
+
+    def test_organisation_totals_reconcile(self, latest_data: pd.DataFrame) -> None:
+        """The organisation Total must equal the sum of the individual orgs."""
+        table = latest_data[latest_data["table"] == "organisation"]
+        for date, group in table.groupby("date"):
+            total = group.loc[group["organisation"] == "Total", "value"]
+            if total.empty:
+                continue
+            parts = group.loc[group["organisation"] != "Total", "value"].sum()
+            assert float(total.iloc[0]) == pytest.approx(parts, rel=1e-6), f"Organisation total mismatch at {date.date()}"
+
+    def test_staff_group_totals_reconcile(self, latest_data: pd.DataFrame) -> None:
+        """The staff group Total must equal the sum of the individual groups."""
+        table = latest_data[latest_data["table"] == "staff_group"]
+        for date, group in table.groupby("date"):
+            total = group.loc[group["staff_group"] == "Total", "value"]
+            if total.empty:
+                continue
+            parts = group.loc[group["staff_group"] != "Total", "value"].sum()
+            assert float(total.iloc[0]) == pytest.approx(parts, rel=1e-6), f"Staff group total mismatch at {date.date()}"
+
+    def test_summary_wte_matches_organisation_total(self, latest_data: pd.DataFrame) -> None:
+        """Headline WTE (Table 1) must agree with the organisation Total (Table 3)."""
+        summary = latest_data[(latest_data["table"] == "summary") & (latest_data["measure"] == "wte")].set_index(
+            "date"
+        )["value"]
+        organisations = latest_data[
+            (latest_data["table"] == "organisation") & (latest_data["organisation"] == "Total")
+        ].set_index("date")["value"]
+        shared = summary.index.intersection(organisations.index)
+        assert len(shared) >= 20
+        for date in shared:
+            assert float(summary[date]) == pytest.approx(float(organisations[date]), rel=1e-6)
+
+    def test_headcount_below_active_posts(self, latest_data: pd.DataFrame) -> None:
+        """Some staff hold more than one post, so headcount < active posts."""
+        summary = latest_data[latest_data["table"] == "summary"].pivot_table(
+            index="date", columns="measure", values="value"
+        )
+        assert (summary["headcount"] < summary["active_posts"]).all()
+
+    def test_multiple_post_holders_reconcile(self, latest_data: pd.DataFrame) -> None:
+        """Surplus posts must be at least the number of multiple-post holders.
+
+        Someone holding three posts adds two surplus posts but counts once as an
+        individual, so the surplus is an upper bound on the holder count.
+        """
+        summary = latest_data[latest_data["table"] == "summary"].pivot_table(
+            index="date", columns="measure", values="value"
+        )
+        surplus = summary["active_posts"] - summary["headcount"]
+        holders = summary["individuals_multiple_posts"]
+        assert (surplus >= holders).all()
+        assert (surplus <= holders * 1.1).all()
+
+    def test_wte_below_headcount(self, latest_data: pd.DataFrame) -> None:
+        """Part-time working means WTE is always below headcount."""
+        summary = latest_data[latest_data["table"] == "summary"].pivot_table(
+            index="date", columns="measure", values="value"
+        )
+        assert (summary["wte"] < summary["headcount"]).all()
+
+    def test_pay_band_shares_sum_to_one(self, latest_data: pd.DataFrame) -> None:
+        """Each staff group's pay band proportions must sum to 1."""
+        bands = hw.get_pay_bands(latest_data)
+        assert len(bands) > 0
+        sums = bands.groupby(["date", "staff_group"])["value"].sum()
+        assert sums.between(0.99, 1.01).all(), f"Pay band shares out of range: {sums[~sums.between(0.99, 1.01)]}"
+
+    def test_rate_measures_are_proportions(self, latest_data: pd.DataFrame) -> None:
+        """Joining, leaving and stability rates are proportions, not percentages."""
+        rates = latest_data.loc[latest_data["measure"].isin(hw.RATE_MEASURES), "value"].dropna()
+        assert len(rates) > 0
+        assert rates.between(0, 1).all()
+
+    def test_turnover_is_march_only(self, latest_data: pd.DataFrame) -> None:
+        """Turnover tables are reported by financial year, so always end 31 March."""
+        turnover = hw.get_turnover(latest_data)
+        assert len(turnover) > 0
+        assert (turnover["date"].dt.month == 3).all()
+
+    def test_stability_rate_plausible(self, latest_data: pd.DataFrame) -> None:
+        """Annual workforce stability sits comfortably above 80%."""
+        stability = latest_data[latest_data["measure"] == "stability_rate"]["value"]
+        assert len(stability) > 0
+        assert stability.between(0.8, 1.0).all()
+
+    def test_total_wte_plausible(self, latest_data: pd.DataFrame) -> None:
+        """NI HSC employs on the order of 60-90k WTE staff."""
+        summary = latest_data[(latest_data["table"] == "summary") & (latest_data["measure"] == "wte")]["value"]
+        assert summary.between(50_000, 100_000).all()
+
+    def test_belfast_is_largest_trust(self, latest_data: pd.DataFrame) -> None:
+        """Belfast HSC Trust is consistently the largest employer of the five."""
+        organisations = hw.get_organisations(latest_data)
+        latest = organisations[organisations["date"] == organisations["date"].max()]
+        trusts = latest[latest["organisation"].isin(HSC_TRUSTS)]
+        assert trusts.loc[trusts["value"].idxmax(), "organisation"] == "Belfast HSC Trust"
+
+    def test_workforce_grew_over_period(self, latest_data: pd.DataFrame) -> None:
+        """Headline WTE has risen across the covered period."""
+        summary = (
+            latest_data[(latest_data["table"] == "summary") & (latest_data["measure"] == "wte")]
+            .sort_values("date")
+            .set_index("date")["value"]
+        )
+        assert summary.iloc[-1] > summary.iloc[0]
+
+    def test_no_duplicate_observations(self, latest_data: pd.DataFrame) -> None:
+        """Each dimension combination must appear at most once."""
+        dimensions = ["date", "table", "measure", "organisation", "staff_group", "grade_band"]
+        assert not latest_data.duplicated(subset=dimensions).any()
+
+    def test_cross_tab_covers_published_quarters(self, latest_data: pd.DataFrame) -> None:
+        """Tables 4/5 are current-quarter only, so appear once per publication."""
+        cross_tab = latest_data[latest_data["table"] == "organisation_staff_group"]
+        assert cross_tab["date"].nunique() >= 3
+
+    def test_other_organisations_decompose(self, latest_data: pd.DataFrame) -> None:
+        """Table 5 decomposes the 'Other HSC Organisations' row of Table 4."""
+        cross_tab = latest_data[latest_data["table"] == "organisation_staff_group"]
+        assert "Other HSC Organisations" in set(cross_tab["organisation"].dropna())
+        other = latest_data[latest_data["table"] == "other_organisation_staff_group"]
+        assert "Public Health Agency" in set(other["organisation"].dropna())
+
+    def test_validate_data_passes(self, latest_data: pd.DataFrame) -> None:
+        """The shipped data must satisfy its own validation rules."""
+        assert hw.validate_data(latest_data) is True
+
+
+class TestAccessors:
+    """Accessor helpers filter the tidy frame down to a single table."""
+
+    @pytest.fixture(scope="class")
+    def latest_data(self) -> pd.DataFrame:
+        return hw.get_latest_data()
+
+    def test_get_summary(self, latest_data: pd.DataFrame) -> None:
+        assert set(hw.get_summary(latest_data)["table"].unique()) == {"summary"}
+
+    def test_get_staff_groups_excludes_total(self, latest_data: pd.DataFrame) -> None:
+        groups = hw.get_staff_groups(latest_data)
+        assert "Total" not in set(groups["staff_group"])
+
+    def test_get_staff_groups_can_include_total(self, latest_data: pd.DataFrame) -> None:
+        groups = hw.get_staff_groups(latest_data, include_total=True)
+        assert "Total" in set(groups["staff_group"])
+
+    def test_get_organisations_excludes_total(self, latest_data: pd.DataFrame) -> None:
+        organisations = hw.get_organisations(latest_data)
+        assert "Total" not in set(organisations["organisation"])
+
+    def test_get_organisations_can_include_total(self, latest_data: pd.DataFrame) -> None:
+        organisations = hw.get_organisations(latest_data, include_total=True)
+        assert "Total" in set(organisations["organisation"])
+
+    def test_get_turnover_tables(self, latest_data: pd.DataFrame) -> None:
+        assert set(hw.get_turnover(latest_data)["table"].unique()) == {"leavers", "joiners", "stability"}
+
+
+class TestPublicationDiscovery:
+    """The article page must list parseable quarterly publications."""
+
+    @pytest.fixture(scope="class")
+    def publications(self) -> list[dict]:
+        return hw.list_publications()
+
+    def test_publications_found(self, publications: list[dict]) -> None:
+        assert len(publications) > 0
+
+    def test_publications_sorted_oldest_first(self, publications: list[dict]) -> None:
+        dates = [publication["date"] for publication in publications]
+        assert dates == sorted(dates)
+
+    def test_publication_fields(self, publications: list[dict]) -> None:
+        for publication in publications:
+            assert publication["url"].startswith("https://")
+            assert publication["quarter"] in {1, 2, 3, 4}
+            assert publication["date"].month in {3, 6, 9, 12}
+
+    def test_workbook_link_resolves(self, publications: list[dict]) -> None:
+        url = hw.find_publication_xlsx(publications[-1]["url"])
+        assert url.lower().endswith(".xlsx")
+
+
+class TestValidation:
+    """Unit tests for validation edge cases - no network calls needed."""
+
+    def _frame(self, **overrides) -> pd.DataFrame:
+        row = {
+            "date": pd.Timestamp("2026-03-31"),
+            "year": 2026,
+            "quarter": 1,
+            "table": "summary",
+            "measure": "wte",
+            "organisation": None,
+            "staff_group": None,
+            "grade_band": None,
+            "value": 68341.2887,
+        }
+        row.update(overrides)
+        return pd.DataFrame([row] * 1000, columns=hw.COLUMNS)
+
+    def test_validate_empty_dataframe(self) -> None:
+        with pytest.raises(NISRAValidationError, match="empty"):
+            hw.validate_data(pd.DataFrame())
+
+    def test_validate_none(self) -> None:
+        with pytest.raises(NISRAValidationError, match="empty"):
+            hw.validate_data(None)
+
+    def test_validate_missing_columns(self) -> None:
+        frame = self._frame().drop(columns=["grade_band"])
+        with pytest.raises(NISRAValidationError, match="Missing required columns"):
+            hw.validate_data(frame)
+
+    def test_validate_too_few_records(self) -> None:
+        with pytest.raises(NISRAValidationError, match="at least"):
+            hw.validate_data(self._frame().head(10))
+
+    def test_validate_unknown_table(self) -> None:
+        with pytest.raises(NISRAValidationError, match="Unknown table"):
+            hw.validate_data(self._frame(table="mystery"))
+
+    def test_validate_negative_values(self) -> None:
+        with pytest.raises(NISRAValidationError, match="negative"):
+            hw.validate_data(self._frame(value=-1.0))
+
+    def test_validate_rate_above_one(self) -> None:
+        with pytest.raises(NISRAValidationError, match="proportions"):
+            hw.validate_data(self._frame(table="leavers", measure="leaving_rate", value=55.0))
+
+    def test_validate_passes_on_good_frame(self) -> None:
+        assert hw.validate_data(self._frame()) is True
+
+
+class TestHelpers:
+    """Unit tests for the parsing helpers - no network calls needed."""
+
+    def test_clean_label_strips_footnotes(self) -> None:
+        assert hw._clean_label("Nursing & Midwifery Support [note 1]") == "Nursing & Midwifery Support"
+
+    def test_clean_label_collapses_whitespace(self) -> None:
+        assert hw._clean_label("Pay bands 8 \n& above") == "Pay bands 8 & above"
+
+    def test_clean_label_normalises_punctuation(self) -> None:
+        assert hw._clean_label("Children’s Court") == "Children's Court"
+
+    def test_clean_label_returns_none_for_blank(self) -> None:
+        assert hw._clean_label(None) is None
+        assert hw._clean_label("   ") is None
+        assert hw._clean_label(float("nan")) is None
+
+    def test_period_end(self) -> None:
+        assert hw._period_end(2026, 3) == pd.Timestamp("2026-03-31")
+        assert hw._period_end(2024, 2) == pd.Timestamp("2024-02-29")
+
+    def test_as_year_accepts_floats(self) -> None:
+        assert hw._as_year(2021.0) == 2021
+
+    def test_as_year_rejects_non_years(self) -> None:
+        assert hw._as_year("% Change 2021 to 2026") is None
+        assert hw._as_year(None) is None
+        assert hw._as_year(12) is None
+
+    def test_as_financial_year_end(self) -> None:
+        assert hw._as_financial_year_end("2025/26") == 2026
+
+    def test_as_financial_year_end_rejects_labels(self) -> None:
+        assert hw._as_financial_year_end("Leavers") is None
+        assert hw._as_financial_year_end(None) is None
+
+    def test_as_measure_known_label(self) -> None:
+        assert hw._as_measure("Individuals with multiple posts") == "individuals_multiple_posts"
+        assert hw._as_measure("Leaving Rate (%)") == "leaving_rate"
+
+    def test_as_measure_falls_back_to_slug(self) -> None:
+        assert hw._as_measure("Some New Measure") == "some_new_measure"
+
+    def test_as_measure_none(self) -> None:
+        assert hw._as_measure(None) is None


### PR DESCRIPTION
## Summary

Adds `bolster.data_sources.health_ni.hsc_workforce`, covering the Department of Health's quarterly [HSC Workforce Statistics](https://www.health-ni.gov.uk/articles/staff-numbers) — staff numbers by staff group, organisation and Agenda for Change pay band, plus financial-year turnover and workforce stability.

The publication is not in PxStat, so this scrapes the staff-numbers article page for each quarterly release and flattens the multi-table workbooks into one tidy frame keyed by a `table` discriminator column.

**Each quarterly release carries a six-year series at its own quarter point**, so combining the four published releases yields **24 distinct reference dates (June 2020 → March 2026)** rather than four — a considerably longer history than the publication page suggests at first glance.

Closes #1881

## Example insights

- **The workforce grew ~10% in six years**: 61,994 WTE at June 2020 → 68,341 WTE at March 2026.
- **Turnover has eased markedly**: the annual leaving rate fell from 8.1% (2021/22) to 6.3% (2025/26), with workforce stability rising to 91.5%.
- **Multi-post working is small but real**: 76,855 people hold 77,705 active posts at March 2026, with 826 individuals holding more than one post. Belfast HSC Trust remains the largest employer at 19,499 WTE, against Southern's 10,604.

## Usage

```python
from bolster.data_sources.health_ni import hsc_workforce

df = hsc_workforce.get_latest_data()

hsc_workforce.get_summary(df)        # headline WTE, headcount, active posts
hsc_workforce.get_organisations(df)  # by trust and other HSC body
hsc_workforce.get_staff_groups(df)   # by staff group
hsc_workforce.get_pay_bands(df)      # Agenda for Change band shares
hsc_workforce.get_turnover(df)       # leavers, joiners, stability rates
```

```console
$ bolster nisra hsc-workforce
$ bolster nisra hsc-workforce --dimension organisation
$ bolster nisra hsc-workforce --dimension pay_band --staff-group Medical
$ bolster nisra hsc-workforce --dimension stability --format json
```

## Test plan

- [x] 59 integrity tests pass against live data, with no mocks
- [x] Assertions anchored to relationships verified in the published workbooks: organisation and staff-group totals reconcile exactly with their components at all 24 dates; pay band shares sum to 1 per staff group; summary WTE matches the organisation total
- [x] Validation and label-parsing edge cases covered without network calls
- [x] `uv run pre-commit run --all-files` clean
- [x] Full coverage suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
