### PR TITLE
Fix doctest rot and enforce doctests in CI

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -87,3 +87,38 @@ jobs:
               with:
                   report_type: test_results
                   token: ${{ secrets.CODECOV_TOKEN }}
+
+    # Docstring examples are executable documentation: they hit the same live
+    # sources as the test suite, so they rot silently when a publisher changes a
+    # column or a URL. Run once on a single Python version rather than folding
+    # `src` into the matrix above — the examples are version-independent, and
+    # repeating them three times would triple the load on upstream publishers.
+    doctests:
+        runs-on: ubuntu-latest
+
+        steps:
+            - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
+            - name: Install uv
+              uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9  # v9.0.0
+              with:
+                  python-version: "3.13"
+                  enable-cache: true
+                  cache-dependency-glob: "uv.lock"
+
+            - name: Get current date
+              id: date
+              run: echo "date=$(date -u +%Y-%m-%d)" >> "$GITHUB_OUTPUT"
+
+            - name: Cache downloaded source data
+              uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6
+              with:
+                  path: ~/.cache/bolster
+                  key: bolster-downloads-${{ runner.os }}-${{ steps.date.outputs.date }}
+                  restore-keys: |
+                      bolster-downloads-${{ runner.os }}-
+
+            - name: Install the project
+              run: uv sync --all-extras --dev
+
+            - name: Run doctests
+              run: uv run pytest src --doctest-modules --no-cov

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,7 +96,9 @@ markers = [
     "network: marks tests requiring network access (deselect with '-m \"not network\"')",
     "integration: marks optional integration tests requiring real network (run with '-m integration')"
 ]
-log_cli = true
+# Live logging swaps sys.stdout out from under doctest's capture, so any doctest
+# whose call emits a log record reports "Got nothing" instead of its real output.
+log_cli = false
 log_cli_level = "WARNING"
 log_cli_format = "%(asctime)s %(levelname)s %(name)s: %(message)s"
 log_cli_date_format = "%H:%M:%S"

--- a/src/bolster/data_sources/cineworld.py
+++ b/src/bolster/data_sources/cineworld.py
@@ -14,17 +14,11 @@ are scheduled and availability changes. The data reflects real-time cinema sched
 immediate updates for booking availability, screening times, and new film releases.
 Data is refreshed multiple times daily to maintain accuracy for current and upcoming showings.
 
-Example:
-    Retrieve current cinema listings for Belfast Cineworld:
-
-        >>> from bolster.data_sources import cineworld
-        >>> listings = cineworld.get_cinema_listings(117)
-        >>> len(listings) > 0
-        True
-        >>> 'name' in listings[0]
-        True
-
 Site Code 117 maps to Belfast, you're on your own for the rest.
+
+Note:
+    cineworld.co.uk returns 403 to automated clients, so this module's calls
+    cannot be exercised as doctests.
 """
 
 import logging
@@ -48,13 +42,6 @@ def get_cinema_listings(site_code: int = 117, screening_date: date = None) -> li
 
     Raises:
         Exception: If there was an error making the API request.
-
-    >>> cinema_listings = get_cinema_listings(117)
-    >>> set(cinema_listings[0].keys()).issuperset({'id', 'name','link','weight','releaseYear','releaseDate','attributeIds','date','site_code'})
-    True
-    >>> list(cinema_listings[0].keys()) # This is likely to break from upstream changes
-    ['id', 'name', 'length', 'posterLink', 'videoLink', 'link', 'weight', 'releaseYear', 'releaseDate', 'attributeIds', 'date', 'site_code']
-
     """
     if screening_date is None:
         screening_date = date.today()

--- a/src/bolster/data_sources/daera_waste.py
+++ b/src/bolster/data_sources/daera_waste.py
@@ -30,7 +30,7 @@ Example:
     >>> df = daera_waste.get_latest_waste_statistics()
     >>> 'council_area' in df.columns
     True
-    >>> 'tonnes' in df.columns
+    >>> 'lac_waste_arisings_tonnes' in df.columns
     True
 
 """
@@ -339,7 +339,7 @@ def get_latest_waste_statistics(force_refresh: bool = False) -> pd.DataFrame:
         >>> df = get_latest_waste_statistics()
         >>> 'council_area' in df.columns
         True
-        >>> (df['lac_waste_arisings_tonnes'] >= 0).all()
+        >>> bool((df['lac_waste_arisings_tonnes'] >= 0).all())
         True
     """
     csv_url = get_waste_publication_url(prefer="csv")

--- a/src/bolster/data_sources/electricity_renewables.py
+++ b/src/bolster/data_sources/electricity_renewables.py
@@ -35,7 +35,7 @@ Example:
     True
     >>> 'renewable_pct_rolling_12m' in data['renewable_pct'].columns
     True
-    >>> (data['renewable_pct']['renewable_pct_rolling_12m'] > 0).all()
+    >>> bool((data['renewable_pct']['renewable_pct_rolling_12m'] > 0).all())
     True
 
 """

--- a/src/bolster/data_sources/health_ni/cancer_waiting_times.py
+++ b/src/bolster/data_sources/health_ni/cancer_waiting_times.py
@@ -35,7 +35,7 @@ Data is fetched from the NISRA PxStat API using the following matrices:
     - CWT62TUMOUR: 62-day waiting times by tumour site
 
 Example:
-    >>> from bolster.data_sources.nisra import cancer_waiting_times as cwt
+    >>> from bolster.data_sources.health_ni import cancer_waiting_times as cwt
     >>> df = cwt.get_latest_31_day_by_trust()
     >>> sorted(df.columns.tolist())
     ['date', 'month', 'over_target', 'performance_rate', 'total', 'trust', 'within_target', 'year']

--- a/src/bolster/data_sources/health_ni/child_protection.py
+++ b/src/bolster/data_sources/health_ni/child_protection.py
@@ -145,6 +145,11 @@ def get_child_protection_publication_url() -> str:
     return excel_url
 
 
+def _is_ni_total(raw: str) -> bool:
+    """Return True if ``raw`` labels the Northern Ireland-wide total rather than a trust."""
+    return "northern ireland" in str(raw).lower()
+
+
 def _normalise_trust(raw: str) -> str:
     """Normalise an HSC Trust name to its short canonical form.
 
@@ -154,6 +159,10 @@ def _normalise_trust(raw: str) -> str:
     Returns:
         Short canonical form (e.g. "Belfast", "Northern")
     """
+    # "Northern Ireland" contains "Northern", so the NI-wide total would otherwise
+    # be normalised into the Northern HSC Trust and silently double its series.
+    if _is_ni_total(raw):
+        return "Northern Ireland"
     for trust in HSC_TRUSTS:
         if trust.lower() in str(raw).lower():
             return trust
@@ -238,7 +247,9 @@ def _parse_cpr_trend(file_path: str | Path, content: bytes | None = None) -> lis
             trust_raw = cells[0]
             if not trust_raw or trust_raw.lower() in ("hsc trust", ""):
                 continue
-            trust = _normalise_trust(trust_raw)
+
+            is_ni_total = _is_ni_total(trust_raw)
+            trust = "Northern Ireland" if is_ni_total else _normalise_trust(trust_raw)
 
             for i, year in enumerate(header_years):
                 if year is None or i + 1 >= len(cells):
@@ -248,8 +259,8 @@ def _parse_cpr_trend(file_path: str | Path, content: bytes | None = None) -> lis
                     records.append(
                         {
                             "year": year,
-                            "measure": "cpr_registrations_trust_snapshot",
-                            "category": "trust",
+                            "measure": MEASURE_CPR_TOTAL if is_ni_total else "cpr_registrations_trust_snapshot",
+                            "category": "ni_total" if is_ni_total else "trust",
                             "subcategory": trust,
                             "value": val,
                             "notes": "Count at 31 March",
@@ -572,6 +583,13 @@ def _parse_abuse_category_trend(file_path: str | Path, content: bytes | None = N
             if not category_raw:
                 continue
 
+            # Combined categories are split across two rows sharing a "Category of
+            # Abuse" label, distinguished only by "Main Category of Abuse". Without it
+            # the two rows collapse into one subcategory and one of them is lost.
+            main_category = cells[1].strip() if n_label_cols > 1 and len(cells) > 1 else ""
+            if main_category:
+                category_raw = f"{category_raw} (main: {main_category})"
+
             # Values start at n_label_cols
             for i, year in enumerate(header_years):
                 col_idx = n_label_cols + i
@@ -639,6 +657,10 @@ def parse_child_protection_file(file_path: str | Path) -> pd.DataFrame:
     df["category"] = df["category"].astype(str)
     df["subcategory"] = df["subcategory"].astype(str)
     df["notes"] = df["notes"].astype(str)
+
+    # Table 2.1 and table 2.2a both report the NI-wide CPR total for the publication
+    # year. Keeping both would double-count it under any groupby.
+    df = df.drop_duplicates(subset=["year", "measure", "category", "subcategory", "value"])
 
     return df[["year", "measure", "category", "subcategory", "value", "notes"]].copy()
 

--- a/src/bolster/data_sources/health_ni/child_protection.py
+++ b/src/bolster/data_sources/health_ni/child_protection.py
@@ -27,7 +27,7 @@ Update Frequency:
     Annual, typically published in October for the year ending 31 March.
 
 Example:
-    >>> from bolster.data_sources.nisra import child_protection as cp
+    >>> from bolster.data_sources.health_ni import child_protection as cp
     >>> df = cp.get_latest_child_protection()
     >>> sorted(df.columns.tolist())
     ['category', 'measure', 'notes', 'subcategory', 'value', 'year']

--- a/src/bolster/data_sources/health_ni/diagnostic_waiting_times.py
+++ b/src/bolster/data_sources/health_ni/diagnostic_waiting_times.py
@@ -26,7 +26,7 @@ Original data source:
 Data is fetched from the NISRA PxStat API using matrix ``DWT``.
 
 Example:
-    >>> from bolster.data_sources.nisra import diagnostic_waiting_times as dwt
+    >>> from bolster.data_sources.health_ni import diagnostic_waiting_times as dwt
     >>> df = dwt.get_latest_diagnostic_waiting_times()
     >>> sorted(df.columns.tolist())
     ['category', 'date', 'over_26_weeks', 'over_9_weeks', 'performance_rate', 'quarter', 'total_waiting', 'trust', 'within_9_weeks', 'year']

--- a/src/bolster/data_sources/health_ni/disease_prevalence.py
+++ b/src/bolster/data_sources/health_ni/disease_prevalence.py
@@ -269,11 +269,14 @@ def validate_disease_prevalence(df: pd.DataFrame, level: str = "ni") -> bool:
 
     Example:
         >>> import pandas as pd
+        >>> diseases = ["Hypertension", "Diabetes", "Asthma", "Depression", "Epilepsy"]
+        >>> years = list(range(2017, 2023))
         >>> df = pd.DataFrame({
-        ...     "year": [2017], "financial_year": ["2017/18"],
-        ...     "disease": ["Hypertension"],
-        ...     "registered_patients": [184824.0],
-        ...     "prevalence_per_1000": [102.9],
+        ...     "year": sum([[y] * len(diseases) for y in years], []),
+        ...     "financial_year": sum([[f"{y}/{(y + 1) % 100:02d}"] * len(diseases) for y in years], []),
+        ...     "disease": diseases * len(years),
+        ...     "registered_patients": [100000.0] * len(diseases) * len(years),
+        ...     "prevalence_per_1000": [55.0] * len(diseases) * len(years),
         ... })
         >>> validate_disease_prevalence(df)
         True
@@ -487,10 +490,11 @@ def parse_gp_practice_lookup(file_path: str, sheet_name: str | None = None) -> p
         NISRADataNotFoundError: If the sheet cannot be found.
 
     Example:
-        >>> lkp = parse_gp_practice_lookup("/tmp/rdptd-tables-2026.xlsx")
+        >>> path = download_file(get_latest_publication_url(), cache_ttl_hours=_CACHE_TTL)
+        >>> lkp = parse_gp_practice_lookup(path)
         >>> "practice_code" in lkp.columns
         True
-        >>> lkp["practice_code"].str.startswith("Z").all()
+        >>> bool(lkp["practice_code"].str.startswith("Z").all())
         True
     """
     target = sheet_name or _SHEET_TABLE4
@@ -541,7 +545,8 @@ def parse_all_gp_practices(file_path: str) -> pd.DataFrame:
         NISRADataNotFoundError: If no Table 5 sheets can be found or parsed.
 
     Example:
-        >>> df = parse_all_gp_practices("/tmp/rdptd-tables-2026.xlsx")
+        >>> path = download_file(get_latest_publication_url(), cache_ttl_hours=_CACHE_TTL)
+        >>> df = parse_all_gp_practices(path)
         >>> df["financial_year"].nunique() >= 17
         True
         >>> df["practice_code"].nunique() >= 300
@@ -612,7 +617,7 @@ def get_latest_gp_prevalence(force_refresh: bool = False) -> pd.DataFrame:
 
     Example:
         >>> df = get_latest_gp_prevalence()
-        >>> df["practice_code"].str.startswith("Z").all()
+        >>> bool(df["practice_code"].str.startswith("Z").all())
         True
         >>> df["financial_year"].nunique() >= 3
         True

--- a/src/bolster/data_sources/health_ni/disease_prevalence.py
+++ b/src/bolster/data_sources/health_ni/disease_prevalence.py
@@ -30,7 +30,7 @@ Update Frequency:
     Annual, approximately May of the following calendar year.
 
 Example:
-    >>> from bolster.data_sources.nisra import disease_prevalence as dp
+    >>> from bolster.data_sources.health_ni import disease_prevalence as dp
     >>> df = dp.get_latest_disease_prevalence()
     >>> 'registered_patients' in df.columns
     True

--- a/src/bolster/data_sources/health_ni/elective_waiting_times.py
+++ b/src/bolster/data_sources/health_ni/elective_waiting_times.py
@@ -50,8 +50,8 @@ Update Frequency:
 Example:
     >>> from bolster.data_sources.health_ni import elective_waiting_times as ewt
     >>> df = ewt.get_latest_elective_waiting_times()
-    >>> sorted(df.columns.tolist())
-    ['date', 'patients_waiting', 'programme_of_care', 'quarter_ending', 'specialty', 'trust', 'waiting_type', 'weeks_waited_band', 'year']
+    >>> {'trust', 'specialty', 'weeks_waited_band', 'patients_waiting'}.issubset(df.columns)
+    True
 
     >>> ewt.validate_elective_waiting_times(df)
     True

--- a/src/bolster/data_sources/health_ni/elective_waiting_times.py
+++ b/src/bolster/data_sources/health_ni/elective_waiting_times.py
@@ -48,7 +48,7 @@ Update Frequency:
     Quarterly, published approximately 3-6 months after the quarter end.
 
 Example:
-    >>> from bolster.data_sources.nisra import elective_waiting_times as ewt
+    >>> from bolster.data_sources.health_ni import elective_waiting_times as ewt
     >>> df = ewt.get_latest_elective_waiting_times()
     >>> sorted(df.columns.tolist())
     ['date', 'patients_waiting', 'programme_of_care', 'quarter_ending', 'specialty', 'trust', 'waiting_type', 'weeks_waited_band', 'year']

--- a/src/bolster/data_sources/health_ni/emergency_care_waiting_times.py
+++ b/src/bolster/data_sources/health_ni/emergency_care_waiting_times.py
@@ -21,7 +21,7 @@ Update Frequency:
     Quarterly, approximately 3 months after the end of each quarter.
 
 Example:
-    >>> from bolster.data_sources.nisra import emergency_care_waiting_times as ecwt
+    >>> from bolster.data_sources.health_ni import emergency_care_waiting_times as ecwt
     >>> df = ecwt.get_latest_data()
     >>> 'pct_within_4hrs' in df.columns
     True

--- a/src/bolster/data_sources/justice/pbni_caseload.py
+++ b/src/bolster/data_sources/justice/pbni_caseload.py
@@ -267,7 +267,7 @@ def get_annual_caseload(force_refresh: bool = False) -> pd.DataFrame:
 
     Example:
         >>> df = get_annual_caseload()
-        >>> (df["caseload"] >= df["service_users"]).all()
+        >>> bool((df["caseload"] >= df["service_users"]).all())
         True
     """
     return get_latest_data("caseload", frequency="annual", force_refresh=force_refresh)

--- a/src/bolster/data_sources/ni_water.py
+++ b/src/bolster/data_sources/ni_water.py
@@ -229,21 +229,24 @@ def _create_legacy_format_series(site_data: pd.DataFrame, zone_code: str) -> pd.
 def get_postcode_to_water_supply_zone() -> dict[str, str]:
     """Using data from OpenDataNI to generate a map from NI Postcodes to Water Supply Zone.
 
+    Counts drift as NI Water republishes the lookup, so these assert shape
+    rather than exact totals.
+
     >>> zones = get_postcode_to_water_supply_zone()
-    >>> len(zones)
-    49006
+    >>> len(zones) > 40000
+    True
 
     Zones is keyed off postcode to a Water Supply Zone
     >>> zones['BT1 1AA']
     'ZS0107'
 
     There are much fewer zones than postcodes
-    >>> len(set(zones.values()))
-    65
+    >>> len(set(zones.values())) < 500
+    True
 
-    And many postcodes that aren't associated with any zone
-    >>> len([k for k,v in zones.items() if v == INVALID_ZONE_IDENTIFIER])
-    97
+    Postcodes with no zone assigned carry a sentinel rather than being dropped
+    >>> all(isinstance(v, str) for v in zones.values())
+    True
 
     """
     url = _get_niwater_resource_url("Postcode v Zone Lookup")

--- a/src/bolster/data_sources/nisra/__init__.py
+++ b/src/bolster/data_sources/nisra/__init__.py
@@ -44,8 +44,8 @@ Note:
 
 Examples:
     >>> from bolster.data_sources.nisra import claimant_count
-    >>> cc_df = claimant_count.get_latest_claimant_count("headline")
-    >>> "claimants_000s" in cc_df.columns
+    >>> cc_df = claimant_count.get_latest_claimant_count("lgd")
+    >>> "claimants_total" in cc_df.columns
     True
 
     >>> from bolster.data_sources.nisra import ashe

--- a/src/bolster/data_sources/nisra/baby_names.py
+++ b/src/bolster/data_sources/nisra/baby_names.py
@@ -29,7 +29,7 @@ Example:
     ['count', 'name', 'rank', 'sex', 'year']
     >>> sorted(df['sex'].unique().tolist())
     ['Boys', 'Girls']
-    >>> df['year'].min() >= 1997
+    >>> bool(df['year'].min() >= 1997)
     True
 """
 
@@ -314,7 +314,7 @@ def get_baby_names(force_refresh: bool = False) -> pd.DataFrame:
         >>> df = get_baby_names()
         >>> sorted(df.columns.tolist())
         ['count', 'name', 'rank', 'sex', 'year']
-        >>> df['year'].min() >= 1997
+        >>> bool(df['year'].min() >= 1997)
         True
         >>> sorted(df['sex'].unique().tolist())
         ['Boys', 'Girls']
@@ -353,9 +353,13 @@ def validate_baby_names(df: pd.DataFrame) -> bool:
 
     Example:
         >>> import pandas as pd
+        >>> years = list(range(1997, 2021))
         >>> valid_df = pd.DataFrame({
-        ...     'year': [2020, 2020], 'name': ['Noah', 'Jack'],
-        ...     'sex': ['Boys', 'Boys'], 'rank': [1, 2], 'count': [100, 90]
+        ...     'year': years * 2,
+        ...     'name': ['Jack'] * len(years) + ['Grace'] * len(years),
+        ...     'sex': ['Boys'] * len(years) + ['Girls'] * len(years),
+        ...     'rank': [1] * len(years) * 2,
+        ...     'count': [100] * len(years) * 2,
         ... })
         >>> validate_baby_names(valid_df)
         True

--- a/src/bolster/data_sources/nisra/business_register.py
+++ b/src/bolster/data_sources/nisra/business_register.py
@@ -243,9 +243,12 @@ def validate_data(df: pd.DataFrame, level: str = "industry") -> bool:
 
     Example:
         >>> import pandas as pd
+        >>> years = list(range(2010, 2022))
+        >>> groups = ["Retail", "Construction", "Agriculture", "Services"]
         >>> df = pd.DataFrame({
-        ...     "year": [2020, 2021], "industry_group": ["Retail", "Retail"],
-        ...     "businesses": [5890.0, 6040.0],
+        ...     "year": years * len(groups),
+        ...     "industry_group": sum([[g] * len(years) for g in groups], []),
+        ...     "businesses": [5890.0] * len(years) * len(groups),
         ... })
         >>> validate_data(df)
         True

--- a/src/bolster/data_sources/nisra/claimant_count.py
+++ b/src/bolster/data_sources/nisra/claimant_count.py
@@ -16,16 +16,12 @@ PxStat matrices used:
 
 Update Frequency: Monthly, approximately 2–3 weeks after the reference month.
 
-Usage:
+Example:
     >>> from bolster.data_sources.nisra import claimant_count
     >>> df = claimant_count.get_latest_claimant_count("lgd")
     >>> "claimants_total" in df.columns
     True
-
-Example:
-    >>> from bolster.data_sources.nisra import claimant_count
-    >>> df = claimant_count.get_latest_claimant_count("lgd")
-    >>> df[df["geography"] == "Northern Ireland"]["claimants_total"].iloc[0] > 0
+    >>> bool(df[df["geography"] == "Northern Ireland"]["claimants_total"].iloc[0] > 0)
     True
 """
 

--- a/src/bolster/data_sources/nisra/deprivation.py
+++ b/src/bolster/data_sources/nisra/deprivation.py
@@ -121,13 +121,13 @@ def validate_data(df: pd.DataFrame) -> bool:
 
     Example:
         >>> import pandas as pd
+        >>> ranks = list(range(1, 891))  # one row per NI Super Output Area
         >>> df = pd.DataFrame({
-        ...     "soa_code": ["95AA01S1"], "soa_name": ["Aldergrove_1"],
-        ...     "lgd": ["Antrim and Newtownabbey"], "urban_rural": ["Rural"],
-        ...     "mdm_rank": [516], "income_rank": [790],
-        ...     "employment_rank": [888], "health_disability_rank": [890],
-        ...     "education_rank": [254], "access_to_services_rank": [17],
-        ...     "living_environment_rank": [75], "crime_disorder_rank": [874],
+        ...     "soa_code": [f"95AA{i:04d}" for i in ranks],
+        ...     "soa_name": [f"SOA_{i}" for i in ranks],
+        ...     "lgd": ["Antrim and Newtownabbey"] * len(ranks),
+        ...     "urban_rural": ["Rural"] * len(ranks),
+        ...     **{col: ranks for col in _RANK_COLUMNS},
         ... })
         >>> validate_data(df)
         True

--- a/src/bolster/data_sources/nisra/drug_related_deaths.py
+++ b/src/bolster/data_sources/nisra/drug_related_deaths.py
@@ -24,7 +24,7 @@ Geographic Coverage: Northern Ireland
 
 Example:
     >>> from bolster.data_sources.nisra import drug_related_deaths as drd
-    >>> df = drd.get_latest_drug_related_deaths()
+    >>> df = drd.get_latest_drug_related_deaths("lgd")
     >>> {"year", "geography", "statistic", "value"}.issubset(df.columns)
     True
     >>> len(df) > 0

--- a/src/bolster/data_sources/nisra/homelessness.py
+++ b/src/bolster/data_sources/nisra/homelessness.py
@@ -266,7 +266,8 @@ def parse_presentations(file_path: str | Path) -> pd.DataFrame:
         presentations, rate_per_1000.
 
     Example:
-        >>> df = parse_presentations('/tmp/homelessness.xlsx')
+        >>> path = download_file(get_latest_publication_url(), cache_ttl_hours=24)
+        >>> df = parse_presentations(path)
         >>> set(df.columns) >= {'year', 'period', 'lgd', 'presentations'}
         True
     """
@@ -286,7 +287,8 @@ def parse_acceptances(file_path: str | Path) -> pd.DataFrame:
         acceptances, rate_per_1000.
 
     Example:
-        >>> df = parse_acceptances('/tmp/homelessness.xlsx')
+        >>> path = download_file(get_latest_publication_url(), cache_ttl_hours=24)
+        >>> df = parse_acceptances(path)
         >>> set(df.columns) >= {'year', 'period', 'lgd', 'acceptances'}
         True
     """

--- a/src/bolster/data_sources/nisra/housing_bulletin.py
+++ b/src/bolster/data_sources/nisra/housing_bulletin.py
@@ -488,7 +488,7 @@ def get_waiting_list_by_district(force_refresh: bool = False) -> pd.DataFrame:
 
     Example:
         >>> df = get_waiting_list_by_district()
-        >>> df.set_index('lgd').loc['Belfast', 'total_applicants'] > 0
+        >>> bool(df.set_index('lgd').loc['Belfast', 'total_applicants'] > 0)
         True
     """
     raw = _load_sheet(_download(force_refresh), _SHEET_WAITING_LIST_LGD)
@@ -639,7 +639,7 @@ def get_affordable_warmth(force_refresh: bool = False) -> pd.DataFrame:
 
     Example:
         >>> df = get_affordable_warmth()
-        >>> df['approvals'].sum() > 0
+        >>> bool(df['approvals'].sum() > 0)
         True
     """
     raw = _load_sheet(_download(force_refresh), _SHEET_AFFORDABLE_WARMTH)

--- a/src/bolster/data_sources/nisra/housing_stock.py
+++ b/src/bolster/data_sources/nisra/housing_stock.py
@@ -281,8 +281,8 @@ def parse_lgd_file(file_path: str | object) -> pd.DataFrame:
         semi_detached, terrace, total.
 
     Example:
-        >>> import pathlib
-        >>> df = parse_lgd_file("/tmp/housing_stock_lgd.xlsx")
+        >>> path = download_file(get_latest_publication_url("lgd"), cache_ttl_hours=24)
+        >>> df = parse_lgd_file(path)
         >>> 'total' in df.columns
         True
     """

--- a/src/bolster/data_sources/nisra/stillbirths.py
+++ b/src/bolster/data_sources/nisra/stillbirths.py
@@ -144,7 +144,7 @@ def validate_stillbirths_data(df: pd.DataFrame) -> bool:
 
     Example:
         >>> import pandas as pd
-        >>> validate_stillbirths_data(pd.DataFrame())
+        >>> validate_stillbirths_data(pd.DataFrame(columns=["year", "geography", "stillbirths"]))
         Traceback (most recent call last):
             ...
         bolster.data_sources.nisra.stillbirths.NISRAValidationError: DataFrame is empty

--- a/src/bolster/data_sources/nisra/work_quality.py
+++ b/src/bolster/data_sources/nisra/work_quality.py
@@ -425,7 +425,7 @@ def get_latest_work_quality(force_refresh: bool = False) -> pd.DataFrame:
         >>> df = get_latest_work_quality()
         >>> 'indicator' in df.columns
         True
-        >>> df['year'].max() >= 2025
+        >>> bool(df['year'].max() >= 2025)
         True
     """
     excel_url, year = get_work_quality_publication_url()

--- a/src/bolster/data_sources/psni/__init__.py
+++ b/src/bolster/data_sources/psni/__init__.py
@@ -18,11 +18,7 @@ with other NISRA datasets.
 
 Example:
     >>> from bolster.data_sources.psni import crime_statistics, road_traffic_collisions
-    >>> df = crime_statistics.get_historical_crime_statistics()
-    >>> 'lgd_code' in df.columns
-    True
-    >>> lgd_code = crime_statistics.get_lgd_code("Belfast City")
-    >>> lgd_code
+    >>> crime_statistics.get_lgd_code("Belfast City")
     'N09000003'
     >>> casualties = road_traffic_collisions.get_casualties()
     >>> 'severity' in casualties.columns

--- a/src/bolster/data_sources/psni/crime_statistics.py
+++ b/src/bolster/data_sources/psni/crime_statistics.py
@@ -311,7 +311,7 @@ def validate_crime_statistics(df: pd.DataFrame) -> bool:  # pragma: no cover
         PSNIValidationError: If validation fails
 
     Example:
-        >>> df = get_latest_crime_statistics()
+        >>> df = get_historical_crime_statistics()
         >>> validate_crime_statistics(df)
         True
     """
@@ -380,7 +380,7 @@ def filter_by_district(
         Filtered DataFrame
 
     Example:
-        >>> df = get_latest_crime_statistics()
+        >>> df = get_historical_crime_statistics()
         >>> belfast = filter_by_district(df, "Belfast City")
         >>> belfast['policing_district'].unique().tolist()
         ['Belfast City']
@@ -410,7 +410,7 @@ def filter_by_crime_type(
         Filtered DataFrame
 
     Example:
-        >>> df = get_latest_crime_statistics()
+        >>> df = get_historical_crime_statistics()
         >>> violence = filter_by_crime_type(df, "Violence with injury (including homicide & death/serious injury by unlawful driving)")
         >>> len(violence) > 0
         True
@@ -437,7 +437,7 @@ def filter_by_date_range(
         Filtered DataFrame
 
     Example:
-        >>> df = get_latest_crime_statistics()
+        >>> df = get_historical_crime_statistics()
         >>> # Get 2020 data
         >>> df_2020 = filter_by_date_range(df, "2020-01-01", "2020-12-31")
         >>> df_2020['calendar_year'].unique().tolist()
@@ -477,7 +477,7 @@ def get_total_crimes_by_district(
         DataFrame with columns: policing_district, lgd_code, nuts3_code, total_crimes
 
     Example:
-        >>> df = get_latest_crime_statistics()
+        >>> df = get_historical_crime_statistics()
         >>> totals_2021 = get_total_crimes_by_district(df, year=2021)
         >>> sorted(totals_2021.columns.tolist())
         ['lgd_code', 'nuts3_code', 'policing_district', 'total_crimes']
@@ -520,7 +520,7 @@ def get_crime_trends(
         DataFrame with columns: date, calendar_year, month, count
 
     Example:
-        >>> df = get_latest_crime_statistics()
+        >>> df = get_historical_crime_statistics()
         >>> trends = get_crime_trends(df, district="Belfast City")
         >>> sorted(trends.columns.tolist())
         ['calendar_year', 'count', 'date', 'month']
@@ -553,7 +553,7 @@ def get_outcome_rates_by_district(
         DataFrame with columns: policing_district, lgd_code, average_outcome_rate
 
     Example:
-        >>> df = get_latest_crime_statistics()
+        >>> df = get_historical_crime_statistics()
         >>> outcomes = get_outcome_rates_by_district(df, year=2021)
         >>> 'average_outcome_rate' in outcomes.columns
         True
@@ -591,7 +591,7 @@ def get_available_crime_types(df: pd.DataFrame) -> list[str]:
         Sorted list of crime type names
 
     Example:
-        >>> df = get_latest_crime_statistics()
+        >>> df = get_historical_crime_statistics()
         >>> crime_types = get_available_crime_types(df)
         >>> isinstance(crime_types, list)
         True
@@ -611,7 +611,7 @@ def get_available_districts(df: pd.DataFrame) -> list[str]:
         Sorted list of district names
 
     Example:
-        >>> df = get_latest_crime_statistics()
+        >>> df = get_historical_crime_statistics()
         >>> districts = get_available_districts(df)
         >>> isinstance(districts, list)
         True

--- a/src/bolster/data_sources/psni/pace.py
+++ b/src/bolster/data_sources/psni/pace.py
@@ -360,14 +360,6 @@ def get_latest_pace(breakdown: str = "stop_search", force_refresh: bool = False)
         ValueError: If ``breakdown`` is not ``"stop_search"`` or ``"arrests"``.
         PSNIDataNotFoundError: If the download fails.
         PSNIValidationError: If the workbook structure is not as expected.
-
-    Example:
-        >>> df = get_latest_pace(breakdown="stop_search")  # doctest: +SKIP
-        >>> "reason" in df.columns
-        True
-        >>> df = get_latest_pace(breakdown="arrests")  # doctest: +SKIP
-        >>> "category" in df.columns
-        True
     """
     if breakdown not in ("stop_search", "arrests"):
         raise ValueError(f"breakdown must be 'stop_search' or 'arrests', got {breakdown!r}")

--- a/src/bolster/data_sources/psni/police_ombudsman.py
+++ b/src/bolster/data_sources/psni/police_ombudsman.py
@@ -30,14 +30,9 @@ Time Coverage:
     - District / allegation / outcome breakdowns: 2011/12 to present
     - Quarterly: latest 5 financial years
 
-Example:
-    >>> from bolster.data_sources.psni import police_ombudsman
-    >>> df = police_ombudsman.get_latest_complaints()
-    >>> 'year' in df.columns
-    True
-    >>> url = police_ombudsman.get_annual_publication_url()
-    >>> url.startswith("https://")
-    True
+Note:
+    policeombudsman.org returns 403 to automated clients, so the fetch helpers
+    in this module cannot be exercised as doctests.
 """
 
 import logging
@@ -168,11 +163,6 @@ def get_quarterly_publication_url() -> str:
     Raises:
         PSNIDataNotFoundError: If the page cannot be retrieved or no .xlsx
             link is found.
-
-    Example:
-        >>> url = get_quarterly_publication_url()
-        >>> url.startswith("https://")
-        True
     """
     try:
         resp = session.get(_QUARTERLY_PAGE, headers=_SCRAPE_HEADERS, timeout=30)
@@ -201,11 +191,6 @@ def get_annual_publication_url() -> str:
     Raises:
         PSNIDataNotFoundError: If the page cannot be retrieved or no .xlsx
             link is found.
-
-    Example:
-        >>> url = get_annual_publication_url()
-        >>> url.startswith("https://")
-        True
     """
     try:
         resp = session.get(_ANNUAL_PAGE, headers=_SCRAPE_HEADERS, timeout=30)
@@ -376,12 +361,6 @@ def parse_annual(file_path: str) -> dict[str, pd.DataFrame]:
 
     Raises:
         PSNIDataNotFoundError: If required sheets cannot be found.
-
-    Example:
-        >>> from bolster.data_sources.psni import police_ombudsman
-        >>> result = parse_annual.__doc__  # placeholder
-        >>> 'totals' in result
-        False
     """
     xl = pd.ExcelFile(file_path)
     return {
@@ -416,11 +395,6 @@ def parse_quarterly(file_path: str) -> dict[str, pd.DataFrame]:
 
     Raises:
         PSNIDataNotFoundError: If required sheets cannot be found.
-
-    Example:
-        >>> from bolster.data_sources.psni import police_ombudsman
-        >>> True  # real call requires downloaded file
-        True
     """
     xl = pd.ExcelFile(file_path)
 
@@ -518,14 +492,6 @@ def get_latest_complaints(
     Raises:
         ValueError: If *breakdown* is not one of the recognised values.
         PSNIDataNotFoundError: If the source cannot be downloaded.
-
-    Example:
-        >>> df = get_latest_complaints()
-        >>> set(["year", "complaints"]).issubset(df.columns)
-        True
-        >>> df_d = get_latest_complaints("by_district")
-        >>> "district" in df_d.columns
-        True
     """
     _annual_keys = {"totals", "by_district", "by_allegation_type", "by_outcome"}
     _quarterly_keys = {"quarterly"}

--- a/src/bolster/data_sources/translink/timetable.py
+++ b/src/bolster/data_sources/translink/timetable.py
@@ -17,9 +17,13 @@ while QL/QB stop records use 12-digit codes starting with ``7``
 (e.g. ``700000009264``).  The relation is ``stop_atco = '7' + trip_atco[0:11]``.
 
 Example:
-    >>> trips = get_trip_index()
-    >>> trips["700000001661"]  # stops serving Victoria Square
-    [TripStop(...), ...]
+    >>> index = get_trip_index()
+    >>> calls = index["700000001661"]  # trips serving Victoria Square
+    >>> len(calls) > 0
+    True
+    >>> trip, stop = calls[0]
+    >>> stop.atco
+    '700000001661'
 """
 
 import io

--- a/src/bolster/utils/dt.py
+++ b/src/bolster/utils/dt.py
@@ -74,6 +74,7 @@ def utc_midnight_on(dt: datetime) -> datetime:
         >>> utc_midnight_on(datetime(2018,9,1,12,12))
         datetime.datetime(2018, 9, 1, 0, 0, tzinfo=datetime.timezone.utc)
 
+        >>> from datetime import timezone
         >>> utc_midnight_on(datetime(2018,9,1,12,12, tzinfo=timezone(timedelta(hours=-13))))
         datetime.datetime(2018, 9, 1, 0, 0, tzinfo=datetime.timezone.utc)
     """

--- a/src/bolster/utils/web.py
+++ b/src/bolster/utils/web.py
@@ -14,7 +14,7 @@ uniformly.
 Example:
     >>> from bolster.utils.web import session
     >>> type(session).__name__
-    'Session'
+    'CachingSession'
 """
 
 import hashlib

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,8 +18,14 @@ def _check_ssl_available():
             # Try to connect to a known HTTPS site
             urllib.request.urlopen("https://www.google.com", timeout=5)
             _SSL_AVAILABLE = True
-        except (ssl.SSLError, urllib.error.URLError):
+        except ssl.SSLError:
             _SSL_AVAILABLE = False
+        except urllib.error.URLError as exc:
+            # URLError covers both cert failures and plain slow/absent network.
+            # Only a genuine SSL error means the local trust store is broken; a
+            # timeout under CI load must not silently skip the whole network
+            # suite, which reads as a pass while tanking coverage.
+            _SSL_AVAILABLE = not isinstance(exc.reason, ssl.SSLError)
         except Exception:
             # Other errors (network unavailable, etc.) - assume SSL would work
             _SSL_AVAILABLE = True

--- a/tests/test_health_ni_child_protection_integrity.py
+++ b/tests/test_health_ni_child_protection_integrity.py
@@ -119,6 +119,90 @@ class TestChildProtectionIntegrity:
         result = cp.validate_child_protection_data(latest_data)
         assert result is latest_data
 
+    def test_cpr_ni_total_covers_full_trend(self, latest_data: pd.DataFrame) -> None:
+        """NI total must span the same years as the trust trend, not just the snapshot year."""
+        total = latest_data[latest_data["measure"] == cp.MEASURE_CPR_TOTAL]
+        assert total["year"].min() <= 2015, f"NI total starts at {total['year'].min()}, expected 2015 or earlier"
+        assert total["year"].max() >= 2024, f"NI total ends at {total['year'].max()}, expected 2024 or later"
+
+    def test_ni_total_not_folded_into_northern_trust(self, latest_data: pd.DataFrame) -> None:
+        """Each trust must have exactly one CPR value per year.
+
+        "Northern Ireland" contains "Northern", so a naive substring match folds the
+        NI-wide total into the Northern HSC Trust and silently doubles its series.
+        """
+        cpr = latest_data[latest_data["measure"] == "cpr_registrations_trust_snapshot"]
+        counts = cpr.groupby(["year", "subcategory"]).size()
+        assert (counts == 1).all(), f"Duplicate trust-year rows: {counts[counts > 1].to_dict()}"
+        assert "Northern Ireland" not in set(cpr["subcategory"]), "NI total leaked into the trust breakdown"
+
+    def test_trusts_sum_to_ni_total(self, latest_data: pd.DataFrame) -> None:
+        """CPR trust values must sum to the NI-wide total for each shared year."""
+        trusts = latest_data[latest_data["measure"] == "cpr_registrations_trust_snapshot"]
+        totals = latest_data[latest_data["measure"] == cp.MEASURE_CPR_TOTAL].set_index("year")["value"]
+        summed = trusts.groupby("year")["value"].sum()
+        shared = summed.index.intersection(totals.index)
+        assert len(shared) >= 5, f"Only {len(shared)} years overlap between trust and NI total series"
+        for year in shared:
+            assert summed[year] == totals[year], f"{year}: trusts sum to {summed[year]}, NI total is {totals[year]}"
+
+    def test_combined_abuse_categories_kept_distinct(self, latest_data: pd.DataFrame) -> None:
+        """Combined categories split by "Main Category of Abuse" must not collapse together."""
+        abuse = latest_data[latest_data["measure"] == "cpr_by_abuse_category"]
+        cats = set(abuse["subcategory"].unique())
+        expected = {
+            "Neglect and Physical Abuse (main: Neglect)",
+            "Neglect and Physical Abuse (main: Physical Abuse)",
+        }
+        assert expected.issubset(cats), f"Combined categories collapsed: {expected - cats}"
+
+    def test_abuse_categories_sum_to_ni_total(self, latest_data: pd.DataFrame) -> None:
+        """Abuse category counts must sum to the NI-wide CPR total for each year.
+
+        This cross-checks table 2.5a against table 2.2a — a dropped or collapsed
+        category row shows up here as a shortfall.
+        """
+        summed = latest_data[latest_data["measure"] == "cpr_by_abuse_category"].groupby("year")["value"].sum()
+        totals = latest_data[latest_data["measure"] == cp.MEASURE_CPR_TOTAL].set_index("year")["value"]
+        shared = summed.index.intersection(totals.index)
+        assert len(shared) >= 5, f"Only {len(shared)} years overlap between category and NI total series"
+        for year in shared:
+            assert summed[year] == totals[year], (
+                f"{year}: abuse categories sum to {summed[year]}, NI total is {totals[year]}"
+            )
+
+    def test_no_duplicate_records(self, latest_data: pd.DataFrame) -> None:
+        """Tables 2.1 and 2.2a both report the NI total; duplicates must be collapsed."""
+        dupes = latest_data.duplicated(subset=["year", "measure", "category", "subcategory"])
+        assert not dupes.any(), f"Duplicate records:\n{latest_data[dupes].to_string()}"
+
+
+class TestTrustNormalisation:
+    """Unit tests for trust-name normalisation — no network calls required."""
+
+    def test_northern_ireland_is_not_a_trust(self) -> None:
+        """The NI-wide label must never normalise to the Northern HSC Trust."""
+        assert cp._is_ni_total("Northern Ireland")
+        assert cp._normalise_trust("Northern Ireland") == "Northern Ireland"
+
+    def test_northern_trust_still_normalises(self) -> None:
+        """The Northern HSC Trust must still resolve to its short form."""
+        assert not cp._is_ni_total("Northern HSC Trust")
+        assert cp._normalise_trust("Northern HSC Trust") == "Northern"
+
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [
+            ("Belfast HSC Trust", "Belfast"),
+            ("South Eastern HSC Trust", "South Eastern"),
+            ("Southern HSC Trust", "Southern"),
+            ("Western HSC Trust", "Western"),
+        ],
+    )
+    def test_known_trusts(self, raw: str, expected: str) -> None:
+        """Each HSC Trust must normalise to its canonical short form."""
+        assert cp._normalise_trust(raw) == expected
+
 
 class TestValidation:
     """Unit tests for validate_child_protection_data — no network calls required."""


### PR DESCRIPTION
## Summary

Doctests were configured in `pyproject.toml` (`--doctest-modules`, `testpaths` including `src`) but **never executed in CI** — the test job scoped pytest to `tests` only, so every `src/` docstring example was silently skipped. Left unrun, they rotted: a full sweep found **51 failures**.

This PR repairs all of them and adds a CI job so they stay green.

- **Root cause of false failures**: `log_cli = true` swapped `sys.stdout` out from under doctest's capture, so any example whose call emitted a log record reported "Got nothing" instead of its real output. Now `log_cli = false`.
- **Doc rot fixed** across NISRA, PSNI, health_ni, justice, translink and utils docstrings — stale function names, renamed columns, changed signatures.
- **Unrunnable examples deleted** rather than skipped: `police_ombudsman` (six blocks, two of them tautological placeholders — a bare `>>> True` and one asserting against the function's own `__doc__`), `cineworld` (403s to automated clients), `pace` (its `+SKIP` applied only to the first line, so the rest raised `NameError`).
- **numpy 2 repr**: `Series.all()` / `.sum() > 0` / `.iloc[0] > 0` now return `np.True_`, not `True`. Wrapped in `bool(...)`.
- **Genuine data drift**: only `ni_water` — postcodes 49006 → 49329, zones 65 → 66. Rewritten to assert shape rather than exact totals; its claim that many postcodes lack a zone was factually false and has been replaced.
- Also carries an earlier fix where `child_protection` silently dropped and double-counted rows.

Result: **563 passed, 10 skipped, 0 failed** across the full `src` tree.

## CI shape

The doctests run as a **separate single-version job**, not folded into the existing `build` matrix. That matrix is 3 Python versions at `max-parallel: 1`; since the examples hit the same live publishers as the test suite, adding them there would triple upstream load for no extra signal — the examples are version-independent.

No deselect or exclude list: every example either runs or was deleted.

## Test plan

- [x] `uv run pytest src --doctest-modules` — 563 passed, 10 skipped, 0 failed
- [x] `uv run pre-commit run --files <changed>` — clean
- [ ] CI `doctests` job green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)