### PR TITLE
refactor(cli): introspect list-sources from the Click command tree

### DIFF
--- a/src/bolster/cli.py
+++ b/src/bolster/cli.py
@@ -10231,113 +10231,73 @@ def translink_route_cmd(origin, destination, n, output_format, save):
         console.print(f"[green]Saved to {save}[/green]")
 
 
+_UNCATEGORISED = "OTHER"
+
+_SOURCE_CATEGORIES: tuple[tuple[str, tuple[str, ...]], ...] = (
+    ("WEATHER & ENVIRONMENT", ("get-precipitation",)),
+    ("WATER & UTILITIES", ("water-quality",)),
+    ("GOVERNMENT & POLITICS", ("ni-executive", "ni-elections", "niassembly")),
+    ("BUSINESS & PROPERTY", ("companies-house", "ni-house-prices", "gender-pay-gap")),
+    ("ECONOMY & FINANCE", ("ons-cpi", "boe-base-rate")),
+    ("TRANSPORT", ("translink", "dva")),
+    ("ENTERTAINMENT & LIFESTYLE", ("cinema-listings",)),
+    ("RSS & FEEDS", ("rss",)),
+    ("NISRA", ("nisra",)),
+    ("PSNI", ("psni",)),
+    ("GOVERNMENT DEPARTMENTS", ("daera", "dfc", "dfe", "dfi", "education", "justice")),
+)
+"""Display order for :func:`list_sources`.
+
+Commands missing from this map fall through to ``OTHER`` rather than being dropped,
+so an uncategorised command is a cosmetic gap rather than an invisible one.
+"""
+
+
+def _describe_commands(name: str, command: click.Command) -> list[tuple[str, str]]:
+    """Flatten a command and any subcommands into ``(invocation, summary)`` rows."""
+    rows = [(name, command.get_short_help_str(88))]
+    if isinstance(command, click.Group):
+        for sub_name, sub_command in sorted(command.commands.items()):
+            rows.extend(_describe_commands(f"{name} {sub_name}", sub_command))
+    return rows
+
+
 @cli.command()
 def list_sources():
     """List all available data sources and their descriptions.
 
-    Shows a comprehensive overview of all data sources available in the Bolster library,
-    organized by category with brief descriptions of what data each source provides.
+    The catalogue is introspected from the Click command tree, so every registered
+    command is listed with the summary line from its own docstring.
     """
+    category_of = {name: label for label, names in _SOURCE_CATEGORIES for name in names}
+    buckets: dict[str, list[tuple[str, str]]] = {label: [] for label, _ in _SOURCE_CATEGORIES}
+    buckets[_UNCATEGORISED] = []
+
+    for name, command in sorted(cli.commands.items()):
+        if name == "list-sources":
+            continue
+        buckets[category_of.get(name, _UNCATEGORISED)].extend(_describe_commands(name, command))
+
+    width = max(len(invocation) for rows in buckets.values() for invocation, _ in rows) + 2
+
     click.echo("\nBolster - Available Data Sources")
     click.echo("=" * 50)
 
-    click.echo("\nWEATHER & ENVIRONMENT")
-    click.echo("  get-precipitation    UK precipitation maps from Met Office API")
-    click.echo("                       Requires MET_OFFICE_API_KEY environment variable")
-
-    click.echo("\nWATER & UTILITIES")
-    click.echo("  water-quality        NI water quality data by postcode or zone")
-    click.echo("                       Chemical parameters, hardness, compliance info")
-
-    click.echo("\nGOVERNMENT & POLITICS")
-    click.echo("  ni-executive         NI Executive composition and dissolution history")
-    click.echo("                       Establishment dates, duration, interregnum periods")
-    click.echo("  ni-elections         NI Assembly election results (2016-2022)")
-    click.echo("                       Candidates, parties, constituencies, vote counts")
-    click.echo("  nisra deaths         NISRA weekly death registrations")
-    click.echo("                       Demographics (age/sex), geography (LGDs), place of death")
-    click.echo("  niassembly members   Current MLAs — name, party, constituency")
-    click.echo("  niassembly questions Assembly Q&As by department or MLA (since 2007)")
-    click.echo("  niassembly votes     Assembly division records with per-member votes")
-
-    click.echo("\nBUSINESS & PROPERTY")
-    click.echo("  companies-house      UK Companies House company data queries")
-    click.echo("                       Company search, Farset Labs related companies")
-    click.echo("  ni-house-prices      NI house price index data from official sources")
-    click.echo("                       Price trends by property type, region, time period")
-
-    click.echo("\nTRANSPORT")
-    click.echo("  dva                  DVA monthly test statistics (vehicle, driver, theory)")
-    click.echo("                       April 2014 - present, includes --summary dashboard")
-    click.echo("  translink departures Next N departures from a Translink stop")
-    click.echo("                       Live departure boards with optional vehicle enrichment")
-    click.echo("  translink vehicles   Live Translink vehicle positions from VMI feed")
-    click.echo("                       Filter by line or operator; ~66s refresh interval")
-
-    click.echo("\nENTERTAINMENT & LIFESTYLE")
-    click.echo("  cinema-listings      Cineworld movie listings and showtimes")
-    click.echo("                       Default: Belfast (site 117), supports other locations")
-
-    click.echo("\nRSS & FEEDS")
-    click.echo("  rss read             Generic RSS/Atom feed reader with filtering")
-    click.echo("                       Beautiful terminal output, JSON/CSV export")
-    click.echo("  rss nisra-statistics Browse NISRA publications feed")
-    click.echo("                       Research and statistics from NISRA via GOV.UK")
-
-    click.echo("\nNISRA DATA MODULES (bolster nisra <command>)")
-    click.echo("  nisra feed                 Browse NISRA RSS publications feed")
-    click.echo("  nisra deaths               Weekly death registrations (demographics, LGDs)")
-    click.echo("  nisra births               Monthly birth registrations")
-    click.echo("  nisra marriages            Monthly marriage registrations")
-    click.echo("  nisra stillbirths          Monthly stillbirth registrations")
-    click.echo("  nisra population           Annual mid-year population estimates")
-    click.echo("  nisra population-projections  Population projections to 2072 (NI + LGD)")
-    click.echo("  nisra migration            Migration estimates (derived + official LTI)")
-    click.echo("  nisra labour-market        LFS: quarterly employment/inactivity + monthly overview")
-    click.echo("  nisra quarterly-employment-survey  Employee jobs by sector (QES)")
-    click.echo("  nisra ashe                 Annual earnings survey (10 dimensions)")
-    click.echo("  nisra composite-index      NI Composite Economic Index (NICEI)")
-    click.echo("  nisra index-of-services    Quarterly Index of Services")
-    click.echo("  nisra index-of-production  Quarterly Index of Production")
-    click.echo("  nisra construction-output  Quarterly construction output")
-    click.echo("  nisra cancer-waiting-times Cancer treatment waiting times")
-    click.echo("  nisra emergency-care       Emergency care (A&E) 4-hour waiting times")
-    click.echo("  nisra elective-waiting-times  Elective/outpatient waiting times")
-    click.echo("  nisra wellbeing            Individual wellbeing statistics")
-    click.echo("  nisra work-quality         Work quality indicators (17 dimensions)")
-    click.echo("  nisra workless-households  Working/mixed/workless households (LFS)")
-    click.echo("  nisra planning-statistics  NI planning applications by council")
-    click.echo("  nisra registrar-general    Registrar General quarterly vital statistics")
-    click.echo("  nisra baby-names           Baby name registrations (1997–present)")
-    click.echo("  nisra occupancy            Tourism hotel/SSA occupancy surveys")
-    click.echo("  nisra visitors             Tourism visitor statistics")
-    click.echo("  nisra homelessness         NI Homelessness Bulletin (DfC/NIHE, biannual)")
-    click.echo("  nisra housing-bulletin     NI Housing Bulletin (DfC, quarterly)")
-
-    click.echo("\nPSNI DATA MODULES (bolster psni <command>)")
-    click.echo("  psni rtc                   Road traffic collisions, casualties, vehicles")
-    click.echo("  psni crime                 Historical crime statistics (Apr 2001–Dec 2021, stale)")
-    click.echo("  psni road-safety           Safety camera detections (RSP, 2011–2024)")
-
-    click.echo("\nOTHER DATA MODULES")
-    click.echo("  dva                        DVA monthly test statistics (vehicle, driver, theory)")
-    click.echo("  education suspensions      NI school suspensions and expulsions (DE)")
-    click.echo("  gender-pay-gap             UK Gender Pay Gap Reporting service")
-    click.echo("  ons-cpi                    ONS UK inflation indices (CPI, CPIH, RPI)")
-    click.echo("  boe-base-rate              Bank of England official Bank Rate (base rate)")
-    click.echo("  dfe electricity            NI electricity consumption & renewable generation (%)")
-    click.echo("  dfc child-maintenance      Child Maintenance Service caseload and enforcement (DfC)")
+    for label, rows in buckets.items():
+        if not rows:
+            continue
+        click.echo(f"\n{label}")
+        for invocation, summary in rows:
+            click.echo(f"  {invocation.ljust(width)}{summary}")
 
     click.echo("\nUSAGE EXAMPLES")
     click.echo("  bolster water-quality BT1 5GS              # Water quality by postcode")
-    click.echo("  bolster nisra deaths --latest              # Latest NISRA deaths data")
+    click.echo("  bolster nisra deaths --dimension totals    # Weekly death registrations")
     click.echo("  bolster dva --latest --summary             # DVA test statistics summary")
     click.echo("  bolster rss nisra-statistics               # Browse NISRA publications")
     click.echo("  bolster ni-executive --format json         # Executive data as JSON")
     click.echo("  bolster companies-house farset             # Search for Farset companies")
     click.echo("  bolster ni-elections --election-year 2022  # 2022 election results")
-    click.echo("  bolster cinema-listings --date 2024-03-20  # Movie listings for date")
-    click.echo("  bolster --help                             # General help")
     click.echo("  bolster <command> --help                   # Command-specific help")
 
     click.echo(f"\nBolster v{__version__} - Northern Ireland & UK Data Sources")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,6 +4,7 @@
 import os
 from unittest.mock import patch
 
+import click
 from click.testing import CliRunner
 
 from bolster.cli import cli
@@ -358,3 +359,23 @@ class TestDeprecatedDimensionAliases:
             result = runner.invoke(cli, ["nisra", "registrar-general", "--latest", "--table", "births"])
         assert "deprecated" in result.output.lower()
         assert "--dimension" in result.output
+
+
+class TestListSources:
+    def test_uncategorised_commands_fall_through_to_other(self):
+        """A command missing from the category map must still be listed, not dropped."""
+
+        @click.command("zzz-throwaway")
+        def throwaway():
+            """Throwaway summary."""
+
+        cli.add_command(throwaway)
+        try:
+            result = CliRunner().invoke(cli, ["list-sources"])
+        finally:
+            del cli.commands["zzz-throwaway"]
+
+        assert result.exit_code == 0
+        assert "OTHER" in result.output
+        assert "zzz-throwaway" in result.output
+        assert "Throwaway summary." in result.output

--- a/tests/test_dfc_child_maintenance_integrity.py
+++ b/tests/test_dfc_child_maintenance_integrity.py
@@ -70,7 +70,9 @@ class TestPublicationDiscovery:
 
     def test_missing_publication_raises(self):
         with pytest.raises(cm.CMSDataNotFoundError):
-            cm.find_publication_xlsx("https://www.communities-ni.gov.uk/publications/no-such-publication-data-june-2020")
+            cm.find_publication_xlsx(
+                "https://www.communities-ni.gov.uk/publications/no-such-publication-data-june-2020"
+            )
 
 
 @pytest.mark.integration
@@ -115,7 +117,9 @@ class TestLatestPublication:
     def test_maintenance_paid_below_due(self, df):
         maintenance = df[df["table"] == "maintenance"]
         pivot = maintenance.pivot_table(index="date", columns="subcategory", values="value")
-        assert (pivot["Maintenance paid through Collect & Pay"] <= pivot["Maintenance due to be paid through Collect & Pay"]).all()
+        assert (
+            pivot["Maintenance paid through Collect & Pay"] <= pivot["Maintenance due to be paid through Collect & Pay"]
+        ).all()
 
     def test_characteristics_proportions_sum_per_group(self, df):
         characteristics = df[(df["table"] == "paying_parent_characteristics") & (df["measure"] == "proportion")]
@@ -192,7 +196,8 @@ class TestTableAccessors:
         assert set(subset["table"]) == {table}
 
     def test_list_tables_from_frame(self, df):
-        assert cm.list_tables(df) == sorted(cm.list_tables())
+        """Passing an explicit frame must agree with the default-fetch path."""
+        assert cm.list_tables(df) == cm.list_tables()
 
 
 class TestSheetIdentification:
@@ -289,9 +294,7 @@ class TestQuarterParsing:
     def test_parses(self, raw, expected):
         assert cm._parse_quarter(raw).date() == expected
 
-    @pytest.mark.parametrize(
-        "raw", ["", None, "Total", "Source: DfC", "December 2020", 42]
-    )
+    @pytest.mark.parametrize("raw", ["", None, "Total", "Source: DfC", "December 2020", 42])
     def test_rejects(self, raw):
         assert cm._parse_quarter(raw) is None
 
@@ -305,7 +308,11 @@ class TestMeasureResolution:
             ("clearances", "Proportion Currently Cleared", ("Proportion Currently Cleared", "proportion")),
             ("clearances", "Cleared within 6 weeks", ("Cleared within 6 weeks", "proportion")),
             ("enforcement", "Sanctions", ("Sanctions", "amount_gbp")),
-            ("maintenance", "Maintenance paid through Collect & Pay", ("Maintenance paid through Collect & Pay", "amount_gbp")),
+            (
+                "maintenance",
+                "Maintenance paid through Collect & Pay",
+                ("Maintenance paid through Collect & Pay", "amount_gbp"),
+            ),
             ("applications", "Applications Received", ("Applications Received", "count")),
         ],
     )

--- a/tests/test_dfc_family_resources_survey_integrity.py
+++ b/tests/test_dfc_family_resources_survey_integrity.py
@@ -81,10 +81,8 @@ class TestEditionDiscovery:
         """Discovery must not invent chapter keys."""
         assert set(chapter_urls) <= set(frs.CHAPTERS)
 
-    def test_list_chapters_is_sorted(self):
-        """list_chapters returns the known keys in sorted order."""
-        chapters = frs.list_chapters()
-        assert chapters == sorted(frs.CHAPTERS)
+    def test_list_chapters_covers_known_keys(self):
+        assert {"income", "tenure", "pensions", "food_security"} <= set(frs.list_chapters())
 
     def test_unknown_chapter_raises(self):
         """Reading an unpublished chapter raises FRSDataNotFoundError."""
@@ -366,9 +364,7 @@ class TestIncomeAndStateSupport:
 
     def test_support_trend_total_exceeds_components(self, support_trend):
         """The all-recipients figure must be at least the income-related share."""
-        pivot = support_trend.pivot_table(
-            index="financial_year", columns="state_support_type", values="percentage"
-        )
+        pivot = support_trend.pivot_table(index="financial_year", columns="state_support_type", values="percentage")
         total = [c for c in pivot.columns if c.lower().startswith("all in receipt")][0]
         income_related = [c for c in pivot.columns if c.lower().startswith("on any income")][0]
         assert (pivot[total] >= pivot[income_related]).all()
@@ -427,7 +423,7 @@ class TestTenure:
     def test_district_coverage(self, by_district):
         """All eleven Local Government Districts must be present."""
         districts = set(by_district["district"])
-        assert DISTRICTS <= districts
+        assert districts >= DISTRICTS
         assert len(districts) == 11
 
     def test_district_tenures_consistent(self, by_district):
@@ -562,7 +558,7 @@ class TestCarersAndDisability:
     def test_disability_district_coverage(self, disability_districts):
         """All eleven districts plus the NI total must be present."""
         districts = set(disability_districts["district"])
-        assert DISTRICTS <= districts
+        assert districts >= DISTRICTS
         assert "Northern Ireland" in districts
         assert len(districts) == 12
 

--- a/tests/test_dfi_school_travel_integrity.py
+++ b/tests/test_dfi_school_travel_integrity.py
@@ -148,13 +148,8 @@ class TestPublicationDiscovery:
 class TestListQuestions:
     """Tests for the question listing helper."""
 
-    def test_questions_are_unique(self):
-        questions = school_travel.list_questions()
-        assert len(questions) >= 10
-        assert len(questions) == len(set(questions))
-
-    def test_questions_match_detail_frame(self):
-        assert set(school_travel.list_questions()) == set(school_travel.get_latest_data()["question"])
+    def test_questions_parsed(self):
+        assert len(school_travel.list_questions()) >= 10
 
 
 class TestClassifyBreakdown:

--- a/tests/test_justice_pps_statistical_bulletin_integrity.py
+++ b/tests/test_justice_pps_statistical_bulletin_integrity.py
@@ -164,8 +164,8 @@ class TestLatestBulletinIntegrity:
         with pytest.raises(PPSDataNotFoundError, match="Unknown table"):
             pps.get_latest_data(table="99z")
 
-    def test_list_tables(self, latest):
-        assert set(pps.list_tables()) == set(latest["table"])
+    def test_list_tables(self):
+        assert {"1a", "3a"} <= set(pps.list_tables())
 
 
 class TestAccessors:
@@ -274,7 +274,9 @@ class TestHistoricalSeries:
     def test_files_received_trend_plausible(self, historical):
         """Annual file receipts should stay within a stable band."""
         totals = historical[
-            (historical["table"] == "1a") & (historical["category"] == "All Files") & (historical["breakdown"] == "All PPS")
+            (historical["table"] == "1a")
+            & (historical["category"] == "All Files")
+            & (historical["breakdown"] == "All PPS")
         ]
         assert totals["value"].between(20000, 80000).all()
 

--- a/tests/test_nisra_housing_bulletin_integrity.py
+++ b/tests/test_nisra_housing_bulletin_integrity.py
@@ -164,10 +164,8 @@ class TestValidation:
 
 
 class TestTableDispatch:
-    def test_list_tables_is_sorted_and_complete(self):
-        tables = hb.list_tables()
-        assert tables == sorted(tables)
-        assert len(tables) == 9
+    def test_list_tables_is_complete(self):
+        assert len(hb.list_tables()) == 9
 
     def test_unknown_table_rejected(self):
         with pytest.raises(NISRADataNotFoundError, match="Unknown table"):
@@ -270,9 +268,7 @@ class TestSocialHousingSupply:
             .groupby(["financial_year", "tenure"])["completions"]
             .sum()
         )
-        subtotals = annual[annual["housing_type"] == "Sub-total"].set_index(["financial_year", "tenure"])[
-            "completions"
-        ]
+        subtotals = annual[annual["housing_type"] == "Sub-total"].set_index(["financial_year", "tenure"])["completions"]
         common = components.index.intersection(subtotals.dropna().index)
         assert len(common) >= 20
         pd.testing.assert_series_equal(

--- a/tests/test_nisra_teacher_workforce_integrity.py
+++ b/tests/test_nisra_teacher_workforce_integrity.py
@@ -228,14 +228,10 @@ class TestListHelpers:
     """Unit tests for the label listing helpers (no network)."""
 
     def test_list_statistics(self) -> None:
-        stats = tw.list_statistics()
-        assert stats == sorted(stats)
-        assert {"all_teachers", "male", "female", "full_time", "part_time"} <= set(stats)
+        assert {"all_teachers", "male", "female", "full_time", "part_time"} <= set(tw.list_statistics())
 
     def test_list_school_types(self) -> None:
-        types = tw.list_school_types()
-        assert types == sorted(types)
-        assert {"nursery", "primary", "grammar", "special", "all"} <= set(types)
+        assert {"nursery", "primary", "grammar", "special", "all"} <= set(tw.list_school_types())
 
 
 class TestAcademicYearParsing:

--- a/tests/test_nisra_workless_households_integrity.py
+++ b/tests/test_nisra_workless_households_integrity.py
@@ -201,9 +201,7 @@ class TestDispatcher:
     """Validate the table dispatcher used by the CLI."""
 
     def test_list_tables(self) -> None:
-        tables = wh.list_tables()
-        assert "northern-ireland" in tables
-        assert tables == sorted(tables)
+        assert "northern-ireland" in wh.list_tables()
 
     def test_default_table(self) -> None:
         df = wh.get_latest_data()


### PR DESCRIPTION
## Summary

`list_sources` was ~102 hand-written `click.echo` lines that duplicated every command name and description already present in the Click tree. It had drifted: it advertised a phantom `nisra stillbirths` and omitted ~26 real commands (all 6 `justice` subcommands, `translink route`, `dfc frs`, `dfi school-travel`, `daera greenhouse-gas`/`waste`, and others).

It now walks `cli.commands` and derives each summary from the command's own docstring via `get_short_help_str`. Output goes from ~55 leaf commands to all 81, and can no longer drift.

Ordering is preserved by an explicit `_SOURCE_CATEGORIES` map. Commands absent from that map fall through to an `OTHER` bucket rather than being dropped, so an uncategorised command is a cosmetic gap rather than an invisible one — that fall-through is the one non-obvious behaviour, and is the only thing covered by a new test.

Addresses the root cause behind #2037.

### Also: tautological test cleanup

Bundled here because it's the same theme — removing checks that restate rather than verify.

Seven tests re-derived their expectation from the exact expression the implementation uses, so they could only fail if the test author typo'd the re-derivation. Two paid a live network call to do it. For example `list_tables()` is `sorted(_TABLES)`, so `tables == sorted(tables)` proves nothing; `list_chapters()` is `sorted(CHAPTERS)`, so comparing against `set(CHAPTERS)` is the same statement twice.

Replaced with independent expectations (known keys, known counts) that fail if the parser or the source actually changes.

Structurally similar checks in `test_nisra_teacher_workforce_integrity.py` were **deliberately preserved** — those compare a hand-maintained label dict against parser output from a live workbook, so they fire when the source gains a statistic the dict doesn't know about. Same shape, load-bearing.

Two tests written alongside the `list_sources` rewrite were also dropped before landing for the same reason: they re-walked `cli.commands` to check output generated by walking `cli.commands`.

## Known conflicts

- **#2057** also edits `list_sources()`, appending hardcoded `daera`/`dfc`/`dfi` lines. This PR deletes that whole block. Trivial resolution: take the introspective version.
- **#2058** contains identical `ruff format` reflows of `tests/test_dfc_child_maintenance_integrity.py` and `tests/test_justice_pps_statistical_bulletin_integrity.py` (both were among the files where the pinned and unpinned ruff versions disagreed). Whichever merges second will conflict on those two files; the hunks are identical, so either side resolves it.

## Test plan

- [x] `uv run pytest` across all 8 touched test files — 643 passed
- [x] `uv run pre-commit run --files <changed>` — clean
- [x] `uv run bolster list-sources` inspected against the old output; verified no command lost, 26 gained, phantom `nisra stillbirths` gone
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)