### PR TITLE
docs(psni): correct false Cloudflare-blocked claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,11 +251,11 @@ The [GOV.UK NISRA statistics RSS feed](https://www.gov.uk/search/research-and-st
 | NI Multiple Deprivation Measure 2017 (NIMDM, SOA-level) | `nisra.deprivation` | ✅ |
 | Translink Live Departures & Vehicle Positions | `translink` | ✅ |
 | Child Maintenance Service Statistics (DfC) | `dfc.child_maintenance` | ✅ |
-| Security Situation Statistics | - | ❌ Cloudflare-blocked |
-| Anti-social Behaviour | - | ❌ Cloudflare-blocked |
-| Domestic Abuse Incidents/Crimes | - | ❌ Cloudflare-blocked |
-| Drug Seizures & Arrests | - | ❌ Cloudflare-blocked |
-| Hate Incidents & Crimes | - | ❌ Cloudflare-blocked |
+| Security Situation Statistics | - | 🔍 not built; source reachable |
+| Anti-social Behaviour | - | 🔍 not built; source reachable |
+| Domestic Abuse Incidents/Crimes | - | 🔍 not built; source reachable |
+| Drug Seizures & Arrests | - | 🔍 not built; source reachable |
+| Hate Motivation Statistics | - | 🔍 not built; source reachable |
 | Road Traffic Collisions | `psni.road_traffic_collisions` | ✅ |
 | PSNI Crime Statistics | `psni.crime_statistics` | ⚠️ historical only (Apr 2001–Dec 2021); `get_latest` raises `PSNIDataStaleError` |
 | Police Ombudsman Complaints | `psni.police_ombudsman` | ✅ |

--- a/src/bolster/data_sources/psni/DATA_RESEARCH.md
+++ b/src/bolster/data_sources/psni/DATA_RESEARCH.md
@@ -14,7 +14,10 @@ ______________________________________________________________________
 ### Access Status
 
 - **Website:** https://www.psni.police.uk/about-us/our-publications-and-reports/official-statistics
-- **Status:** Website uses Cloudflare protection that blocks automated access
+- **Status:** Reachable. Sits behind Cloudflare, which blocks some hosting-provider
+  egress IPs — verified HTTP 200 for the index and all topic pages from GitHub Actions
+  (2026-08-01). Earlier "blocked" findings in this document were recorded from a
+  datacentre IP and do not generalise.
 - **Alternative Access:** Data is mirrored on OpenDataNI (https://www.opendatani.gov.uk) and data.gov.uk
 
 ### Key Publications
@@ -22,6 +25,25 @@ ______________________________________________________________________
 - **Police Recorded Crime in Northern Ireland Annual Trends** - Main publication with detailed crime type breakdowns
 - **User Guide to Police Recorded Crime Statistics** - Methodology and process changes documentation
 - **Monthly Updates** - Quarterly data releases within financial years
+
+### Official Statistics Index — Topic Pages
+
+Scraped from the index on 2026-08-01 (all HTTP 200). Paths are relative to
+`https://www.psni.police.uk`. Note the two topics that sit at a shorter path.
+
+| Topic | Path |
+| --- | --- |
+| Police Recorded Crime Statistics | `/about-us/our-publications-and-reports/official-statistics/police-recorded-crime-statistics` |
+| Anti-Social Behaviour Statistics | `/about-us/our-publications-and-reports/official-statistics/anti-social-behaviour-statistics` |
+| Domestic Abuse Statistics | `/about-us/our-publications-and-reports/official-statistics/domestic-abuse-statistics` |
+| Hate Motivation Statistics | `/about-us/our-publications-and-reports/official-statistics/hate-motivation-statistics` |
+| Drug Seizure Statistics | `/official-statistics/drug-seizure-statistics` |
+| Road Traffic Collision Statistics | `/about-us/our-publications-and-reports/official-statistics/road-traffic-collision-statistics` |
+| Security Situation Statistics | `/official-statistics/security-situation-statistics` |
+| Stop and Search Statistics | `/about-us/our-publications-and-reports/official-statistics/stop-and-search-statistics` |
+| Statistics on Police Use of Force | `/about-us/our-publications-and-reports/official-statistics/statistics-police-use-force` |
+| Motoring Offence Statistics | `/about-us/our-publications-and-reports/official-statistics/motoring-offence-statistics` |
+| Police and Criminal Evidence (PACE) Order Statistics | `/about-us/our-publications-and-reports/official-statistics/police-and-criminal-evidence-pace-order` |
 
 ______________________________________________________________________
 
@@ -449,8 +471,8 @@ ______________________________________________________________________
 
    - **URL:** https://www.psni.police.uk/about-us/our-publications-and-reports/official-statistics/police-recorded-crime-statistics
    - **Format:** PDF reports with embedded Excel tables (likely)
-   - **Status:** Protected by Cloudflare (blocks automated access)
-   - **Access Method:** Manual download via web browser
+   - **Status:** Reachable (HTTP 200 from GitHub Actions, 2026-08-01)
+   - **Access Method:** Scrapeable; no scraper built yet
 
 1. **PSNI Statistics Branch** - Direct Contact
 
@@ -489,11 +511,12 @@ ______________________________________________________________________
    - **Pros:** Official channel, may provide clean data
    - **Cons:** Requires manual intervention, unknown response time
 
-1. **RSS Feed Monitoring** (Blocked by Cloudflare)
+1. **RSS Feed Monitoring**
 
    - PSNI website has RSS feeds for new publications
-   - **Status:** RSS feeds are also protected by Cloudflare (HTTP 403)
-   - **Conclusion:** Not viable for automated monitoring
+   - **Status:** The earlier HTTP 403 was recorded from a datacentre egress IP; retest
+     before treating it as a limitation
+   - **Conclusion:** Worth re-evaluating for automated monitoring
 
 #### Long-Term Solutions
 

--- a/src/bolster/data_sources/psni/_base.py
+++ b/src/bolster/data_sources/psni/_base.py
@@ -72,8 +72,7 @@ class PSNIDataStaleError(PSNIDataError):
     """Raised when a PSNI data source is known to be stale with no accessible update.
 
     This exception is raised when the underlying data source has not been updated
-    and no machine-readable replacement is accessible (e.g. due to Cloudflare
-    protection on the official PSNI website blocking automated downloads).
+    and this package has no route to a machine-readable replacement.
     """
 
     pass

--- a/src/bolster/data_sources/psni/crime_statistics.py
+++ b/src/bolster/data_sources/psni/crime_statistics.py
@@ -19,8 +19,7 @@ Data Source:
     The OpenDataNI dataset was last updated 27 January 2022 and only contains
     data through December 2021. PSNI stopped pushing updates to OpenDataNI after
     that date. The PSNI official statistics page publishes quarterly Excel files
-    with current data, but psni.police.uk is protected by Cloudflare which
-    blocks automated downloads.
+    with current data; a scraper for those has not been built yet.
 
     Calling ``get_latest_crime_statistics()`` will raise ``PSNIDataStaleError``
     to make this limitation explicit. The historical data (Apr 2001–Dec 2021)
@@ -62,7 +61,7 @@ from ._base import (
 
 logger = logging.getLogger(__name__)
 
-# OpenDataNI CSV URL (direct download, no Cloudflare protection)
+# OpenDataNI CSV URL (direct download)
 CRIME_STATISTICS_URL = "https://admin.opendatani.gov.uk/dataset/80dc9542-7b2a-48f5-bbf4-ccc7040d36af/resource/6fd51851-df78-4469-98c5-4f06953621a0/download/police-recorded-crime-monthly-data.csv"
 
 # Data guide for reference
@@ -236,18 +235,18 @@ def get_latest_crime_statistics(
 ) -> pd.DataFrame:
     """Raises PSNIDataStaleError — use get_historical_crime_statistics() instead.
 
-    The OpenDataNI source was last updated January 2022. PSNI's official site
-    publishes current data but is Cloudflare-protected and inaccessible to
-    automated downloads. Use ``get_historical_crime_statistics()`` to access
-    the data available (Apr 2001–Dec 2021).
+    The OpenDataNI source was last updated January 2022. PSNI publishes current
+    data on its own site, but a scraper for that has not been built. Use
+    ``get_historical_crime_statistics()`` to access the data available
+    (Apr 2001–Dec 2021).
 
     Raises:
-        PSNIDataStaleError: Always — this data source has no accessible update.
+        PSNIDataStaleError: Always — this module has no route to 2022+ data.
     """
     raise PSNIDataStaleError(
         "PSNI crime statistics are stale since January 2022 (last data: December 2021). "
-        "The OpenDataNI mirror has not been updated and the official PSNI website "
-        "(psni.police.uk) is Cloudflare-protected, blocking automated access to 2022+ data. "
+        "The OpenDataNI mirror has not been updated, and this module does not yet "
+        "scrape the quarterly Excel files PSNI publishes on its own site. "
         "To access the available historical data (Apr 2001–Dec 2021), use "
         "get_historical_crime_statistics() instead. "
         "For current data, visit: https://www.psni.police.uk/about-us/our-publications-and-reports/official-statistics/police-recorded-crime-statistics "

--- a/src/bolster/data_sources/psni/pace.py
+++ b/src/bolster/data_sources/psni/pace.py
@@ -11,11 +11,15 @@ published by PSNI Statistics Branch each May on the PSNI publications index:
 
     https://www.psni.police.uk/about-us/our-publications-and-reports/official-statistics/police-and-criminal-evidence-pace-order
 
-**URL discovery note**: The PSNI publications index page is protected by Cloudflare
-and cannot be scraped programmatically. Direct asset URLs at ``/sites/default/files/``
-*can* be fetched with a browser-like ``User-Agent`` + ``Referer`` header, but the
-filename portion of the URL is not predictable (includes the year in ``YYYY.YY``
-format and may include a revision suffix such as ``a2``).
+**URL discovery note**: The filename portion of each asset URL is not predictable
+— it includes the year in ``YYYY.YY`` format and may carry a revision suffix such
+as ``a2`` — so the download URL cannot be constructed from the year alone.
+
+psni.police.uk sits behind Cloudflare, which serves a block page to clients on some
+hosting-provider networks. This is an egress-reputation effect, not a property of
+the site: the publications index and its assets fetch normally from GitHub Actions
+and from ordinary consumer connections. Do not infer from a local 403 that the
+source is unavailable.
 
 The :data:`PACE_URLS` dict therefore hard-codes confirmed download URLs. It should
 be updated each May when PSNI publishes the new edition. Use
@@ -56,8 +60,7 @@ logger = logging.getLogger(__name__)
 #
 # IMPORTANT: Update this dict each May when PSNI publishes the new edition.
 # The URL filename is not predictable (year format YYYY.YY, sometimes with a
-# revision suffix like ``a2``).  The direct asset URLs can be fetched with the
-# browser-like headers defined in _base_http_headers.py.
+# revision suffix like ``a2``), so it must be read off the publications index.
 # ---------------------------------------------------------------------------
 PACE_URLS: dict[str, str] = {
     "2024/25": (


### PR DESCRIPTION
## Summary

`psni.police.uk` and `policeombudsman.org` were recorded across the README, module docstrings, and `DATA_RESEARCH.md` as blocking automated access via Cloudflare. That is not true.

A probe run from GitHub Actions (egress `172.185.31.97`) returned **HTTP 200 with no block page** for:

- the official-statistics index (260,439 bytes — the page `pace.py` claimed "cannot be scraped programmatically"; the probe scraped it and extracted all 11 topic links)
- every topic page under it
- both Police Ombudsman pages

The 403s seen locally are an **egress-reputation effect** — this sandbox egresses from a DigitalOcean AMS-3 address that Cloudflare rate-limits. It is not a property of the sites, and it does not affect CI or ordinary consumer connections.

## What changed

| File | Change |
| --- | --- |
| `README.md` | Five rows `❌ Cloudflare-blocked` → `🔍 not built; source reachable`. Last row renamed to its real upstream title, "Hate Motivation Statistics". |
| `crime_statistics.py` | Docstring and `PSNIDataStaleError` message: reason corrected from "Cloudflare blocks downloads" to "a scraper has not been built". |
| `pace.py` | Replaced the "cannot be scraped" note with an accurate description of the egress effect. Fixed a stale comment referencing a non-existent `_base_http_headers.py`. |
| `_base.py` | `PSNIDataStaleError` docstring generalised away from Cloudflare. |
| `DATA_RESEARCH.md` | Three status lines corrected; added the probe's full topic-URL inventory. |

## What deliberately did *not* change

`get_latest_crime_statistics()` **still raises**. The OpenDataNI mirror genuinely stopped updating in January 2022 (`DATA_RESEARCH.md:440`), independent of any blocking. Only the stated *reason* was wrong. Re-enabling it would require building a new scraper, which is out of scope here.

## Test plan

- [x] `ruff check` + `ruff format --check` clean
- [x] `uv run pytest tests/test_psni_crime_statistics_integrity.py tests/test_psni_pace_integrity.py -q` → 67 passed
- [ ] CI green

Related: #2041 (egress investigation), PR #2040.

🤖 Generated with [Claude Code](https://claude.com/claude-code)