### PR TITLE
ci(lint): match pre-commit scope and add ruff format check

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,9 +13,17 @@ jobs:
         runs-on: ubuntu-latest
         steps:
           - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
+          # Scope and version both mirror .pre-commit-config.yaml so CI and the
+          # local hooks cannot disagree about what counts as clean.
           - uses: astral-sh/ruff-action@278981a28ce3188b1e39527901f38254bf3aac89  # v4.1.0
             with:
-              src: "./src"  # Only check src directory to match pre-commit scope
+              version: "0.9.10"
+              src: "./src ./tests"
+          - uses: astral-sh/ruff-action@278981a28ce3188b1e39527901f38254bf3aac89  # v4.1.0
+            with:
+              version: "0.9.10"
+              src: "./src ./tests"
+              args: "format --check --diff"
 
     security:
         runs-on: ubuntu-latest

--- a/tests/test_daera_greenhouse_gas_integrity.py
+++ b/tests/test_daera_greenhouse_gas_integrity.py
@@ -454,9 +454,7 @@ class TestCrossValidation:
         """PfG progress is the headline series expressed in MtCO2e."""
         pfg = get_pfg_progress()
         row = pfg[pfg["year"] == latest]
-        assert float(row["emissions_mtco2e"].iloc[0]) == pytest.approx(
-            headline_ktco2e / 1000, rel=1e-6
-        )
+        assert float(row["emissions_mtco2e"].iloc[0]) == pytest.approx(headline_ktco2e / 1000, rel=1e-6)
 
     def test_gas_changes_total_matches_headline(self, headline_ktco2e):
         changes = get_gas_changes().set_index("gas")["latest_year_mtco2e"]
@@ -481,9 +479,9 @@ class TestCrossValidation:
         sectors = get_emissions_by_sector()
         current = sectors[sectors["year"] == latest].set_index("sector")["emissions_ktco2e"]
         for sector in NI_SECTORS:
-            assert float(changes[sector]) == pytest.approx(
-                float(current[sector]) / 1000, abs=0.01
-            ), f"{sector} disagrees between the change table and the time series"
+            assert float(changes[sector]) == pytest.approx(float(current[sector]) / 1000, abs=0.01), (
+                f"{sector} disagrees between the change table and the time series"
+            )
 
     def test_revisions_current_edition_matches_series(self):
         """Revision table's 'current edition' column is this year's inventory."""

--- a/tests/test_dfc_child_maintenance_integrity.py
+++ b/tests/test_dfc_child_maintenance_integrity.py
@@ -70,7 +70,9 @@ class TestPublicationDiscovery:
 
     def test_missing_publication_raises(self):
         with pytest.raises(cm.CMSDataNotFoundError):
-            cm.find_publication_xlsx("https://www.communities-ni.gov.uk/publications/no-such-publication-data-june-2020")
+            cm.find_publication_xlsx(
+                "https://www.communities-ni.gov.uk/publications/no-such-publication-data-june-2020"
+            )
 
 
 @pytest.mark.integration
@@ -115,7 +117,9 @@ class TestLatestPublication:
     def test_maintenance_paid_below_due(self, df):
         maintenance = df[df["table"] == "maintenance"]
         pivot = maintenance.pivot_table(index="date", columns="subcategory", values="value")
-        assert (pivot["Maintenance paid through Collect & Pay"] <= pivot["Maintenance due to be paid through Collect & Pay"]).all()
+        assert (
+            pivot["Maintenance paid through Collect & Pay"] <= pivot["Maintenance due to be paid through Collect & Pay"]
+        ).all()
 
     def test_characteristics_proportions_sum_per_group(self, df):
         characteristics = df[(df["table"] == "paying_parent_characteristics") & (df["measure"] == "proportion")]
@@ -289,9 +293,7 @@ class TestQuarterParsing:
     def test_parses(self, raw, expected):
         assert cm._parse_quarter(raw).date() == expected
 
-    @pytest.mark.parametrize(
-        "raw", ["", None, "Total", "Source: DfC", "December 2020", 42]
-    )
+    @pytest.mark.parametrize("raw", ["", None, "Total", "Source: DfC", "December 2020", 42])
     def test_rejects(self, raw):
         assert cm._parse_quarter(raw) is None
 
@@ -305,7 +307,11 @@ class TestMeasureResolution:
             ("clearances", "Proportion Currently Cleared", ("Proportion Currently Cleared", "proportion")),
             ("clearances", "Cleared within 6 weeks", ("Cleared within 6 weeks", "proportion")),
             ("enforcement", "Sanctions", ("Sanctions", "amount_gbp")),
-            ("maintenance", "Maintenance paid through Collect & Pay", ("Maintenance paid through Collect & Pay", "amount_gbp")),
+            (
+                "maintenance",
+                "Maintenance paid through Collect & Pay",
+                ("Maintenance paid through Collect & Pay", "amount_gbp"),
+            ),
             ("applications", "Applications Received", ("Applications Received", "count")),
         ],
     )

--- a/tests/test_dfc_family_resources_survey_integrity.py
+++ b/tests/test_dfc_family_resources_survey_integrity.py
@@ -366,9 +366,7 @@ class TestIncomeAndStateSupport:
 
     def test_support_trend_total_exceeds_components(self, support_trend):
         """The all-recipients figure must be at least the income-related share."""
-        pivot = support_trend.pivot_table(
-            index="financial_year", columns="state_support_type", values="percentage"
-        )
+        pivot = support_trend.pivot_table(index="financial_year", columns="state_support_type", values="percentage")
         total = [c for c in pivot.columns if c.lower().startswith("all in receipt")][0]
         income_related = [c for c in pivot.columns if c.lower().startswith("on any income")][0]
         assert (pivot[total] >= pivot[income_related]).all()
@@ -427,7 +425,7 @@ class TestTenure:
     def test_district_coverage(self, by_district):
         """All eleven Local Government Districts must be present."""
         districts = set(by_district["district"])
-        assert DISTRICTS <= districts
+        assert districts >= DISTRICTS
         assert len(districts) == 11
 
     def test_district_tenures_consistent(self, by_district):
@@ -562,7 +560,7 @@ class TestCarersAndDisability:
     def test_disability_district_coverage(self, disability_districts):
         """All eleven districts plus the NI total must be present."""
         districts = set(disability_districts["district"])
-        assert DISTRICTS <= districts
+        assert districts >= DISTRICTS
         assert "Northern Ireland" in districts
         assert len(districts) == 12
 

--- a/tests/test_health_ni_hsc_recruitment_integrity.py
+++ b/tests/test_health_ni_hsc_recruitment_integrity.py
@@ -52,9 +52,7 @@ class TestRecruitmentIntegrity:
 
     def test_all_expected_tables_present(self, latest_data: pd.DataFrame) -> None:
         expected = {"1A", "1B", "2", "3", "4A", "4B", "5A", "5B", "6", "7", "8A", "8B", "8C"}
-        assert expected <= set(latest_data.table_id), (
-            f"Missing tables: {sorted(expected - set(latest_data.table_id))}"
-        )
+        assert expected <= set(latest_data.table_id), f"Missing tables: {sorted(expected - set(latest_data.table_id))}"
 
     def test_list_tables_matches_data(self, latest_data: pd.DataFrame) -> None:
         tables = hsc_recruitment.list_tables()

--- a/tests/test_health_ni_hsc_workforce_integrity.py
+++ b/tests/test_health_ni_hsc_workforce_integrity.py
@@ -59,9 +59,7 @@ class TestWorkforceIntegrity:
 
     def test_all_expected_tables_present(self, latest_data: pd.DataFrame) -> None:
         expected = {"1", "2A", "2B", "3", "4", "5", "6", "7A", "7B", "7C"}
-        assert expected <= set(latest_data.table_id), (
-            f"Missing tables: {sorted(expected - set(latest_data.table_id))}"
-        )
+        assert expected <= set(latest_data.table_id), f"Missing tables: {sorted(expected - set(latest_data.table_id))}"
 
     def test_list_tables_matches_data(self, latest_data: pd.DataFrame) -> None:
         tables = hsc_workforce.list_tables()

--- a/tests/test_justice_first_time_entrants_integrity.py
+++ b/tests/test_justice_first_time_entrants_integrity.py
@@ -160,10 +160,7 @@ class TestHeadlineFigures:
     @staticmethod
     def _value(df, table, category, measure, year="2024-25"):
         match = df[
-            (df["table"] == table)
-            & (df["category"] == category)
-            & (df["year"] == year)
-            & (df["measure"] == measure)
+            (df["table"] == table) & (df["category"] == category) & (df["year"] == year) & (df["measure"] == measure)
         ]
         assert len(match) == 1, f"expected one row for {table}/{category}/{year}/{measure}"
         return match["value"].iloc[0]

--- a/tests/test_justice_pps_statistical_bulletin_integrity.py
+++ b/tests/test_justice_pps_statistical_bulletin_integrity.py
@@ -274,7 +274,9 @@ class TestHistoricalSeries:
     def test_files_received_trend_plausible(self, historical):
         """Annual file receipts should stay within a stable band."""
         totals = historical[
-            (historical["table"] == "1a") & (historical["category"] == "All Files") & (historical["breakdown"] == "All PPS")
+            (historical["table"] == "1a")
+            & (historical["category"] == "All Files")
+            & (historical["breakdown"] == "All PPS")
         ]
         assert totals["value"].between(20000, 80000).all()
 

--- a/tests/test_nisra_housing_bulletin_integrity.py
+++ b/tests/test_nisra_housing_bulletin_integrity.py
@@ -270,9 +270,7 @@ class TestSocialHousingSupply:
             .groupby(["financial_year", "tenure"])["completions"]
             .sum()
         )
-        subtotals = annual[annual["housing_type"] == "Sub-total"].set_index(["financial_year", "tenure"])[
-            "completions"
-        ]
+        subtotals = annual[annual["housing_type"] == "Sub-total"].set_index(["financial_year", "tenure"])["completions"]
         common = components.index.intersection(subtotals.dropna().index)
         assert len(common) >= 20
         pd.testing.assert_series_equal(

--- a/tests/test_nisra_neet_integrity.py
+++ b/tests/test_nisra_neet_integrity.py
@@ -118,12 +118,18 @@ class TestQuarterlySeriesIntegrity:
         """
         difference = (series["male_neet"] + series["female_neet"] - series["total_neet"]).abs()
         bad = series[difference > 1000]
-        assert bad.empty, f"Gender counts do not sum to total:\n{bad[['quarter', 'male_neet', 'female_neet', 'total_neet']]}"
+        assert bad.empty, (
+            f"Gender counts do not sum to total:\n{bad[['quarter', 'male_neet', 'female_neet', 'total_neet']]}"
+        )
 
     def test_confidence_interval_brackets_total(self, series: pd.DataFrame) -> None:
         """Test that the count confidence interval contains its point estimate."""
-        bad = series[(series["total_neet_lower"] > series["total_neet"]) | (series["total_neet_upper"] < series["total_neet"])]
-        assert bad.empty, f"Count CI does not bracket estimate:\n{bad[['quarter', 'total_neet_lower', 'total_neet', 'total_neet_upper']]}"
+        bad = series[
+            (series["total_neet_lower"] > series["total_neet"]) | (series["total_neet_upper"] < series["total_neet"])
+        ]
+        assert bad.empty, (
+            f"Count CI does not bracket estimate:\n{bad[['quarter', 'total_neet_lower', 'total_neet', 'total_neet_upper']]}"
+        )
 
     def test_rate_confidence_interval_brackets_rate(self, series: pd.DataFrame) -> None:
         """Test that the rate confidence interval contains its point estimate."""
@@ -136,7 +142,7 @@ class TestQuarterlySeriesIntegrity:
     def test_rates_are_plausible(self, series: pd.DataFrame) -> None:
         """Test that NEET rates stay within the historically observed band."""
         rates = series["total_neet_rate_pct"]
-        assert 5 <= rates.min() and rates.max() <= 30, f"Implausible NEET rates: min={rates.min()}, max={rates.max()}"
+        assert rates.min() >= 5 and rates.max() <= 30, f"Implausible NEET rates: min={rates.min()}, max={rates.max()}"
 
     def test_validate_function_passes(self, series: pd.DataFrame) -> None:
         """Test that the module validator accepts its own output."""

--- a/tests/test_psni_road_safety_partnership_integrity.py
+++ b/tests/test_psni_road_safety_partnership_integrity.py
@@ -32,7 +32,7 @@ class TestDatasetDiscovery:
 
     def test_batches_do_not_overlap(self, datasets):
         """Each year must be published by exactly one batch."""
-        for earlier, later in zip(datasets, datasets[1:]):
+        for earlier, later in zip(datasets, datasets[1:], strict=False):
             assert earlier["end_year"] < later["start_year"], f"{earlier['url']} overlaps {later['url']}"
 
     def test_available_years_are_contiguous(self):
@@ -477,8 +477,8 @@ class TestCrossValidation:
         assert set(rsp_districts["district"]) == set(rtc_districts["district"])
 
     def test_lgd_codes_match_road_traffic_collisions(self, rsp_districts, rtc_districts):
-        rsp_map = dict(zip(rsp_districts["district"], rsp_districts["lgd_code"]))
-        rtc_map = dict(zip(rtc_districts["district"], rtc_districts["lgd_code"]))
+        rsp_map = dict(zip(rsp_districts["district"], rsp_districts["lgd_code"], strict=False))
+        rtc_map = dict(zip(rtc_districts["district"], rtc_districts["lgd_code"], strict=False))
         assert rsp_map == rtc_map
 
     def test_detection_years_overlap_collision_years(self):
@@ -508,7 +508,7 @@ class TestCrossValidation:
         """Every district must map onto the project-wide LGD code table."""
         from bolster.data_sources.psni.crime_statistics import get_lgd_code
 
-        for district, code in zip(rsp_districts["district"], rsp_districts["lgd_code"]):
+        for district, code in zip(rsp_districts["district"], rsp_districts["lgd_code"], strict=False):
             assert get_lgd_code(district) == code
 
     def test_detections_per_capita_are_plausible(self, rsp_districts):
@@ -524,7 +524,7 @@ class TestCrossValidation:
         if by_lgd.empty:
             pytest.skip("LGD-level population estimates unavailable for 2023")
 
-        for code, detections in zip(rsp_districts["lgd_code"], rsp_districts["detections"]):
+        for code, detections in zip(rsp_districts["lgd_code"], rsp_districts["detections"], strict=False):
             if code not in by_lgd.index:
                 continue
             per_1000 = detections / by_lgd[code] * 1000


### PR DESCRIPTION
## Summary

`.github/workflows/lint.yml` scoped ruff to `./src` with the comment *"Only check src directory to match pre-commit scope"* — that comment was wrong. `.pre-commit-config.yaml` scopes both `ruff` and `ruff-format` to `^(src|tests)/.*\.py$`. CI was **narrower** than the local hooks.

Worse: **no CI job ran `ruff format --check` anywhere.** `astral-sh/ruff-action` defaults to `ruff check` (lint only), so format drift was never going to be caught regardless of scope. Ten test files had accumulated drift that no CI run ever flagged.

Changes:
- Widen `src:` to `./src ./tests` to actually match pre-commit
- Add a second step running `format --check --diff`
- Pin the action to ruff `0.9.10`, matching the pre-commit `rev`
- Replace the false comment

## Why the version pin matters

The `ruff` dev dependency in `pyproject.toml` is unpinned and currently resolves to 0.16.1, which formats differently from the 0.9.10 that pre-commit pins — it wants to reformat 2 files the hooks accept. Without pinning the action, CI would reject files that pass locally, which is the failure mode this PR exists to prevent.

Leaving the unpinned dev dependency alone as out of scope, but it's the reason `uv run ruff format` and `pre-commit` disagree locally.

## Test plan

- [x] `uv run ruff check ./src ./tests` — clean
- [x] `uv run pre-commit run --all-files` — all hooks pass, including actionlint on the changed workflow
- [x] `uv run pytest` on the 10 reformatted files — 886 passed
- [ ] CI green on this PR (self-verifying: the new steps run against the widened scope)