### PR TITLE
chore: remove pre-push full-suite coverage gate

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -75,16 +75,6 @@ repos:
             # Only run on Python files in src/ to match other checks
             files: ^src/.*\.py$
 
-          - id: coverage-check
-            name: Run tests with coverage (pre-push gate)
-            entry: bash
-            language: system
-            args:
-                - -c
-                - uv run pytest tests/ -q --cov=src/bolster --cov-report=xml:cov.xml --cov-fail-under=80
-            pass_filenames: false
-            stages: [pre-push]
-
     # - repo: https://github.com/kynan/nbstripout
     #   rev: 0.8.1
     #   hooks:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,13 +37,13 @@ Keep flat modules when the data source is standalone.
 
 ```bash
 uv run pytest tests/ -q --no-cov                     # Quick local run (no coverage)
-uv run pytest tests/ -q --cov=src/bolster --cov-report=xml:cov.xml  # Full run with coverage (required before push)
+uv run pytest tests/ -q --cov=src/bolster --cov-report=xml:cov.xml  # Full run with coverage
 make test                                            # Same as above via Makefile
 uv run pre-commit run --all-files                    # Lint/format
 uv run bolster --help                                # CLI
 ```
 
-**Coverage gate**: always run the full coverage suite before pushing. The `pre-push` hook in `.pre-commit-config.yaml` enforces this automatically when using `git push`. `cli.py` is omitted from coverage by design — confirm it's absent from `cov.xml` with `grep cli cov.xml` (should return nothing).
+**Coverage gate**: CI enforces coverage; there is no local pre-push hook. Run the full coverage suite yourself when a change warrants it. `cli.py` is omitted from coverage by design — confirm it's absent from `cov.xml` with `grep cli cov.xml` (should return nothing).
 
 ## Tool Preferences
 


### PR DESCRIPTION
## Summary

- Removes the `coverage-check` hook from `.pre-commit-config.yaml`, which ran the full 2200-test suite with `--cov-fail-under=80` on every `git push`.
- Updates `AGENTS.md` to stop claiming a pre-push hook enforces coverage.

## Why

The hook was added in #1811 (closing #1808). The issue asked for an *optional* hook gating on patch coverage of changed files; what landed was an unconditional full-suite run. Running an exhaustive suite on every push is too heavy a gate.

It has never actually fired — `.git/hooks/pre-push` was never installed locally — so this removes no behaviour anyone currently relies on. Left in place, it's a trap for anyone who runs `pre-commit install --hook-type pre-push` on a fresh clone and suddenly finds pushes blocked on a full network-backed test run.

CI remains the coverage gate.

## Test plan

- [x] `uv run pre-commit run --all-files` passes (config still parses, remaining hooks unaffected)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)